### PR TITLE
build: enable HAVE_BOLOS_APP_STACK_CANARY

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -49,6 +49,11 @@ ICON_APEX_P = icons/icon_seed_32px.png
 
 #DEFINES += HAVE_ELECTRUM
 
+# Whole-app stack canary written at init and checked on every I/O event loop
+# iteration on nanos-secure-sdk (io_seproxyhal_se_reset() on mismatch); write
+# path only, no observable app-side check, on newer SDKs (nanox/stax/flex/...).
+DEFINES += HAVE_BOLOS_APP_STACK_CANARY
+
 ifeq ($(TARGET_NAME),TARGET_NANOS)
     $(info Using BAGL)
     DISABLE_STANDARD_USB = 1


### PR DESCRIPTION
## What this changes

Enables `HAVE_BOLOS_APP_STACK_CANARY` in the Makefile — a single `DEFINES +=` line, no source code touched. This is a whole-app canary, distinct from the per-function `-fstack-protector` canaries already active by default on every target.

## Why

Evaluates a defense-in-depth mitigation motivated by the SSKR stack overflows fixed in #58/#62. The linker symbol `app_stack_canary` is already declared unconditionally in `script.ld` on all six targets, so this requires no linker change.

## Branch and scope

- Base SHA: `fb8ec5d` (`origin/bip85`, includes PR #71)
- Target branch: `bip85`
- Devices: all six (nanos, nanosplus, nanox, stax, flex, apex_p)
- UI stack: both NBGL and BAGL

## Security properties

- Remote channel: not applicable — build configuration only
- Host-controlled input: not applicable
- Secret output: not applicable
- NVM writes: none
- Memory-safety impact: adds a coarse, whole-app detection mechanism for stack overflows that escape the existing per-function canaries; no change to any memory-safety-relevant code path

## Commits

1. `build: enable HAVE_BOLOS_APP_STACK_CANARY` — single commit, pure build configuration change

## Verification

| Check | Command | Result |
|---|---|---|
| Unit | `ctest` in `tests/unit` (ledger-app-dev-tools) | pass (18/18, unchanged by this change) |
| ASan | n/a | not applicable |
| UBSan | n/a | not applicable |
| Speculos | n/a | not run |
| Hardware | n/a | not run |
| Builds | `make` for nanos/nanox/nanosplus/stax/flex/apex_p (ledger-app-builder-lite) | pass, all six link |
| Symbol | `arm-none-eabi-nm build/<target>/bin/app.elf \| grep canary` | `app_stack_canary` present in the linked ELF, checked on nanos and flex |

## Before and after

Not applicable — this isn't a bug fix with a discriminating test. Before: `app_stack_canary` declared by the linker script but never written or checked by the app on any target. After: written at init on every target; **checked** every I/O event loop iteration on `nanos-secure-sdk` only (see Limitations).

## Limitations

- **Runtime behavior is not tested here.** Verifying that a real stack overflow is actually caught requires the firmware to detect it in practice (Speculos or hardware) — out of scope for this PR, tracked separately for a hardware/Speculos verification pass.
- **Confirmed source-level asymmetry between old and new SDKs**, found by inspecting the actual SDK sources in `ghcr.io/ledgerhq/ledger-app-builder/ledger-app-builder-lite` images (not assumed):
  - On `nanos-secure-sdk` (Nano S — the most memory-constrained target, and the one where the #62 overflow measured 4224 bytes against a 1603-byte capacity), `src/os_io_seproxyhal.c` both writes `app_stack_canary = APP_STACK_CANARY_MAGIC` at init **and** checks it every I/O event loop iteration, calling `io_seproxyhal_se_reset()` on mismatch — a detected overflow triggers a clean SE reset, not silent corruption.
  - On newer SDKs (`nanox-secure-sdk`, `flex-secure-sdk`, `stax-secure-sdk`, `apex-secure-sdk`), `io_legacy/src/os_io_legacy.c` writes the canary at the same point, but `grep -rn "app_stack_canary" /opt/<sdk>/` shows only the write and the linker declaration — never a comparison anywhere in the app-side source available in this image. Verification may happen on the closed-source BOLOS OS side, or may not exist at this level on these targets — **this could not be determined from the sources available**, and is not claimed as confirmed either way.
- BAGL paths (nanos/nanosplus/nanox) are compile- and link-tested only in this PR, consistent with the rest of this change being a build-configuration toggle with no source path to exercise.

## Follow-up

None required by this PR itself. Runtime confirmation of the Nano S detect-and-reset path, and clarification of the newer-SDK behavior (OS-side or absent), belongs to a hardware/Speculos verification pass.

