### PR TITLE
sskr: check sss_split_secret()'s return in shard generation (#59 item 2)

### DIFF
--- a/src/common/sskr/sskr.c
+++ b/src/common/sskr/sskr.c
@@ -277,8 +277,13 @@ static int16_t sskr_generate_shards_internal(
 
     uint8_t group_shares[SSS_MAX_SECRET_SIZE * SSKR_MAX_GROUP_COUNT];
 
-    sss_split_secret(group_threshold, groups_len, master_secret,
-                     master_secret_len, group_shares, random_generator);
+    int16_t split_error =
+        sss_split_secret(group_threshold, groups_len, master_secret,
+                         master_secret_len, group_shares, random_generator);
+    if (split_error < 0) {
+        memzero(group_shares, sizeof(group_shares));
+        return split_error;
+    }
 
     uint8_t* group_share = group_shares;
 
@@ -287,8 +292,14 @@ static int16_t sskr_generate_shards_internal(
 
     for (uint8_t i = 0; i < groups_len; ++i, group_share += master_secret_len) {
         uint8_t member_shares[SSS_MAX_SECRET_SIZE * SSS_MAX_SHARE_COUNT];
-        sss_split_secret(groups[i].threshold, groups[i].count, group_share,
-                         master_secret_len, member_shares, random_generator);
+        split_error = sss_split_secret(groups[i].threshold, groups[i].count,
+                                       group_share, master_secret_len,
+                                       member_shares, random_generator);
+        if (split_error < 0) {
+            memzero(member_shares, sizeof(member_shares));
+            memzero(group_shares, sizeof(group_shares));
+            return split_error;
+        }
 
         uint8_t* value = member_shares;
         for (uint8_t j = 0; j < groups[i].count;

--- a/tests/unit/CMakeLists.txt
+++ b/tests/unit/CMakeLists.txt
@@ -181,6 +181,9 @@ target_link_libraries(test_sskr_memzero PUBLIC cmocka gcov sskr sss testutils)
 add_executable(test_sskr_shard_count tests/sskr_shard_count.c)
 target_link_libraries(test_sskr_shard_count PUBLIC cmocka gcov sskr sss testutils)
 
+add_executable(test_sskr_generate_split_error tests/sskr_generate_split_error.c)
+target_link_libraries(test_sskr_generate_split_error PUBLIC cmocka gcov sskr sss testutils)
+
 # Built with AddressSanitizer: this one is about what the code writes, not
 # what it returns, so the sanitizer is the assertion.
 add_executable(test_sskr_combine_bounds ./tests/sskr_combine_bounds.c ../../src/common/bip39/seed_rom_variables.c ../../src/common/bip39/seed_bip39.c ../../src/common/sskr/seed_rom_variables.c ../../src/common/sskr/seed_sskr.c)
@@ -222,6 +225,6 @@ target_compile_options(test_base85 PRIVATE -fsanitize=undefined -fno-sanitize-re
 target_link_options(test_base85 PRIVATE -fsanitize=undefined)
 target_link_libraries(test_base85 PUBLIC cmocka gcov)
 
-foreach(target test_sss test_sskr test_sskr_share_len test_sskr_memzero test_sskr_shard_count test_sskr_combine_bounds test_sskr_combine_error test_sskr_entry_bounds test_bip39 test_roundtrip test_words test_base64 test_base85)
+foreach(target test_sss test_sskr test_sskr_share_len test_sskr_memzero test_sskr_shard_count test_sskr_generate_split_error test_sskr_combine_bounds test_sskr_combine_error test_sskr_entry_bounds test_bip39 test_roundtrip test_words test_base64 test_base85)
     add_test(NAME ${target} COMMAND ${target})
 endforeach()

--- a/tests/unit/tests/sskr_generate_split_error.c
+++ b/tests/unit/tests/sskr_generate_split_error.c
@@ -1,0 +1,103 @@
+/*
+ * Regression test for the ignored sss_split_secret() return value in
+ * sskr_generate_shards_internal().
+ *
+ * The per-group call at sskr.c's `sss_split_secret(groups[i].threshold,
+ * groups[i].count, ...)` can fail -- SSS_ERROR_TOO_MANY_SHARES if
+ * groups[i].count exceeds SSS_MAX_SHARE_COUNT, which nothing checks before
+ * this call -- but the return value is discarded. The write loop that
+ * follows then reads groups[i].count shares out of a member_shares buffer
+ * that sss_split_secret() never touched (it failed before writing anything),
+ * and writes that many shards into the caller's fixed-size array, one
+ * element past its end at this test's count. Before the fix, this crashes
+ * (verified: SIGSEGV, cmocka reports it as a failed test).
+ *
+ * sskr_generate_shards() -- the public entry point this test calls, since
+ * sskr_generate_shards_internal() is static -- collapses any error surfacing
+ * from the internal call into a plain 0 rather than propagating the SSS_*
+ * code (`if (error) { memzero(output, buffer_size); return 0; }`). That
+ * collapse is pre-existing and out of scope here (nothing about this fix
+ * changes it, only which failures reach it); this test asserts the 0 that
+ * contract already promises, and that output was actually cleared rather
+ * than left holding shards built from whatever was on the stack.
+ *
+ * Not reachable from the UI today (the menu options that set group/member
+ * counts cannot exceed the arrays either), but a public library entry point,
+ * not an internal-only path.
+ */
+
+#include <stdarg.h>
+#include <stdint.h>
+#include <stddef.h>
+#include <setjmp.h>
+#include <cmocka.h>
+#include <string.h>
+#include <lcx_rng.h>
+
+#include "sskr.h"
+#include "sss-constants.h"
+#include "testutils.h"
+
+#define SHARDS_CAPACITY (SSS_MAX_SHARE_COUNT * SSKR_MAX_GROUP_COUNT)
+#define SECRET_LEN      (SSKR_MIN_STRENGTH_BYTES)
+
+/*
+ * One more member share than sss_split_secret() (and the shards[] array it
+ * feeds) can hold. Nothing here is malformed: it is what an (n)-of-(n+1)
+ * single-group backup looks like when SSS_MAX_SHARE_COUNT is smaller on one
+ * target than the count a UI on a different target could produce.
+ */
+static void test_generate_reports_the_split_error_instead_of_succeeding(void **state) {
+    (void) state;
+
+    const uint8_t master_secret[SECRET_LEN] = {0};
+    const sskr_group_descriptor_t groups[] = {
+        {.threshold = 2, .count = SHARDS_CAPACITY + 1}
+    };
+    const uint16_t share_buffer_len =
+        (SECRET_LEN + SSKR_METADATA_LENGTH_BYTES) * (SHARDS_CAPACITY + 1);
+    uint8_t share_buffer[share_buffer_len];
+    uint8_t expected_buffer[share_buffer_len];
+    uint8_t share_len;
+
+    memset(share_buffer, 0xFF, share_buffer_len);
+    memset(expected_buffer, 0, share_buffer_len);
+
+    int16_t result = sskr_generate_shards(1, groups, 1, master_secret,
+                                          SECRET_LEN, &share_len, share_buffer,
+                                          share_buffer_len, cx_rng);
+
+    assert_int_equal(result, 0);
+    assert_memory_equal(share_buffer, expected_buffer, share_buffer_len);
+}
+
+/*
+ * A group at exactly the capacity must still be accepted, so that the fix
+ * cannot be an off-by-one that turns away a supported backup.
+ */
+static void test_generate_accepts_a_group_at_capacity(void **state) {
+    (void) state;
+
+    const uint8_t master_secret[SECRET_LEN] = {0};
+    const sskr_group_descriptor_t groups[] = {
+        {.threshold = 2, .count = SHARDS_CAPACITY}
+    };
+    const uint16_t share_buffer_len =
+        (SECRET_LEN + SSKR_METADATA_LENGTH_BYTES) * SHARDS_CAPACITY;
+    uint8_t share_buffer[share_buffer_len];
+    uint8_t share_len;
+
+    int16_t result = sskr_generate_shards(1, groups, 1, master_secret,
+                                          SECRET_LEN, &share_len, share_buffer,
+                                          share_buffer_len, cx_rng);
+
+    assert_int_equal(result, SHARDS_CAPACITY);
+}
+
+int main(void) {
+    const struct CMUnitTest tests[] = {
+        cmocka_unit_test(test_generate_reports_the_split_error_instead_of_succeeding),
+        cmocka_unit_test(test_generate_accepts_a_group_at_capacity),
+    };
+    return cmocka_run_group_tests(tests, NULL, NULL);
+}


### PR DESCRIPTION
## What this changes

Both calls to `sss_split_secret()` in `sskr_generate_shards_internal()`
now check the return value, propagate the error, and erase the share
buffers before returning, instead of discarding it and continuing.

## Why

Fixes the item 2 defect from #59. Nothing checks a group's member count
against `SSS_MAX_SHARE_COUNT` before the per-group call at `sskr.c:290`
(`sskr_count_shards()` only checks the group/member thresholds against
each other, not against `SSS_MAX_SHARE_COUNT`), so `sss_split_secret()`
can fail there with `SSS_ERROR_TOO_MANY_SHARES`. Because the return value
was discarded, the code went on reading `groups[i].count` shares out of a
`member_shares` buffer the failed split never wrote to, and wrote that
many shards into the caller's fixed-size array -- past its end once the
count exceeds capacity. **Verified: this crashes (SIGSEGV) before the
fix.** The first call (`sskr.c:280`) has the same discarded-return
pattern; not independently reachable today given `SSKR_MAX_GROUP_COUNT`
is 1, but the same bug regardless, so fixed the same way.

Not reachable from the UI today -- the menu options that set group/member
counts cannot exceed the arrays either -- but `sskr_generate_shards()` is
a public library entry point, not an internal-only path.

## Branch and scope

- Base SHA: `bip85` head at the time of this branch (rebased past #63)
- Target branch: `bip85`
- Devices: all (NBGL and BAGL)
- UI stack: common (`src/common/sskr/sskr.c`)

## Security properties

- Remote channel: no
- Host-controlled input: no
- Secret output: none -- output buffer is fully erased on this error path
- NVM writes: none -- RAM buffers only
- Memory-safety impact: fixes a crash (stack write past the caller's fixed-size shard array)

## Commits

1. Regression test (`tests/unit/tests/sskr_generate_split_error.c`)
2. Fix (`src/common/sskr/sskr.c:280`, `:290`)

## Verification

| Check | Command | Result |
|---|---|---|
| Unit | `ctest` via `ledger-app-builder-dev-tools:latest` (14 targets) | pass (14/14) |
| Build NBGL | `BOLOS_SDK=/opt/flex-secure-sdk make -j4` | pass |
| Build BAGL | `BOLOS_SDK=/opt/nanox-secure-sdk make -j4` | pass |
| clang-format | `clang-format --dry-run -Werror` on `sskr.c` | pass |
| Speculos | -- | not run |
| Hardware | -- | not run |

## Before and after

Before the fix, calling `sskr_generate_shards()` with a group whose member
count exceeds `SSS_MAX_SHARE_COUNT` (a legal call shape for this public
function, just not one the current UI can produce) segfaults:
`cmocka` reports `Test failed with exception: Segmentation fault(11)`.

After the fix, the same call returns `0` and leaves `output` fully zeroed
-- `sskr_generate_shards()`'s existing (separately-scoped) error handling
collapses any failure surfacing from the internal call into a plain `0`
rather than propagating the specific `SSS_*` code
(`if (error) { memzero(output, buffer_size); return 0; }`); this fix does
not change that contract, only which failures correctly reach it instead
of corrupting memory first. A companion test confirms a group exactly at
capacity is still accepted (no off-by-one regression).

## Limitations

Not run on Speculos or physical hardware.

## Follow-up

`sskr_generate_shards()` swallowing all internal-generation errors into a
plain `0` instead of propagating the real code is a separate, pre-existing
gap, out of scope here -- flagging it as a candidate for its own fix.