### PR TITLE
bip85: compute dice bits_per_roll as ceil(log2(sides)) (#60)

### DIFF
--- a/src/common/bip85/seed_bip85.c
+++ b/src/common/bip85/seed_bip85.c
@@ -30,7 +30,7 @@
  * @return The number of bits per roll.
  */
 uint8_t bip85_dice_bits_per_roll(uint32_t sides) {
-    return (sizeof(sides) << 3) - __builtin_clz(sides);
+    return (sizeof(sides) << 3) - __builtin_clz(sides - 1);
 }
 
 #if defined(HAVE_NBGL)

--- a/src/common/bip85/seed_bip85.c
+++ b/src/common/bip85/seed_bip85.c
@@ -14,6 +14,25 @@
  *  See the License for the specific language governing permissions and
  *  limitations under the License.
  ********************************************************************************/
+#include <stdint.h>
+
+/**
+ * @brief Computes the number of bits needed to represent a DICE roll drawn
+ * uniformly from `[0, sides)`.
+ *
+ * @details Kept outside the `HAVE_NBGL` guard below, and with external
+ * linkage, purely so it can be linked into a unit test: the rest of this
+ * file pulls in NBGL headers the unit test harness does not have.
+ *
+ * @param[in] sides Number of sides on the die. Must be in
+ * `[2, UINT32_MAX >> 1]`; the caller enforces this.
+ *
+ * @return The number of bits per roll.
+ */
+uint8_t bip85_dice_bits_per_roll(uint32_t sides) {
+    return (sizeof(sides) << 3) - __builtin_clz(sides);
+}
+
 #if defined(HAVE_NBGL)
 #include <lcx_hmac.h>
 #include <lcx_sha3.h>
@@ -257,7 +276,7 @@ void bolos_ux_bip85_dice(uint32_t* out, uint32_t sides, uint32_t rolls,
                   "BIP85 SHAKE256 hash failed");
     memzero(buffer_ent, BIP85_ENTROPY_LENGTH);
 
-    uint8_t bits_per_roll = (sizeof(sides) << 3) - __builtin_clz(sides);
+    uint8_t bits_per_roll = bip85_dice_bits_per_roll(sides);
     PRINTF("BIP85 DICE bits per roll : %d\n", bits_per_roll);
 
     uint8_t bytes_per_roll = (bits_per_roll + 7) >> 3;

--- a/tests/unit/CMakeLists.txt
+++ b/tests/unit/CMakeLists.txt
@@ -234,6 +234,12 @@ target_compile_options(test_base85 PRIVATE -fsanitize=undefined -fno-sanitize-re
 target_link_options(test_base85 PRIVATE -fsanitize=undefined)
 target_link_libraries(test_base85 PUBLIC cmocka gcov)
 
-foreach(target test_sss test_sskr test_sskr_share_len test_sskr_memzero test_sskr_shard_count test_sskr_generate_split_error test_sskr_combine_bounds test_sskr_combine_error test_sskr_entry_bounds test_sss_recover_erase_length test_bip39 test_roundtrip test_words test_base64 test_base85)
+# bip85_dice_bits_per_roll() is defined outside the HAVE_NBGL guard in
+# seed_bip85.c precisely so it can be linked here without the NBGL headers
+# the rest of that file needs.
+add_executable(test_bip85_dice_bits_per_roll tests/bip85_dice_bits_per_roll.c ../../src/common/bip85/seed_bip85.c)
+target_link_libraries(test_bip85_dice_bits_per_roll PUBLIC cmocka gcov)
+
+foreach(target test_sss test_sskr test_sskr_share_len test_sskr_memzero test_sskr_shard_count test_sskr_generate_split_error test_sskr_combine_bounds test_sskr_combine_error test_sskr_entry_bounds test_sss_recover_erase_length test_bip39 test_roundtrip test_words test_base64 test_base85 test_bip85_dice_bits_per_roll)
     add_test(NAME ${target} COMMAND ${target})
 endforeach()

--- a/tests/unit/tests/bip85_dice_bits_per_roll.c
+++ b/tests/unit/tests/bip85_dice_bits_per_roll.c
@@ -1,0 +1,33 @@
+#include <stdarg.h>
+#include <stdint.h>
+#include <stddef.h>
+#include <setjmp.h>
+#include <cmocka.h>
+
+extern uint8_t bip85_dice_bits_per_roll(uint32_t sides);
+
+// bits_per_roll must be ceil(log2(sides)): the minimum number of bits that
+// lets a rejection-sampling loop draw uniformly from [0, sides). Non-power-
+// of-two dice (d3, d6, d20) already exercised the formula the same way
+// before and after the fix; the power-of-two cases (d2, d4, d8, d16, d256)
+// are the ones a floor(log2(sides))+1 formula overcounts by one bit.
+static void test_bip85_dice_bits_per_roll(void **state) {
+    (void) state;
+
+    assert_int_equal(bip85_dice_bits_per_roll(2), 1);      // d2
+    assert_int_equal(bip85_dice_bits_per_roll(3), 2);      // d3
+    assert_int_equal(bip85_dice_bits_per_roll(4), 2);      // d4
+    assert_int_equal(bip85_dice_bits_per_roll(6), 3);      // d6
+    assert_int_equal(bip85_dice_bits_per_roll(8), 3);      // d8
+    assert_int_equal(bip85_dice_bits_per_roll(16), 4);     // d16
+    assert_int_equal(bip85_dice_bits_per_roll(20), 5);     // d20
+    assert_int_equal(bip85_dice_bits_per_roll(256), 8);    // d256
+    assert_int_equal(bip85_dice_bits_per_roll(0x7FFFFFFF), 31); // UINT32_MAX >> 1
+}
+
+int main(void) {
+    const struct CMUnitTest tests[] = {
+        cmocka_unit_test(test_bip85_dice_bits_per_roll)
+    };
+    return cmocka_run_group_tests(tests, NULL, NULL);
+}


### PR DESCRIPTION
## What this changes

`bolos_ux_bip85_dice()`'s `bits_per_roll` computation is corrected from
`floor(log2(sides)) + 1` to `ceil(log2(sides))`. The two only diverge when
`sides` is an exact power of two (d8, d16, ...), where the old formula
takes one bit more than the rejection-sampling loop actually needs.

## Why

Fixes the remaining half of #60 (the DRNG out-of-bounds read was already
fixed by the earlier `fix/bip85-dice-drng-bounds` merge). For a
power-of-two `sides`, the old formula consumes one extra byte of DRNG
output per roll (via `bytes_per_roll = ceil(bits_per_roll / 8)`), so a d8
die burns 4 bits (1 byte) per roll instead of 3, and the fixed 256-byte
DRNG digest yields fewer usable rolls than it should for every
power-of-two die size.

## Branch and scope

- Base SHA: `3aba4ce76409bab6ef18a60503a61bc138019774`
- Target branch: `bip85`
- Devices: none directly (pure algorithm change; no UI reaches this
  function yet, see #60/#23)
- UI stack: common (`src/common/bip85/seed_bip85.c`, behind `HAVE_NBGL`)

## Security properties

- Remote channel: none
- Host-controlled input: none (`sides` comes from the caller, already
  bounded to `[2, UINT32_MAX >> 1]` by a `LEDGER_ASSERT` this change does
  not touch)
- Secret output: none (this function computes a bit count, not a secret)
- NVM writes: none
- Memory-safety impact: none by itself. Combined with the existing DRNG
  bound (`buffer_ptr - buffer_drng + bytes_per_roll <= BIP85_DRNG_MAX_DIGEST_SIZE`),
  a *smaller* `bits_per_roll` for power-of-two sides can only shrink
  `bytes_per_roll`, never grow it, so this cannot reopen the bound fixed
  earlier.

## Commits

1. `tests: reproduce bits_per_roll overcounting power-of-two dice sides (#60)`
   -- extracts the calculation into `bip85_dice_bits_per_roll(uint32_t sides)`,
   defined outside the `HAVE_NBGL` guard (external linkage, no behaviour
   change) so it can be linked into a real cmocka test instead of a copy
   of the formula living only in the test file. Fails on this commit.
2. `bip85: compute dice bits_per_roll as ceil(log2(sides))` -- the actual
   fix, one line.

## Verification

| Check | Command | Result |
|---|---|---|
| Unit | `cmake -B build -H. && make -C build && ctest` (image `ledger-app-dev-tools:latest`) | pass (16/16, including the new `test_bip85_dice_bits_per_roll`) |
| ASan | n/a | not applicable |
| UBSan | n/a | not applicable |
| Speculos | -- | not run |
| Hardware | -- | not run (no UI reaches this function; see scope) |
| Builds | `flex` (NBGL), `nanox` (BAGL), image `ledger-app-builder-lite:latest` | pass, both link; `seed_bip85.o` confirmed present in the `flex` object tree |

`clang-format --dry-run -Werror` (v21 -- v11, what CI pins, isn't available
here) is clean on the touched source file `seed_bip85.c`.

## Before and after

Commit 1 alone (before the fix), `test_bip85_dice_bits_per_roll`:

```
[ RUN      ] test_bip85_dice_bits_per_roll
[  ERROR   ] --- 2 != 1
[   LINE   ] --- tests/bip85_dice_bits_per_roll.c:17: error: Failure!
[  FAILED  ] test_bip85_dice_bits_per_roll
```

(d2 returns 2 bits instead of 1; d4, d8, d16, d256 are each one bit over
in the same way.)

After commit 2: all 9 cases in the test (d2, d3, d4, d6, d8, d16, d20,
d256, and the upper bound `UINT32_MAX >> 1`) pass.

## Limitations

- No Speculos or hardware run: this function has no caller reachable from
  the current UI (tracked separately as the DICE API rework, see #60/#23) -- there is nothing to drive on-screen.
- `clang-format` checked against v21, not the v11 CI pins.

## Follow-up

None expected for this PR specifically. The DICE buffer/return-type/silent-
truncation issues flagged alongside this one in #60 are intentionally out
of scope here and tracked as a separate DICE API rework.

