### PR TITLE
bip85: NUL-terminate the base64 password before %s

### DIFF
--- a/src/common/bip85/seed_bip85.c
+++ b/src/common/bip85/seed_bip85.c
@@ -213,6 +213,7 @@ uint8_t bolos_ux_bip85_pwd_base64(char* pwd, uint8_t pwd_len,
         "Base64 encoding failed");
 
     memcpy(pwd, buffer_pwd, pwd_len);
+    pwd[pwd_len] = '\0';  // Add string termination character
 
     memzero(buffer_ent, BIP85_ENTROPY_LENGTH);
     memzero(buffer_pwd, BASE64_ENCODE_LENGTH);


### PR DESCRIPTION
## What this changes

`bolos_ux_bip85_pwd_base64()` now NUL-terminates `pwd` before the `PRINTF("... %s\n", pwd)` that follows, matching its sibling `bolos_ux_bip85_pwd_base85()` a few lines below, which already does this.

## Why

`bolos_ux_bip85_pwd_base64()` copies `pwd_len` bytes into `pwd` and then `PRINTF`s it with `%s` without ever writing a terminator, so the format reads past the `pwd_len` bytes actually copied until it happens to hit a zero byte. `bolos_ux_bip85_pwd_base85()`, the same shape of function directly below it in the same file, adds `pwd[pwd_len] = '\0';` before its own copy of the same `PRINTF` — the base64 version is missing that line.

Confirmed safe to write `pwd[pwd_len]`: the only caller, `bip85_app_pwd_base64_gen()` (`src/nbgl/bip85_app.c`), passes `app_data.buffer`, a `BASE64_ENCODE_LENGTH`-byte (88) static buffer, and `pwd_len` is bounded to `BASE64_ENCODE_LENGTH - 2` (86) by the `LEDGER_ASSERT` at the top of this function — `pwd[86]` is still inside the 88-byte allocation.

More than a cosmetic gap: `app_data.buffer` is reused across BIP39/PWD64/PWD85 generations (same struct field, `src/nbgl/bip85_app.c`). After a longer generation followed by a shorter one, the byte at `pwd[pwd_len]` can be leftover from the previous generation rather than zero, so the unterminated `%s` is not guaranteed to stop quickly.

## Branch and scope

- Base SHA: `1343081` (`aido/bip85`, includes #69)
- Target branch: `bip85`
- Devices: all — source-level fix, not device-specific
- UI stack: NBGL only (`bolos_ux_bip85_pwd_base64()` is behind `HAVE_NBGL`)

## Security properties

- Remote channel: none — no host-controlled input involved
- Host-controlled input: none
- Secret output: `pwd` is a derived BIP-85 password; this change only affects what a debug `PRINTF` reads past the buffer, not the returned/copied password itself
- NVM writes: none
- Memory-safety impact: fixes an out-of-bounds read in a debug log format string (`%s` on a buffer not guaranteed to be terminated within its bounds)

## Commits

1. Fix (single commit — see Limitations for why there is no separate red test)

## Verification

| Check | Command | Result |
|---|---|---|
| Unit | `cmake -B build -H. && make -C build && ctest` (ledger-app-dev-tools:latest) | pass (17/17, function not exercised by the harness — see Limitations) |
| ASan | not applicable | not applicable |
| UBSan | not applicable | not applicable |
| Speculos | not run | not run |
| Hardware | not run | not run |
| Builds | `BOLOS_SDK=/opt/flex-secure-sdk make` (NBGL) | pass |
| Builds | `BOLOS_SDK=/opt/nanox-secure-sdk make` (BAGL) | pass |
| Format | `clang-format --dry-run -Werror` (v21) on `src/common/bip85/seed_bip85.c` | clean |

## Before and after

Before, `pwd[pwd_len]` is whatever was left in `app_data.buffer` (zero-initialized once at boot, but reused untouched across generations after that — see Why); `PRINTF("...%s\n", pwd)` reads past the `pwd_len` bytes just copied until it happens to hit a zero byte. After, `pwd[pwd_len] = '\0';` bounds the read to exactly the bytes copied, matching `bolos_ux_bip85_pwd_base85()`.

## Limitations

No unit test. `bolos_ux_bip85_pwd_base64()` sits behind `HAVE_NBGL`, like `bolos_ux_bip85_dice()` (fixed in `d09d704`, same rationale given there): defining `HAVE_NBGL` in `tests/unit` pulls in NBGL UI headers the harness does not have, and unlike `bip85_dice_bits_per_roll()` there is no pure formula to extract here — the whole function calls into HMAC/SHAKE crypto via `bolos_ux_bip85_entropy()` that the harness does not provide. Verified by direct code comparison against the correct sibling function and by compilation only (see Verification table). No BAGL runtime test — `bolos_ux_bip85_pwd_base64()` is NBGL-only code, so this does not apply here.

## Follow-up

Part of `ROADMAP.md` item 15 (plan §D3-D4). Other points of that item remain open: pre-filled destination buffer, user lengths 20/86 and 10/80. No port to another branch and no UX decision needed for this specific fix.
