### PR TITLE
ui: correct BIP85 index error message upper bound

### DIFF
--- a/src/nbgl/ui.c
+++ b/src/nbgl/ui.c
@@ -755,8 +755,8 @@ static void bip85_index_validate(const uint8_t* indexentry, uint8_t length) {
                 break;
         }
     } else {
-        nbgl_useCaseStatus("BIP85 index must be between 0 and 2,147,483,647",
-                           false, display_bip39_select_phrase_length_page);
+        nbgl_useCaseStatus("BIP85 index must be between 0 and 9,999,999", false,
+                           display_bip39_select_phrase_length_page);
     }
 }
 


### PR DESCRIPTION
## What this changes

Fixes the upper bound advertised in the BIP85 index error message.

## Why

`bip85_index_validate()` guards with `bip85_index_get() <= (UINT32_MAX >> 1)`
and reports "between 0 and 2,147,483,647" on failure. In practice the keypad
that feeds this function caps entry at `BIP85_INDEX_MAX_NUMBER_LENGTH` (7)
digits, so `bip85_index_get()` can never exceed `9,999,999` — the message
describes a bound the UI can never actually hit or reject.

Suggested in review on #14 (2026-07-26 18:32 UTC), not applied there.

The guard itself is left untouched (out of scope for this text-only fix —
it becomes dead code once the keyboard limit is accounted for, a separate
concern).

## Branch and scope

- Base SHA: `ba0f039`
- Target branch: `bip85`
- Devices: all (message-only change, no device-specific behaviour)
- UI stack: NBGL

## Security properties

- Remote channel: none
- Host-controlled input: none
- Secret output: none
- NVM writes: none
- Memory-safety impact: none (string literal only)

## Commits

1. Text-only fix (single commit)

## Verification

| Check | Command | Result |
|---|---|---|
| Unit | `cmake -B build -H. && make -C build && ctest` (ledger-app-dev-tools:latest) | pass (16/16) |
| clang-format | `clang-format --dry-run -Werror src/nbgl/ui.c` (v21; CI pins v11, unavailable locally) | pass |
| Builds | flex (NBGL), nanox (BAGL) | pass |
| Hardware | — | not run |

## Before and after

Before: `BIP85 index must be between 0 and 2,147,483,647`
After: `BIP85 index must be between 0 and 9,999,999`

## Limitations

Text-only change; no functional or hardware testing needed beyond the
builds above. The unreachable guard condition itself is not addressed here.

## Follow-up

None planned.