### PR TITLE
sskr: bound the share entry buffer and the declared share length (#62)

### DIFF
--- a/src/bagl/nanos_enter_phrase.c
+++ b/src/bagl/nanos_enter_phrase.c
@@ -360,6 +360,16 @@ void screen_onboarding_restore_word_validate(void) {
         G_bolos_ux_context.words_buffer_length =
             strlen(G_bolos_ux_context.words_buffer);
     } else if (G_bolos_ux_context.tool_type == TOOL_TYPE_SSKR) {
+        // Both the share length and the share count below are read out of
+        // the entered data, so neither can be trusted to keep these writes
+        // inside the buffer. bolos_ux_sskr_hex_check() only runs once every
+        // share has been entered, so nothing else stands between the keyboard
+        // and it.
+        if (G_bolos_ux_context.sskr_words_buffer_length >=
+            SSKR_WORDS_BUFFER_MAX_SIZE_B) {
+            return;
+        }
+
         G_bolos_ux_context
             .sskr_words_buffer[G_bolos_ux_context.sskr_words_buffer_length] =
             G_bolos_ux_context.onboarding_index +
@@ -378,11 +388,20 @@ void screen_onboarding_restore_word_validate(void) {
                 break;
             case 4:
                 if ((G_bolos_ux_context.sskr_words_buffer[3] & 0x1F) == 24) {
+                    // Read the declared length as the unsigned wire byte it is.
                     G_bolos_ux_context.bip39_type =
                         4 + 1 +
-                        G_bolos_ux_context.sskr_words_buffer
+                        (uint8_t)G_bolos_ux_context.sskr_words_buffer
                             [G_bolos_ux_context.sskr_words_buffer_length] +
                         sizeof(uint32_t);
+                    // A serialized shard is SSKR_METADATA_LENGTH_BYTES plus a
+                    // value of at most SSKR_MAX_STRENGTH_BYTES, so no share
+                    // can be longer than this on the wire.
+                    if (G_bolos_ux_context.bip39_type >
+                        SSKR_SHARE_MAX_WIRE_LENGTH) {
+                        G_bolos_ux_context.bip39_type =
+                            SSKR_SHARE_MAX_WIRE_LENGTH;
+                    }
                 }
                 PRINTF("SSKR number of words: %d\n",
                        G_bolos_ux_context.bip39_type);

--- a/src/bagl/nanox_enter_phrase.c
+++ b/src/bagl/nanox_enter_phrase.c
@@ -372,6 +372,16 @@ void screen_onboarding_restore_word_validate(void) {
         G_bolos_ux_context.words_buffer_length =
             strlen(G_bolos_ux_context.words_buffer);
     } else if (G_bolos_ux_context.tool_type == TOOL_TYPE_SSKR) {
+        // Both the share length and the share count below are read out of
+        // the entered data, so neither can be trusted to keep these writes
+        // inside the buffer. bolos_ux_sskr_hex_check() only runs once every
+        // share has been entered, so nothing else stands between the keyboard
+        // and it.
+        if (G_bolos_ux_context.sskr_words_buffer_length >=
+            SSKR_WORDS_BUFFER_MAX_SIZE_B) {
+            return;
+        }
+
         G_bolos_ux_context
             .sskr_words_buffer[G_bolos_ux_context.sskr_words_buffer_length] =
             G_bolos_ux_context.onboarding_index +
@@ -390,11 +400,20 @@ void screen_onboarding_restore_word_validate(void) {
                 break;
             case 4:
                 if ((G_bolos_ux_context.sskr_words_buffer[3] & 0x1F) == 24) {
+                    // Read the declared length as the unsigned wire byte it is.
                     G_bolos_ux_context.bip39_type =
                         4 + 1 +
-                        G_bolos_ux_context.sskr_words_buffer
+                        (uint8_t)G_bolos_ux_context.sskr_words_buffer
                             [G_bolos_ux_context.sskr_words_buffer_length] +
                         sizeof(uint32_t);
+                    // A serialized shard is SSKR_METADATA_LENGTH_BYTES plus a
+                    // value of at most SSKR_MAX_STRENGTH_BYTES, so no share
+                    // can be longer than this on the wire.
+                    if (G_bolos_ux_context.bip39_type >
+                        SSKR_SHARE_MAX_WIRE_LENGTH) {
+                        G_bolos_ux_context.bip39_type =
+                            SSKR_SHARE_MAX_WIRE_LENGTH;
+                    }
                 }
                 PRINTF("SSKR number of words: %d\n",
                        G_bolos_ux_context.bip39_type);

--- a/src/common/sskr/common_sskr.h
+++ b/src/common/sskr/common_sskr.h
@@ -19,6 +19,13 @@
 
 // SSKR helpers
 #include "./seed_rom_variables.h"
+#include "./sskr-constants.h"
+
+// Largest a serialized share can be on the wire, in bytes: the CBOR long-form
+// byte-string header (3-byte tag + 0x58 + one length byte), the shard itself
+// (SSKR_METADATA_LENGTH_BYTES plus a value of at most SSKR_MAX_STRENGTH_BYTES)
+// and the CRC32. Nothing longer can be a share, whatever its header declares.
+#define SSKR_SHARE_MAX_WIRE_LENGTH (5 + SSKR_METADATA_LENGTH_BYTES + SSKR_MAX_STRENGTH_BYTES + 4)
 
 // Encode SSKR ByteWord as hex
 unsigned int bolos_ux_sskr_byteword_to_hex(unsigned char *byteword);

--- a/src/nbgl/sskr_shares.c
+++ b/src/nbgl/sskr_shares.c
@@ -76,6 +76,14 @@ size_t sskr_shares_current_word_number_get(void) {
 }
 
 size_t sskr_shares_word_add(const char* const byteword) {
+    // Both the share length and the share count below are read out of the
+    // entered data, so neither can be trusted to keep these writes inside the
+    // buffer. bolos_ux_sskr_hex_check() only runs once every share has been
+    // entered, so nothing else stands between the keyboard and this array.
+    if (shares.length >= SSKR_SHARES_MAX_LENGTH) {
+        return sskr_shares_current_word_number_get();
+    }
+
     shares.buffer[shares.length] =
         bolos_ux_sskr_byteword_to_hex((unsigned char*)byteword);
     switch (sskr_shares_current_word_number_get()) {
@@ -87,8 +95,18 @@ size_t sskr_shares_word_add(const char* const byteword) {
             break;
         case 4:
             if ((shares.buffer[3] & 0x1F) == 24) {
-                shares.final_size =
-                    4 + 1 + shares.buffer[shares.length] + sizeof(uint32_t);
+                // Read the declared length as the unsigned wire byte it is:
+                // `char` is signed on the host that builds the unit tests and
+                // unsigned on the device.
+                shares.final_size = 4 + 1 +
+                                    (uint8_t)shares.buffer[shares.length] +
+                                    sizeof(uint32_t);
+                // A serialized shard is SSKR_METADATA_LENGTH_BYTES plus a
+                // value of at most SSKR_MAX_STRENGTH_BYTES, so no share can be
+                // longer than this on the wire.
+                if (shares.final_size > SSKR_SHARE_MAX_WIRE_LENGTH) {
+                    shares.final_size = SSKR_SHARE_MAX_WIRE_LENGTH;
+                }
             }
             PRINTF("SSKR final number of words in this share: %d\n",
                    shares.final_size);

--- a/tests/unit/CMakeLists.txt
+++ b/tests/unit/CMakeLists.txt
@@ -201,6 +201,11 @@ add_executable(test_roundtrip ./tests/roundtrip.c ../../src/common/bip39/seed_ro
 target_include_directories(test_roundtrip PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/../../src ${CMAKE_CURRENT_SOURCE_DIR}/../../src/common)
 target_link_libraries(test_roundtrip PUBLIC cmocka gcov testutils sskr sss)
 
+add_executable(test_sskr_entry_bounds ./tests/sskr_entry_bounds.c ../../src/common/bip39/seed_rom_variables.c ../../src/common/bip39/seed_bip39.c ../../src/common/sskr/seed_rom_variables.c ../../src/common/sskr/seed_sskr.c ../../src/nbgl/sskr_shares.c)
+target_compile_definitions(test_sskr_entry_bounds PRIVATE SCREEN_SIZE_WALLET)
+target_include_directories(test_sskr_entry_bounds PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/../../src/common ${CMAKE_CURRENT_SOURCE_DIR}/../../src)
+target_link_libraries(test_sskr_entry_bounds PUBLIC cmocka gcov sskr sss testutils)
+
 add_executable(test_words ./tests/words.c ../../src/common/bip39/seed_rom_variables.c ../../src/common/bip39/seed_bip39.c ../../src/common/sskr/seed_rom_variables.c ../../src/common/sskr/seed_sskr.c)
 target_include_directories(test_words PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/../../src/common)
 target_link_libraries(test_words PUBLIC cmocka gcov testutils sskr sss)
@@ -217,6 +222,6 @@ target_compile_options(test_base85 PRIVATE -fsanitize=undefined -fno-sanitize-re
 target_link_options(test_base85 PRIVATE -fsanitize=undefined)
 target_link_libraries(test_base85 PUBLIC cmocka gcov)
 
-foreach(target test_sss test_sskr test_sskr_share_len test_sskr_memzero test_sskr_shard_count test_sskr_combine_bounds test_sskr_combine_error test_bip39 test_roundtrip test_words test_base64 test_base85)
+foreach(target test_sss test_sskr test_sskr_share_len test_sskr_memzero test_sskr_shard_count test_sskr_combine_bounds test_sskr_combine_error test_sskr_entry_bounds test_bip39 test_roundtrip test_words test_base64 test_base85)
     add_test(NAME ${target} COMMAND ${target})
 endforeach()

--- a/tests/unit/tests/sskr_entry_bounds.c
+++ b/tests/unit/tests/sskr_entry_bounds.c
@@ -1,0 +1,131 @@
+/*
+ * Regression test for the unbounded SSKR entry buffer.
+ *
+ * sskr_shares_word_add() appends one byte per entered ByteWord:
+ *
+ *     shares.buffer[shares.length] = bolos_ux_sskr_byteword_to_hex(byteword);
+ *     ...
+ *     shares.length++;
+ *
+ * and nothing compares shares.length against SSKR_SHARES_MAX_LENGTH, which is
+ * only ever used to declare the buffer. Both quantities that decide how much
+ * gets written come from the entered data itself:
+ *
+ *     case 4: final_size = 4 + 1 + buffer[length] + 4;   // up to 264
+ *     case 8: count      = (buffer[length] & 0x0F) + 1;  // up to 16
+ *
+ * 16 shares x 264 bytes is 4224 against a 3664-byte buffer, and
+ * bolos_ux_sskr_hex_check() only runs once every share has been entered, so
+ * the CRC does not gate this.
+ *
+ * What the overflow does differs between the two UI stacks, and only the first
+ * of these is exercised here:
+ *
+ *   - NBGL (this file): `length` is the field immediately after `buffer` in
+ *     sskr_buffer_t, so the first out-of-bounds write lands on the counter
+ *     driving it. The writes then fold back inside the buffer. The damage is
+ *     silent corruption of already-entered shares and an inconsistent counter,
+ *     contained within the struct.
+ *
+ *   - BAGL (src/bagl/nanos_enter_phrase.c, nanox_enter_phrase.c): there
+ *     sskr_words_buffer is the LAST member of bolos_ux_context_t and its
+ *     counter sits before it, so nothing folds the writes back and they run
+ *     past the end of the object -- 4224 bytes against 1603 on Nano S. Those
+ *     two files live inside the BAGL UX flows and cannot be driven from this
+ *     harness; they take the same change, verified by compilation only.
+ *
+ * A serialized shard is SSKR_METADATA_LENGTH_BYTES plus a 16..32 byte value,
+ * so one share is at most 5 + 37 + 4 = 46 bytes on the wire. Nothing larger
+ * can be a share.
+ */
+
+#include <stdarg.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include <stddef.h>
+#include <setjmp.h>
+#include <cmocka.h>
+#include <string.h>
+
+#include "testutils.h"
+#include "sskr/common_sskr.h"
+#include "sskr/sskr-constants.h"
+#include "../../../src/nbgl/sskr_shares.h"
+
+extern unsigned char const SSKR_WORDLIST[];
+
+/*
+ * sskr_shares.c also holds sskr_shares_from_bip39_mnemonic() and
+ * sskr_shares_check(), which reach into the BIP39 module and the seed
+ * comparison. Neither is on the entry path under test; these exist only so the
+ * object links, and each aborts if it is ever reached.
+ */
+char *bip39_mnemonic_get(void) { fail_msg("not on the entry path"); }
+size_t bip39_mnemonic_length_get(void) { fail_msg("not on the entry path"); }
+uint8_t bip39_mnemonic_final_size_get(void) { fail_msg("not on the entry path"); }
+bool compare_recovery_phrase(void) { fail_msg("not on the entry path"); }
+
+/* Largest a serialized share can be on the wire: CBOR long-form header
+ * (tag + 0x58 + length byte), the shard itself, and the CRC32. */
+#define MAX_SHARE_WIRE_LEN \
+    (5 + SSKR_METADATA_LENGTH_BYTES + SSKR_MAX_STRENGTH_BYTES + 4)
+
+/* ByteWord whose decoded value is `b`; the table holds 256 four-letter words. */
+static const char *word_for(uint8_t b)
+{
+    return (const char *) &SSKR_WORDLIST[(size_t) b * SSKR_BYTEWORD_LENGTH];
+}
+
+/*
+ * Header of a share declaring a 255-byte body and a member-threshold nibble of
+ * 0x0F: the largest values the wire format can express. Returns how many words
+ * it consumed.
+ */
+static size_t feed_worst_case_header(void)
+{
+    sskr_shares_word_add(word_for(0xD9)); /* CBOR tag                      */
+    sskr_shares_word_add(word_for(0x9D));
+    sskr_shares_word_add(word_for(0x75));
+    sskr_shares_word_add(word_for(0x58)); /* byte string, long form        */
+    sskr_shares_word_add(word_for(0xFF)); /* declared body length = 255    */
+    sskr_shares_word_add(word_for(0x00)); /* identifier                    */
+    sskr_shares_word_add(word_for(0x00));
+    sskr_shares_word_add(word_for(0x00)); /* group threshold / count       */
+    sskr_shares_word_add(word_for(0x0F)); /* member threshold -> 16 shares */
+    return 9;
+}
+
+/*
+ * Every accepted word must advance the buffer by exactly one byte. Once the
+ * write runs off the end it lands on `length` itself, and the counter stops
+ * tracking the buffer -- which is what this pins down.
+ */
+static void test_entry_counter_never_folds_back(void **state)
+{
+    (void) state;
+
+    sskr_shares_reset();
+    size_t fed = feed_worst_case_header();
+
+    while (fed < SSKR_SHARES_MAX_LENGTH + 64) {
+        const size_t before = sskr_shares_length_get();
+        sskr_shares_word_add(word_for(0x42));
+        const size_t after = sskr_shares_length_get();
+
+        /* Either the word was refused (length unchanged) or it advanced by
+         * exactly one. Anything else means the counter was overwritten. */
+        if (after != before) {
+            assert_int_equal(after, before + 1);
+        }
+        assert_true(after <= SSKR_SHARES_MAX_LENGTH);
+        fed++;
+    }
+}
+
+int main(void)
+{
+    const struct CMUnitTest tests[] = {
+        cmocka_unit_test(test_entry_counter_never_folds_back),
+    };
+    return cmocka_run_group_tests(tests, NULL, NULL);
+}


### PR DESCRIPTION
## What this changes

Bounds the SSKR share-entry buffer against the two attacker/user-controlled
quantities that currently drive how much it writes: the declared share
length nibble and the member-threshold nibble. Applies to all three entry
paths (NBGL and both BAGL variants).

## Why

Fixes #62. `sskr_shares_word_add()` (and the equivalent BAGL code in
`nanos_enter_phrase.c` / `nanox_enter_phrase.c`) appends one byte per
entered ByteWord without ever checking the buffer it is filling.
`bolos_ux_sskr_hex_check()` only runs once every share has been entered, so
nothing inspects the buffer while it fills.

A forged share (declared length up to 264 bytes, member-threshold nibble up
to 16 shares) can drive this past the buffer. On BAGL, `sskr_words_buffer`
is the last member of `bolos_ux_context_t`, so the write runs past the end
of the object — measured at up to 4224 bytes against a 1603-byte capacity
on Nano S. On NBGL, the counter sits immediately after the buffer in
`sskr_buffer_t`, so the first out-of-bounds write lands on the counter
itself and later writes fold back inside the struct — silent corruption of
already-entered shares rather than a wild write.

The declared length is also now read as the unsigned wire byte it is:
`char` is signed on the host that builds the unit tests and unsigned on the
device, so a declared length above `0x7F` behaved differently on the two.

## Branch and scope

- Base SHA: `3935126` (current `bip85` head)
- Target branch: `bip85`
- Devices: all (NBGL and BAGL)
- UI stack: NBGL (`src/nbgl/sskr_shares.c`) and BAGL (`src/bagl/nanos_enter_phrase.c`, `src/bagl/nanox_enter_phrase.c`)

## Security properties

- Remote channel: no — only reachable through local UI entry of a share, not APDU
- Host-controlled input: no — the attacker-controlled input is the content of an SSKR share entered on-device (forged-share scenario, same class as #58 item 2), not host/USB input
- Secret output: none
- NVM writes: none — RAM buffers only
- Memory-safety impact: fixes a real out-of-bounds write on BAGL; fixes silent data corruption on NBGL

## Commits

1. `f680a51` — regression test (`tests/unit/tests/sskr_entry_bounds.c`)
2. `5c0d9f9` — fix (bound the buffer write in all three entry paths, bound the declared length, fix the signed/unsigned read)

## Verification

| Check | Command | Result |
|---|---|---|
| Unit | `ctest` via `ledger-app-builder-dev-tools:latest` (13 targets) | pass (13/13) |
| Build NBGL | `BOLOS_SDK=/opt/flex-secure-sdk make -j4` | pass |
| Build BAGL | `BOLOS_SDK=/opt/nanox-secure-sdk make -j4`, `BOLOS_SDK=/opt/nanos-secure-sdk make -j4` | pass |
| clang-format | `clang-format --dry-run -Werror` on the 4 changed files | pass (no violations before or after) |
| Speculos | — | not run |
| Hardware | — | not run |

## Before and after

Isolating `test_sskr_entry_bounds` on the test-only commit (`f680a51`,
before the fix) fails as expected:

```
[ RUN      ] test_entry_counter_never_folds_back
[  ERROR   ] --- 3651 != 3665
[  FAILED  ] test_entry_counter_never_folds_back
```

It passes once the fix (`5c0d9f9`) is applied.

## Limitations

BAGL paths are verified by compilation only — Ragger does not cover any
BAGL target either, and this was not run on physical hardware.

## Follow-up

None expected for this fix specifically. It was rebased directly onto the
current `bip85` (past the six branches merged 26-27/07) with no source
conflicts — only an additive conflict in `tests/unit/CMakeLists.txt`'s test
list, resolved by merging both branches' entries.