### PR TITLE
sskr: erase exactly share_length bytes in sss_recover_secret() (#59 item 3)

### DIFF
--- a/src/common/sskr/sss/sss.c
+++ b/src/common/sskr/sss/sss.c
@@ -170,7 +170,7 @@ int16_t sss_recover_secret(uint8_t threshold, const uint8_t* x,
                     digest) != CX_OK ||
         interpolate(threshold, x, share_length, shares, SSS_SECRET_INDEX,
                     secret) != CX_OK) {
-        memzero(secret, sizeof(digest));
+        memzero(secret, share_length);
         memzero(digest, sizeof(digest));
         memzero(verify, sizeof(verify));
 

--- a/tests/unit/CMakeLists.txt
+++ b/tests/unit/CMakeLists.txt
@@ -193,6 +193,15 @@ add_executable(test_sskr_combine_error ./tests/sskr_combine_error.c ../../src/co
 target_include_directories(test_sskr_combine_error PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/../../src/common)
 target_link_libraries(test_sskr_combine_error PUBLIC cmocka gcov sskr sss testutils)
 
+# Built with AddressSanitizer: sss.c/interpolate.c are compiled directly into
+# this target (rather than linked from libsss) so ASan instruments their
+# stack frames, not just this file's.
+add_executable(test_sss_recover_erase_length ./tests/sss_recover_erase_length.c ../../src/common/sskr/sss/sss.c ../../src/common/sskr/sss/interpolate.c)
+target_include_directories(test_sss_recover_erase_length PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/../../src/common/sskr/sss)
+target_compile_options(test_sss_recover_erase_length PRIVATE -fsanitize=address -fno-omit-frame-pointer)
+target_link_options(test_sss_recover_erase_length PRIVATE -fsanitize=address)
+target_link_libraries(test_sss_recover_erase_length PUBLIC cmocka gcov testutils)
+
 add_executable(test_bip39 ./tests/bip39.c ../../src/common/bip39/seed_rom_variables.c  ../../src/common/bip39/seed_bip39.c)
 target_include_directories(test_bip39 PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/../../src/common)
 target_link_libraries(test_bip39 PUBLIC cmocka gcov testutils)
@@ -222,6 +231,6 @@ target_compile_options(test_base85 PRIVATE -fsanitize=undefined -fno-sanitize-re
 target_link_options(test_base85 PRIVATE -fsanitize=undefined)
 target_link_libraries(test_base85 PUBLIC cmocka gcov)
 
-foreach(target test_sss test_sskr test_sskr_share_len test_sskr_memzero test_sskr_shard_count test_sskr_combine_bounds test_sskr_combine_error test_sskr_entry_bounds test_bip39 test_roundtrip test_words test_base64 test_base85)
+foreach(target test_sss test_sskr test_sskr_share_len test_sskr_memzero test_sskr_shard_count test_sskr_combine_bounds test_sskr_combine_error test_sskr_entry_bounds test_sss_recover_erase_length test_bip39 test_roundtrip test_words test_base64 test_base85)
     add_test(NAME ${target} COMMAND ${target})
 endforeach()

--- a/tests/unit/tests/sss_recover_erase_length.c
+++ b/tests/unit/tests/sss_recover_erase_length.c
@@ -1,0 +1,108 @@
+/*
+ * Regression test for the oversized erase in sss_recover_secret()'s
+ * interpolation-failure path.
+ *
+ * Upstream declared `uint8_t digest[share_length]` (a VLA), so
+ * `memzero(secret, sizeof(digest))` erased exactly `share_length` bytes. The
+ * port declares `digest[SSS_MAX_SECRET_SIZE]` (32 bytes, fixed), so the same
+ * call now always erases 32 bytes of the caller's `secret` buffer regardless
+ * of `share_length` -- which the caller is only required to size at
+ * `share_length` bytes (SSS_MIN_SECRET_SIZE..SSS_MAX_SECRET_SIZE, so as few
+ * as 16). Only on the interpolation-failure path; current callers happen to
+ * pass buffers large enough for it not to matter.
+ *
+ * Forcing a genuine interpolation failure would need faulting the crypto
+ * library's Lagrange interpolation itself. interpolate() takes a shortcut
+ * instead: its first action is `cx_bn_lock()`, which fails immediately if a
+ * BN context is already locked. Locking one before calling
+ * sss_recover_secret() makes interpolate() fail at its very first line,
+ * deterministically, without touching any of the secret-sharing math.
+ *
+ * `secret` and `canary` are fields of one struct rather than separate stack
+ * arrays, so the layout is guaranteed by the language instead of left to the
+ * compiler: `canary` is guaranteed to sit immediately after `secret`. The
+ * erase is asserted against the canary rather than under a sanitizer --
+ * AddressSanitizer's stack-buffer-overflow check did not fire on this write,
+ * because `memzero` here resolves to `explicit_bzero`, which this
+ * toolchain's ASan does not appear to intercept.
+ */
+
+#include <stdarg.h>
+#include <stdint.h>
+#include <stddef.h>
+#include <setjmp.h>
+#include <cmocka.h>
+#include <string.h>
+#include <cx.h>
+
+#include "sss.h"
+#include "sss-constants.h"
+#include "testutils.h"
+
+struct guarded_secret {
+    uint8_t secret[SSS_MIN_SECRET_SIZE];
+    uint8_t canary[SSS_MAX_SECRET_SIZE - SSS_MIN_SECRET_SIZE];
+};
+
+static void test_recover_failure_does_not_overrun_a_min_size_secret(void **state) {
+    (void) state;
+
+    const uint8_t share_length = SSS_MIN_SECRET_SIZE;
+    struct guarded_secret guarded;
+    uint8_t share_a[SSS_MIN_SECRET_SIZE];
+    uint8_t share_b[SSS_MIN_SECRET_SIZE];
+    const uint8_t x[2] = {0, 1};
+    const uint8_t* shares[2] = {share_a, share_b};
+
+    memset(share_a, 0x11, sizeof(share_a));
+    memset(share_b, 0x22, sizeof(share_b));
+    memset(guarded.canary, 0xA5, sizeof(guarded.canary));
+
+    /* Force interpolate()'s own cx_bn_lock() to fail: it refuses to lock an
+     * already-locked context. Its cleanup path unlocks whatever is locked
+     * when it bails out, so this releases the lock again on the way out --
+     * no matching unlock needed here. */
+    assert_int_equal(cx_bn_lock(1, 0), CX_OK);
+
+    int16_t result = sss_recover_secret(2, x, shares, share_length, guarded.secret);
+
+    assert_int_equal(result, SSS_ERROR_INTERPOLATION_FAILURE);
+
+    uint8_t expected_canary[sizeof(guarded.canary)];
+    memset(expected_canary, 0xA5, sizeof(expected_canary));
+    assert_memory_equal(guarded.canary, expected_canary, sizeof(guarded.canary));
+}
+
+/*
+ * At share_length == SSS_MAX_SECRET_SIZE the erase is the right size by
+ * coincidence -- this is the case the issue meant by "current callers pass
+ * buffers large enough for it not to matter". Kept as a boundary check so
+ * the fix cannot regress it.
+ */
+static void test_recover_failure_at_max_size_still_reports_the_error(void **state) {
+    (void) state;
+
+    const uint8_t share_length = SSS_MAX_SECRET_SIZE;
+    uint8_t secret[SSS_MAX_SECRET_SIZE];
+    uint8_t share_a[SSS_MAX_SECRET_SIZE];
+    uint8_t share_b[SSS_MAX_SECRET_SIZE];
+    const uint8_t x[2] = {0, 1};
+    const uint8_t* shares[2] = {share_a, share_b};
+
+    memset(share_a, 0x11, sizeof(share_a));
+    memset(share_b, 0x22, sizeof(share_b));
+
+    assert_int_equal(cx_bn_lock(1, 0), CX_OK);
+
+    int16_t result = sss_recover_secret(2, x, shares, share_length, secret);
+
+    assert_int_equal(result, SSS_ERROR_INTERPOLATION_FAILURE);
+}
+
+int main(void) {
+    const struct CMUnitTest tests[] = {
+        cmocka_unit_test(test_recover_failure_does_not_overrun_a_min_size_secret),
+        cmocka_unit_test(test_recover_failure_at_max_size_still_reports_the_error),
+    };
+    return cmocka_run_group_tests(tests, NULL, NULL);
+}


### PR DESCRIPTION
## What this changes

On the interpolation-failure path, `sss_recover_secret()` now erases exactly
`share_length` bytes of the caller's `secret` buffer instead of always
erasing `sizeof(digest)` (32) bytes.

## Why

Fixes the item 3 defect from #59. Upstream declared `digest` as a
`share_length`-sized VLA, so `memzero(secret, sizeof(digest))` erased
exactly the caller's buffer. The port fixed `digest` at
`SSS_MAX_SECRET_SIZE` (32), so the same call started erasing 32 bytes
regardless of `share_length` -- a buffer the caller is only required to
size at `share_length` bytes, as few as `SSS_MIN_SECRET_SIZE` (16). Only on
the interpolation-failure path; current callers happen to pass buffers
large enough for it not to matter, which is why this was not otherwise
visible.

## Branch and scope

- Base SHA: `bip85` head at the time of this branch (rebased past #63)
- Target branch: `bip85`
- Devices: all (NBGL and BAGL) -- `sss.c` is shared by both stacks
- UI stack: common (`src/common/sskr/sss/sss.c`)

## Security properties

- Remote channel: no
- Host-controlled input: no
- Secret output: yes -- this is exactly the erase of a recovered-secret buffer that the fix corrects
- NVM writes: none -- RAM buffer only
- Memory-safety impact: fixes an out-of-bounds write on the caller's `secret` buffer whenever `share_length < SSS_MAX_SECRET_SIZE`

## Commits

1. Regression test (`tests/unit/tests/sss_recover_erase_length.c`)
2. Fix (`src/common/sskr/sss/sss.c:173`)

## Verification

| Check | Command | Result |
|---|---|---|
| Unit | `ctest` via `ledger-app-builder-dev-tools:latest` (14 targets) | pass (14/14) |
| Build NBGL | `BOLOS_SDK=/opt/flex-secure-sdk make -j4` | pass |
| Build BAGL | `BOLOS_SDK=/opt/nanox-secure-sdk make -j4` | pass |
| clang-format | `clang-format --dry-run -Werror` on `sss.c` | pass |
| Speculos | -- | not run |
| Hardware | -- | not run |

## Before and after

Forcing the interpolation-failure path requires faulting the crypto
library's Lagrange interpolation itself. `interpolate()` takes a shortcut:
its first action is `cx_bn_lock()`, which fails immediately if a BN
context is already locked. The test locks one before calling
`sss_recover_secret()`, making `interpolate()` fail at its very first
line, deterministically, without touching any secret-sharing math.

`secret` and a `canary` field are declared as fields of one struct so the
memory layout is guaranteed by the language: `canary` sits immediately
after `secret`. Before the fix, the canary comes back zeroed (16 bytes of
`0xA5` become `0x00`) -- confirmed. After the fix, it is untouched.

AddressSanitizer did not catch this overrun (`memzero` resolves to
`explicit_bzero`, which this toolchain's ASan does not appear to
intercept), which is why the test asserts against the canary instead.

## Limitations

Not run on Speculos or physical hardware. `sss.c`/`interpolate.c` are
common to both UI stacks and are exercised by the existing `test_sss` and
`test_sskr` suites beyond this regression test.

## Follow-up

None expected for this fix specifically.