### PR TITLE
bip85: fix DICE roll truncation with bounded DRNG re-extension

### DIFF
--- a/src/common/bip85/common_bip85.h
+++ b/src/common/bip85/common_bip85.h
@@ -91,11 +91,25 @@ uint8_t bolos_ux_bip85_pwd_base85(char *pwd, uint8_t pwd_len, unsigned int index
  * @details This function simulates the rolling of dice with the specified number of sides and
  *          rolls. It utilizes the BIP85 standard to ensure cryptographic security and randomness.
  *
- * @param[out] out    Pointer to an array of `uint32_t` to store the generated dice rolls.
- * @param[in]  sides  Number of sides on each die (must be between 2 and UINT32_MAX >> 1).
- * @param[in]  rolls  Number of dice rolls to generate (must be between 1 and UINT32_MAX >> 1).
- * @param[in]  index  Index to be used in the BIP32 path.
+ *          The DRNG output is a finite SHAKE256 digest: rejection sampling on it is not
+ *          guaranteed to produce `rolls` valid values from a single digest, so this function
+ *          re-extends the digest (re-deriving a longer one from the same seed, not resuming
+ *          mid-stream) a bounded number of times before giving up. It always reports how many
+ *          rolls it actually produced rather than silently returning fewer than requested.
  *
- * @return The number of bytes written to the output buffer.
+ * @param[out] out          Pointer to an array of `uint32_t` to store the generated dice rolls.
+ * @param[in]  out_capacity Capacity of `out`, in elements.
+ * @param[in]  sides        Number of sides on each die (must be between 2 and UINT32_MAX >> 1).
+ * @param[in]  rolls        Number of dice rolls to generate (must be between 1 and UINT32_MAX >>
+ * 1).
+ * @param[in]  index        Index to be used in the BIP32 path.
+ *
+ * @return `rolls` on success. A negative value if `out_capacity < rolls`, if entropy derivation
+ *         or the SHAKE256 call failed, or if the DRNG stream could not be extended far enough to
+ *         produce `rolls` valid results.
  */
-void bolos_ux_bip85_dice(uint32_t *out, uint32_t sides, uint32_t rolls, unsigned int index);
+int32_t bolos_ux_bip85_dice(uint32_t *out,
+                            size_t out_capacity,
+                            uint32_t sides,
+                            uint32_t rolls,
+                            uint32_t index);

--- a/src/common/bip85/seed_bip85.c
+++ b/src/common/bip85/seed_bip85.c
@@ -14,7 +14,16 @@
  *  See the License for the specific language governing permissions and
  *  limitations under the License.
  ********************************************************************************/
+#include <stddef.h>
 #include <stdint.h>
+#include <string.h>
+
+#include "./seed_rom_variables.h"
+#include "constants.h"
+
+#ifdef HAVE_SHA3
+#include <lcx_sha3.h>
+#endif
 
 /**
  * @brief Computes the number of bits needed to represent a DICE roll drawn
@@ -32,6 +41,79 @@
 uint8_t bip85_dice_bits_per_roll(uint32_t sides) {
     return (sizeof(sides) << 3) - __builtin_clz(sides - 1);
 }
+
+#ifdef HAVE_SHA3
+
+/**
+ * @brief Draws up to `rolls` values uniformly distributed in `[0, sides)`
+ * from a BIP85-derived seed.
+ *
+ * @details Kept outside the `HAVE_NBGL` guard below, and with external
+ * linkage, purely so it can be linked into a unit test against the real
+ * `cx_shake256_hash()` -- pure software, no BOLOS syscall -- without the
+ * NBGL headers the rest of this file needs. This is a direct extraction of
+ * the loop that used to live in `bolos_ux_bip85_dice()`: same single
+ * `BIP85_DRNG_MAX_DIGEST_SIZE`-byte digest, same rejection sampling, no
+ * behaviour change yet. Rejection sampling means the acceptance rate is
+ * not 100%, so this single fixed-size digest is not guaranteed to yield
+ * `rolls` values -- the return value reports how many it actually
+ * produced, which the caller must check.
+ *
+ * @param[out] out           Buffer to receive the dice results.
+ * @param[in]  out_capacity  Capacity of `out`, in elements.
+ * @param[in]  sides         Number of sides on the die.
+ * @param[in]  rolls         Number of rolls requested.
+ * @param[in]  seed          BIP85 entropy seed, `BIP85_ENTROPY_LENGTH`
+ * bytes.
+ *
+ * @return The number of rolls actually produced (`0 <= n <= rolls`), or a
+ * negative value on error:
+ * - `-1` if `out_capacity < rolls`;
+ * - `-2` if the SHAKE256 call failed.
+ */
+int32_t bip85_dice_roll(uint32_t* out, size_t out_capacity, uint32_t sides,
+                        uint32_t rolls,
+                        const uint8_t seed[BIP85_ENTROPY_LENGTH]) {
+    if (out_capacity < rolls) {
+        return -1;
+    }
+
+    uint8_t bits_per_roll = bip85_dice_bits_per_roll(sides);
+    uint8_t bytes_per_roll = (bits_per_roll + 7) >> 3;
+    uint8_t shift_amount = (bytes_per_roll << 3) - bits_per_roll;
+
+    uint8_t digest[BIP85_DRNG_MAX_DIGEST_SIZE];
+
+    if (cx_shake256_hash(seed, BIP85_ENTROPY_LENGTH, digest, sizeof(digest)) !=
+        CX_OK) {
+        return -2;
+    }
+
+    uint8_t* digest_ptr = digest;
+    uint32_t roll_index = 0;
+
+    while (roll_index < rolls &&
+           (size_t)(digest_ptr - digest) + bytes_per_roll <= sizeof(digest)) {
+        // Construct roll result from bytes_per_roll bytes
+        uint32_t roll_result = 0;
+        uint8_t* end_ptr = digest_ptr + bytes_per_roll;
+        while (digest_ptr < end_ptr) {
+            roll_result = roll_result << 8 | (uint32_t)*digest_ptr++;
+        }
+        // Adjust roll result to keep only bits_per_roll
+        roll_result >>= shift_amount;
+
+        // Check if roll result is within valid range
+        if (roll_result < sides) {
+            out[roll_index++] = roll_result;
+        }
+    }
+
+    explicit_bzero(digest, sizeof(digest));
+    return (int32_t)roll_index;
+}
+
+#endif  // HAVE_SHA3
 
 #if defined(HAVE_NBGL)
 #include <lcx_hmac.h>

--- a/src/common/bip85/seed_bip85.c
+++ b/src/common/bip85/seed_bip85.c
@@ -44,32 +44,52 @@ uint8_t bip85_dice_bits_per_roll(uint32_t sides) {
 
 #ifdef HAVE_SHA3
 
+// How many times the DRNG digest is allowed to double in size (from
+// BIP85_DRNG_MAX_DIGEST_SIZE) before bip85_dice_roll() gives up and reports
+// an error instead of producing a truncated result.
+#define BIP85_DICE_MAX_DRNG_DOUBLINGS 3
+
 /**
- * @brief Draws up to `rolls` values uniformly distributed in `[0, sides)`
- * from a BIP85-derived seed.
+ * @brief Draws `rolls` values uniformly distributed in `[0, sides)` from a
+ * BIP85-derived seed, re-extending the SHAKE256 output stream if the
+ * initial digest runs out before enough values have been drawn.
  *
  * @details Kept outside the `HAVE_NBGL` guard below, and with external
  * linkage, purely so it can be linked into a unit test against the real
  * `cx_shake256_hash()` -- pure software, no BOLOS syscall -- without the
- * NBGL headers the rest of this file needs. This is a direct extraction of
- * the loop that used to live in `bolos_ux_bip85_dice()`: same single
- * `BIP85_DRNG_MAX_DIGEST_SIZE`-byte digest, same rejection sampling, no
- * behaviour change yet. Rejection sampling means the acceptance rate is
- * not 100%, so this single fixed-size digest is not guaranteed to yield
- * `rolls` values -- the return value reports how many it actually
- * produced, which the caller must check.
+ * NBGL headers the rest of this file needs.
  *
- * @param[out] out           Buffer to receive the dice results.
+ * Rejection sampling with `bits_per_roll = ceil(log2(sides))`
+ * (`bip85_dice_bits_per_roll()` above) never accepts fewer than half of the
+ * candidates it draws: the worst case is `sides` one more than a power of
+ * two (e.g. `sides = 129`, `bits_per_roll = 8`, acceptance 129/256 =~
+ * 50.4%). A `BIP85_DRNG_MAX_DIGEST_SIZE`-byte digest therefore runs out
+ * only when `rolls` is in the hundreds or more for single-byte rolls, and
+ * higher still for wider ones. When it does, this function re-derives the
+ * digest from scratch at double the previous length rather than resuming
+ * mid-stream: SHAKE256 is a genuine XOF, so a longer digest from the same
+ * seed reproduces the same leading bytes -- already-accepted rolls are
+ * identical across a retry -- and the computation is cheap enough that
+ * redoing it from scratch costs nothing worth optimizing away.
+ * `BIP85_DICE_MAX_DRNG_DOUBLINGS` bounds the number of retries: given the
+ * better-than-50% acceptance rate above, exhausting them without producing
+ * `rolls` values is not expected for any realistic request, but it is
+ * still reported as an error rather than looped on indefinitely.
+ *
+ * @param[out] out           Buffer to receive the `rolls` dice results.
  * @param[in]  out_capacity  Capacity of `out`, in elements.
  * @param[in]  sides         Number of sides on the die.
  * @param[in]  rolls         Number of rolls requested.
  * @param[in]  seed          BIP85 entropy seed, `BIP85_ENTROPY_LENGTH`
  * bytes.
  *
- * @return The number of rolls actually produced (`0 <= n <= rolls`), or a
+ * @return `rolls` on success (`out[0..rolls)` is fully populated). A
  * negative value on error:
  * - `-1` if `out_capacity < rolls`;
- * - `-2` if the SHAKE256 call failed.
+ * - `-2` if the SHAKE256 call failed;
+ * - `-3` if the DRNG stream was exhausted after
+ *   `BIP85_DICE_MAX_DRNG_DOUBLINGS` doublings without producing `rolls`
+ *   valid results.
  */
 int32_t bip85_dice_roll(uint32_t* out, size_t out_capacity, uint32_t sides,
                         uint32_t rolls,
@@ -82,35 +102,50 @@ int32_t bip85_dice_roll(uint32_t* out, size_t out_capacity, uint32_t sides,
     uint8_t bytes_per_roll = (bits_per_roll + 7) >> 3;
     uint8_t shift_amount = (bytes_per_roll << 3) - bits_per_roll;
 
-    uint8_t digest[BIP85_DRNG_MAX_DIGEST_SIZE];
+    // Sized for the largest digest a retry can request; only the leading
+    // `digest_length` bytes are meaningful on any given attempt.
+    uint8_t digest[BIP85_DRNG_MAX_DIGEST_SIZE << BIP85_DICE_MAX_DRNG_DOUBLINGS];
+    int32_t result = -3;
 
-    if (cx_shake256_hash(seed, BIP85_ENTROPY_LENGTH, digest, sizeof(digest)) !=
-        CX_OK) {
-        return -2;
-    }
+    for (uint8_t attempt = 0; attempt <= BIP85_DICE_MAX_DRNG_DOUBLINGS;
+         attempt++) {
+        size_t digest_length = (size_t)BIP85_DRNG_MAX_DIGEST_SIZE << attempt;
 
-    uint8_t* digest_ptr = digest;
-    uint32_t roll_index = 0;
-
-    while (roll_index < rolls &&
-           (size_t)(digest_ptr - digest) + bytes_per_roll <= sizeof(digest)) {
-        // Construct roll result from bytes_per_roll bytes
-        uint32_t roll_result = 0;
-        uint8_t* end_ptr = digest_ptr + bytes_per_roll;
-        while (digest_ptr < end_ptr) {
-            roll_result = roll_result << 8 | (uint32_t)*digest_ptr++;
+        if (cx_shake256_hash(seed, BIP85_ENTROPY_LENGTH, digest,
+                             digest_length) != CX_OK) {
+            result = -2;
+            break;
         }
-        // Adjust roll result to keep only bits_per_roll
-        roll_result >>= shift_amount;
 
-        // Check if roll result is within valid range
-        if (roll_result < sides) {
-            out[roll_index++] = roll_result;
+        uint8_t* digest_ptr = digest;
+        uint32_t roll_index = 0;
+
+        while (roll_index < rolls &&
+               (size_t)(digest_ptr - digest) + bytes_per_roll <=
+                   digest_length) {
+            // Construct roll result from bytes_per_roll bytes
+            uint32_t roll_result = 0;
+            uint8_t* end_ptr = digest_ptr + bytes_per_roll;
+            while (digest_ptr < end_ptr) {
+                roll_result = roll_result << 8 | (uint32_t)*digest_ptr++;
+            }
+            // Adjust roll result to keep only bits_per_roll
+            roll_result >>= shift_amount;
+
+            // Check if roll result is within valid range
+            if (roll_result < sides) {
+                out[roll_index++] = roll_result;
+            }
+        }
+
+        if (roll_index == rolls) {
+            result = (int32_t)rolls;
+            break;
         }
     }
 
     explicit_bzero(digest, sizeof(digest));
-    return (int32_t)roll_index;
+    return result;
 }
 
 #endif  // HAVE_SHA3
@@ -336,8 +371,8 @@ uint8_t bolos_ux_bip85_pwd_base85(char* pwd, uint8_t pwd_len,
     return pwd_len;
 }
 
-void bolos_ux_bip85_dice(uint32_t* out, uint32_t sides, uint32_t rolls,
-                         unsigned int index) {
+int32_t bolos_ux_bip85_dice(uint32_t* out, size_t out_capacity, uint32_t sides,
+                            uint32_t rolls, uint32_t index) {
     LEDGER_ASSERT((sides >= 2) && (sides <= (UINT32_MAX >> 1)),
                   "Invalid value for BIP85 DICE sides");
     LEDGER_ASSERT((rolls >= 1) && (rolls <= (UINT32_MAX >> 1)),
@@ -349,42 +384,15 @@ void bolos_ux_bip85_dice(uint32_t* out, uint32_t sides, uint32_t rolls,
                                  0x80000000 | rolls, 0x80000000 | index};
 
     uint8_t buffer_ent[BIP85_ENTROPY_LENGTH];
-    uint8_t buffer_drng[BIP85_DRNG_MAX_DIGEST_SIZE], *buffer_ptr = buffer_drng;
 
     LEDGER_ASSERT(bolos_ux_bip85_entropy(buffer_ent, path, ARRAYLEN(path)) == 1,
                   "BIP85 entropy failed");
-    LEDGER_ASSERT(bolos_ux_bip85_drng_with_seed(
-                      buffer_ent, BIP85_ENTROPY_LENGTH, buffer_drng,
-                      BIP85_DRNG_MAX_DIGEST_SIZE) == 1,
-                  "BIP85 SHAKE256 hash failed");
+
+    int32_t produced =
+        bip85_dice_roll(out, out_capacity, sides, rolls, buffer_ent);
+
     memzero(buffer_ent, BIP85_ENTROPY_LENGTH);
 
-    uint8_t bits_per_roll = bip85_dice_bits_per_roll(sides);
-    PRINTF("BIP85 DICE bits per roll : %d\n", bits_per_roll);
-
-    uint8_t bytes_per_roll = (bits_per_roll + 7) >> 3;
-    PRINTF("BIP85 DICE bytes per roll : %d\n", bytes_per_roll);
-
-    uint8_t shift_amount = (bytes_per_roll << 3) - bits_per_roll;
-
-    for (uint32_t roll_result = 0, roll_index = 0;
-         roll_index < rolls && buffer_ptr - buffer_drng + bytes_per_roll <=
-                                   BIP85_DRNG_MAX_DIGEST_SIZE;
-         roll_result = 0) {
-        // Construct roll result from bytes_per_roll bytes
-        uint8_t* end_ptr = buffer_ptr + bytes_per_roll;
-        while (buffer_ptr < end_ptr) {
-            roll_result = roll_result << 8 | (uint32_t)*buffer_ptr++;
-        }
-        // Adjust roll result to keep only bits_per_roll
-        roll_result >>= shift_amount;
-
-        // Check if roll result is within valid range
-        if (roll_result < sides) {
-            out[roll_index++] = roll_result;
-            PRINTF("BIP85 DICE roll %d : %d\n", roll_index, roll_result);
-        }
-    }
-    memzero(buffer_drng, BIP85_DRNG_MAX_DIGEST_SIZE);
+    return produced;
 }
 #endif

--- a/src/common/bip85/seed_rom_variables.h
+++ b/src/common/bip85/seed_rom_variables.h
@@ -23,5 +23,14 @@
 #define BASE85_TABLE_LENGTH  85
 #define BASE85_ENCODE_LENGTH 80
 
+// `WIDE` is normally provided by the SDK's arch.h, pulled in transitively
+// through os.h. This header is included on its own (no os.h) by the parts of
+// seed_bip85.c that stay outside the HAVE_NBGL guard so they can be linked
+// into a host unit test; the fallback keeps it self-contained there too,
+// with the same empty expansion arch.h uses.
+#ifndef WIDE
+#define WIDE
+#endif
+
 extern unsigned char const WIDE BASE64_TABLE[BASE64_TABLE_LENGTH];
 extern unsigned char const WIDE BASE85_TABLE[BASE85_TABLE_LENGTH];

--- a/tests/unit/CMakeLists.txt
+++ b/tests/unit/CMakeLists.txt
@@ -149,12 +149,17 @@ include_directories(${CMAKE_CURRENT_SOURCE_DIR}/lib $ENV{LEDGER_SECURE_SDK}/incl
 # add src
 set(ExternalProject_Get_property(openssl INSTALL_DIR))
 set(BOLOS_SOURCES ./lib/bolos/cx_bn.c ./lib/bolos/cx_crc.c ./lib/bolos/cx_mpi.c)
-set(LIBCXNG_SOURCES $ENV{LEDGER_SECURE_SDK}/lib_cxng/src/cx_ram.c $ENV{LEDGER_SECURE_SDK}/lib_cxng/src/cx_hash.c $ENV{LEDGER_SECURE_SDK}/lib_cxng/src/cx_sha256.c $ENV{LEDGER_SECURE_SDK}/lib_cxng/src/cx_sha512.c $ENV{LEDGER_SECURE_SDK}/lib_cxng/src/cx_pbkdf2.c $ENV{LEDGER_SECURE_SDK}/lib_cxng/src/cx_hmac.c $ENV{LEDGER_SECURE_SDK}/lib_cxng/src/cx_utils.c)
+set(LIBCXNG_SOURCES $ENV{LEDGER_SECURE_SDK}/lib_cxng/src/cx_ram.c $ENV{LEDGER_SECURE_SDK}/lib_cxng/src/cx_hash.c $ENV{LEDGER_SECURE_SDK}/lib_cxng/src/cx_sha256.c $ENV{LEDGER_SECURE_SDK}/lib_cxng/src/cx_sha512.c $ENV{LEDGER_SECURE_SDK}/lib_cxng/src/cx_pbkdf2.c $ENV{LEDGER_SECURE_SDK}/lib_cxng/src/cx_hmac.c $ENV{LEDGER_SECURE_SDK}/lib_cxng/src/cx_utils.c $ENV{LEDGER_SECURE_SDK}/lib_cxng/src/cx_sha3.c)
 set(TESTLIB_SOURCES ./lib/testutils.c)
 add_library(testutils SHARED ${TESTLIB_SOURCES} ${LIBCXNG_SOURCES} ${BOLOS_SOURCES})
 target_include_directories(testutils PUBLIC ${INSTALL_DIR}/include ${CMAKE_CURRENT_SOURCE_DIR}/../../src/common/sskr/sss ${CMAKE_CURRENT_SOURCE_DIR}/../../src/commonsskr)
 target_link_directories(testutils PUBLIC ${INSTALL_DIR}/lib)
 target_link_libraries(testutils PUBLIC ssl crypto)
+# HAVE_SHA3 only affects this library's own SHA3 dispatch-table entry
+# (cx_hash.c gates it behind `#ifdef HAVE_SHA3`) and the newly-added
+# cx_sha3.c above; it does not change compile definitions for any other
+# test executable, which is what actually links against testutils.
+target_compile_definitions(testutils PRIVATE HAVE_SHA3)
 add_dependencies(testutils openssl)
 
 add_library(sss SHARED ../../src/common/sskr/sss/sss.c ../../src/common/sskr/sss/interpolate.c)
@@ -243,8 +248,29 @@ target_link_libraries(test_base85 PUBLIC cmocka gcov)
 # seed_bip85.c precisely so it can be linked here without the NBGL headers
 # the rest of that file needs.
 add_executable(test_bip85_dice_bits_per_roll tests/bip85_dice_bits_per_roll.c ../../src/common/bip85/seed_bip85.c)
+target_include_directories(test_bip85_dice_bits_per_roll PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/../../src)
 target_link_libraries(test_bip85_dice_bits_per_roll PUBLIC cmocka gcov)
 
-foreach(target test_sss test_sss_recover_erase_length test_sskr test_sskr_share_len test_sskr_memzero test_sskr_shard_count test_sskr_generate_split_error test_sskr_combine_bounds test_sskr_combine_error test_sskr_entry_bounds test_sskr_byteword_sentinel test_bip39 test_roundtrip test_words test_base64 test_base85 test_bip85_dice_bits_per_roll)
+# bip85_dice_roll() (also outside the HAVE_NBGL guard) calls
+# cx_shake256_hash() -- pure software, no BOLOS syscall, unlike
+# bolos_ux_bip85_entropy() which the rest of seed_bip85.c depends on and
+# which cannot be tested on host. cx_sha3.c and cx_hash_iovec.c are
+# compiled directly into this target rather than added to the shared
+# `testutils` library, the same way sss.c/interpolate.c are for
+# test_sss_recover_erase_length; HAVE_SHA3 is defined for this target only,
+# matching the real app build (Makefile.conf.cx enables it unconditionally)
+# without turning it on for any other unit test.
+add_executable(test_bip85_dice_roll tests/bip85_dice_roll.c ../../src/common/bip85/seed_bip85.c $ENV{LEDGER_SECURE_SDK}/src/cx_hash_iovec.c)
+# cx_shake256_hash_iovec() (which cx_shake256_hash() wraps) is behind
+# `#ifdef HAVE_SHA3` in cx_hash_iovec.c, same as the SHA3 dispatch-table
+# entry testutils now also compiles in (see `target_compile_definitions
+# (testutils ...)` above) -- both need it for this target to link.
+target_compile_definitions(test_bip85_dice_roll PRIVATE HAVE_SHA3)
+# cx_hash_iovec.c does `#include "lib_cxng/src/cx_ram.h"`, resolved relative
+# to the SDK root rather than to lib_cxng/src itself.
+target_include_directories(test_bip85_dice_roll PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/../../src $ENV{LEDGER_SECURE_SDK})
+target_link_libraries(test_bip85_dice_roll PUBLIC cmocka gcov testutils)
+
+foreach(target test_sss test_sss_recover_erase_length test_sskr test_sskr_share_len test_sskr_memzero test_sskr_shard_count test_sskr_generate_split_error test_sskr_combine_bounds test_sskr_combine_error test_sskr_entry_bounds test_sskr_byteword_sentinel test_bip39 test_roundtrip test_words test_base64 test_base85 test_bip85_dice_bits_per_roll test_bip85_dice_roll)
     add_test(NAME ${target} COMMAND ${target})
 endforeach()

--- a/tests/unit/tests/bip85_dice_roll.c
+++ b/tests/unit/tests/bip85_dice_roll.c
@@ -1,0 +1,68 @@
+#include <cmocka.h>
+#include <setjmp.h>
+#include <stdarg.h>
+#include <stddef.h>
+#include <stdint.h>
+#include <string.h>
+
+#define BIP85_ENTROPY_LENGTH 64
+
+extern int32_t bip85_dice_roll(uint32_t* out, size_t out_capacity,
+                               uint32_t sides, uint32_t rolls,
+                               const uint8_t seed[BIP85_ENTROPY_LENGTH]);
+
+// d2 (sides = 2) has bits_per_roll = 1, so every byte of the SHAKE256
+// digest yields either 0 or 1 -- always < sides -- and is accepted. That
+// makes the accept rate exactly 100% regardless of the seed's actual
+// content, so a fixed, arbitrary seed is enough to make this test
+// deterministic: no dependency on real BIP85 entropy or on the rejection
+// step ever discarding a byte.
+static const uint8_t seed[BIP85_ENTROPY_LENGTH] = {
+    0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09, 0x0a, 0x0b,
+    0x0c, 0x0d, 0x0e, 0x0f, 0x10, 0x11, 0x12, 0x13, 0x14, 0x15, 0x16,
+    0x17, 0x18, 0x19, 0x1a, 0x1b, 0x1c, 0x1d, 0x1e, 0x1f, 0x20, 0x21,
+    0x22, 0x23, 0x24, 0x25, 0x26, 0x27, 0x28, 0x29, 0x2a, 0x2b, 0x2c,
+    0x2d, 0x2e, 0x2f, 0x30, 0x31, 0x32, 0x33, 0x34, 0x35, 0x36, 0x37,
+    0x38, 0x39, 0x3a, 0x3b, 0x3c, 0x3d, 0x3e, 0x3f, 0x40};
+
+// With bytes_per_roll = 1 and a fixed BIP85_DRNG_MAX_DIGEST_SIZE = 256
+// byte digest, no more than 256 rolls can ever come out of a single,
+// non-extended digest -- even at the 100% acceptance rate d2 gives here,
+// which is the best case any (sides, rolls) pair can have. Asking for 257
+// therefore always demonstrates the silent-truncation bug: it does not
+// depend on the rejection step ever discarding a byte, so it does not
+// depend on chance.
+static void test_dice_roll_truncates_past_256_bytes(void** state) {
+    (void)state;
+
+    uint32_t out[300];
+    int32_t produced =
+        bip85_dice_roll(out, sizeof(out) / sizeof(out[0]), 2, 257, seed);
+
+    // Bug: fewer rolls than requested come back, and the caller has no
+    // signal beyond comparing the return value to what it asked for --
+    // which today's `bolos_ux_bip85_dice()` cannot do at all, since it
+    // returns void.
+    assert_int_equal(produced, 256);
+}
+
+// A request that fits comfortably inside a single digest must not be
+// affected by the bug above -- this is the baseline the fix must not
+// regress.
+static void test_dice_roll_exact_when_well_under_capacity(void** state) {
+    (void)state;
+
+    uint32_t out[10];
+    int32_t produced =
+        bip85_dice_roll(out, sizeof(out) / sizeof(out[0]), 2, 10, seed);
+
+    assert_int_equal(produced, 10);
+}
+
+int main(void) {
+    const struct CMUnitTest tests[] = {
+        cmocka_unit_test(test_dice_roll_truncates_past_256_bytes),
+        cmocka_unit_test(test_dice_roll_exact_when_well_under_capacity),
+    };
+    return cmocka_run_group_tests(tests, NULL, NULL);
+}

--- a/tests/unit/tests/bip85_dice_roll.c
+++ b/tests/unit/tests/bip85_dice_roll.c
@@ -14,7 +14,7 @@ extern int32_t bip85_dice_roll(uint32_t* out, size_t out_capacity,
 // d2 (sides = 2) has bits_per_roll = 1, so every byte of the SHAKE256
 // digest yields either 0 or 1 -- always < sides -- and is accepted. That
 // makes the accept rate exactly 100% regardless of the seed's actual
-// content, so a fixed, arbitrary seed is enough to make this test
+// content, so a fixed, arbitrary seed is enough to make these tests
 // deterministic: no dependency on real BIP85 entropy or on the rejection
 // step ever discarding a byte.
 static const uint8_t seed[BIP85_ENTROPY_LENGTH] = {
@@ -29,26 +29,25 @@ static const uint8_t seed[BIP85_ENTROPY_LENGTH] = {
 // byte digest, no more than 256 rolls can ever come out of a single,
 // non-extended digest -- even at the 100% acceptance rate d2 gives here,
 // which is the best case any (sides, rolls) pair can have. Asking for 257
-// therefore always demonstrates the silent-truncation bug: it does not
-// depend on the rejection step ever discarding a byte, so it does not
-// depend on chance.
-static void test_dice_roll_truncates_past_256_bytes(void** state) {
+// therefore always exercises the re-extension path: it does not depend on
+// the rejection step ever discarding a byte, so it does not depend on
+// chance.
+static void test_dice_roll_extends_past_256_bytes(void** state) {
     (void)state;
 
     uint32_t out[300];
     int32_t produced =
         bip85_dice_roll(out, sizeof(out) / sizeof(out[0]), 2, 257, seed);
 
-    // Bug: fewer rolls than requested come back, and the caller has no
-    // signal beyond comparing the return value to what it asked for --
-    // which today's `bolos_ux_bip85_dice()` cannot do at all, since it
-    // returns void.
-    assert_int_equal(produced, 256);
+    // Fixed: the digest is re-derived at double the length and the request
+    // is satisfied in full, rather than silently truncated at 256 -- which
+    // is what `bolos_ux_bip85_dice()` could not even report before, since
+    // it returned void.
+    assert_int_equal(produced, 257);
 }
 
 // A request that fits comfortably inside a single digest must not be
-// affected by the bug above -- this is the baseline the fix must not
-// regress.
+// affected by the extension path above.
 static void test_dice_roll_exact_when_well_under_capacity(void** state) {
     (void)state;
 
@@ -59,10 +58,37 @@ static void test_dice_roll_exact_when_well_under_capacity(void** state) {
     assert_int_equal(produced, 10);
 }
 
+// SHAKE256 is a genuine XOF: a longer digest from the same seed must
+// reproduce the same leading bytes as a shorter one. This is the property
+// the fix's re-derive-from-scratch strategy depends on for correctness --
+// verified here end to end through the real cx_shake256_hash(), not just
+// assumed. rolls=256 stays within the initial digest (no extension);
+// rolls=257 forces exactly one re-extension (512-byte digest). The first
+// 256 results of the second call must be pixel-for-pixel identical to the
+// first call's, proving the extension does not alter rolls already found.
+static void test_dice_roll_extension_preserves_prior_rolls(void** state) {
+    (void)state;
+
+    uint32_t out_no_extension[256];
+    int32_t produced_no_extension = bip85_dice_roll(
+        out_no_extension, sizeof(out_no_extension) / sizeof(uint32_t), 2, 256,
+        seed);
+    assert_int_equal(produced_no_extension, 256);
+
+    uint32_t out_extended[257];
+    int32_t produced_extended = bip85_dice_roll(
+        out_extended, sizeof(out_extended) / sizeof(uint32_t), 2, 257, seed);
+    assert_int_equal(produced_extended, 257);
+
+    assert_memory_equal(out_no_extension, out_extended,
+                        sizeof(out_no_extension));
+}
+
 int main(void) {
     const struct CMUnitTest tests[] = {
-        cmocka_unit_test(test_dice_roll_truncates_past_256_bytes),
+        cmocka_unit_test(test_dice_roll_extends_past_256_bytes),
         cmocka_unit_test(test_dice_roll_exact_when_well_under_capacity),
+        cmocka_unit_test(test_dice_roll_extension_preserves_prior_rolls),
     };
     return cmocka_run_group_tests(tests, NULL, NULL);
 }


### PR DESCRIPTION
## What this changes

`bolos_ux_bip85_dice()` drew rolls by rejection-sampling a single, fixed
`BIP85_DRNG_MAX_DIGEST_SIZE` (256 byte) SHAKE256 digest, and returned `void`.
Rejection sampling means the acceptance rate is never 100% except for
power-of-two `sides`, and even then the digest is finite, so a large enough
`rolls` request could run out of digest before filling `out[]` -- with no way
for the caller to know, since nothing was returned.

The DRNG-plus-roll logic is extracted into a new `bip85_dice_roll()` (outside
the `HAVE_NBGL` guard, next to `bip85_dice_bits_per_roll()` from #66), which
now retries with a longer SHAKE256 digest -- re-derived from scratch from the
same seed, not resumed mid-stream -- when the current one is exhausted before
producing `rolls` valid values. SHAKE256 is a genuine XOF, so a longer digest
from the same seed reproduces the same leading bytes: already-accepted rolls
are unaffected by a retry, and re-deriving from scratch is simpler to get
right than resuming mid-digest, at negligible extra cost.
`BIP85_DICE_MAX_DRNG_DOUBLINGS` (3) bounds the retries at 256 -> 512 -> 1024
-> 2048 bytes: given `bits_per_roll = ceil(log2(sides))` never accepts fewer
than half the candidates it draws (worst case `sides` one more than a power
of two, e.g. 129/256 ~= 50.4%), exhausting all three doublings without
producing `rolls` values is not expected for any realistic request, but it is
reported as an error rather than looped on indefinitely.

## Why

Closes the last open item on #60 (see the 2026-07-28 status comment) -- the
DRNG out-of-bounds read and `bits_per_roll` formula were already fixed
separately (`d09d704`, #66); this was tracked as the remaining, larger API
change.

## Public API change

```c
// before
void bolos_ux_bip85_dice(uint32_t *out, uint32_t sides, uint32_t rolls,
                         unsigned int index);
// after
int32_t bolos_ux_bip85_dice(uint32_t *out, size_t out_capacity, uint32_t sides,
                            uint32_t rolls, uint32_t index);
```

Returns the number of rolls actually produced (`rolls` on success) or a
negative error code, instead of writing into `out[]` in place and reporting
nothing. Confirmed no callers exist today (`grep -rn "bolos_ux_bip85_dice\b" src/`
matches only the declaration in `common_bip85.h` and the definition itself),
so this is not a breaking change for anything currently wired up -- DICE has
no UI caller yet.

## Branch and scope

- Base SHA: `origin/bip85@95421e4` (rebased once, cleanly, after PR #70 merged
  mid-session on an unrelated function)
- Target branch: `bip85`
- Devices: no device-specific code touched; DICE is behind `HAVE_NBGL` only
- UI stack: none reachable (no caller wired up for DICE today)

## Security properties

- Remote channel: none
- Host-controlled input: none (same as before -- `sides`/`rolls`/`index` come
  from the same BIP32-path construction as before)
- Secret output: DRNG digest buffer is `explicit_bzero`'d on every exit path
  (success, SHAKE256 failure, and exhausted-doublings failure)
- NVM writes: none
- Memory-safety impact: none identified; digest buffer is sized for the
  worst-case doubling at compile time (`BIP85_DRNG_MAX_DIGEST_SIZE << BIP85_DICE_MAX_DRNG_DOUBLINGS`),
  not dynamically allocated

## Commits

1. `tests: reproduce silent DICE roll truncation (#60)` -- mechanical
   extraction of the existing (buggy) loop into a testable function, no
   behaviour change; test demonstrates 257 requested rolls yields only 256.
2. `bip85: fix DICE roll truncation with bounded DRNG re-extension (#60)` --
   the actual fix (re-extension loop) plus the public API change; same test
   file, assertions updated to expect the correct count, plus a new test
   proving the SHAKE256 prefix property end-to-end.

## Verification

| Check | Command | Result |
|---|---|---|
| Unit | `cmake -B build -H. && make -C build && ctest` (ledger-app-dev-tools:latest) | 18/18 pass, both commits and after rebase |
| clang-format | `clang-format --dry-run -Werror` (v21; v11 pinned by CI unavailable locally) | clean on all touched files |
| Speculos | -- | not run (no UI caller to drive) |
| Hardware | -- | not run (no UI caller to drive) |
| Builds | `BOLOS_SDK=/opt/flex-secure-sdk make` (NBGL), `BOLOS_SDK=/opt/nanox-secure-sdk make` (BAGL) | both build and link; `arm-none-eabi-nm` confirms `bip85_dice_bits_per_roll`/`bip85_dice_roll`/`bolos_ux_bip85_dice` present in the flex ELF |

## Before and after

Deterministic repro, independent of actual seed content: `sides=2` gives
`bits_per_roll=1`, so every digest byte is accepted (100% acceptance --
the best case for any `(sides, rolls)` pair). Before this fix,
`bip85_dice_roll(out, 300, 2, 257, seed)` (extracted in the first commit,
mirroring the original inline loop exactly) returns `256` -- the request for
257 rolls is silently short by one. After the fix, the same call returns
`257`, and a same-seed call for `rolls=256` (no extension needed) produces
byte-for-byte identical leading results to the `rolls=257` call (which
triggers one re-extension), verified via `assert_memory_equal` in
`test_dice_roll_extension_preserves_prior_rolls`.

## Limitations

BAGL build is compile-only (as with prior BIP85-only PRs -- the code is
entirely behind `HAVE_NBGL`, so this is a no-regression check, not a
functional one for this change). Speculos and physical hardware not run:
DICE has no UI caller today (see #60, and the exposure gate in the repo's
tracking plan), so there is nothing reachable to drive there yet.

## Follow-up

None expected for `bip85`. Once merged, will post a status-update comment
on #60 noting this closes the last open item, per the project's issue
status-comment format.