### PR TITLE
sskr: reject reserved CBOR additional-info bytes instead of a literal length

### DIFF
--- a/src/bagl/nanos_enter_phrase.c
+++ b/src/bagl/nanos_enter_phrase.c
@@ -378,14 +378,31 @@ void screen_onboarding_restore_word_validate(void) {
         switch (G_bolos_ux_context.onboarding_step) {
             // 4th byte of CBOR header contains number of data bytes to follow
             case 3:
-                // SSKR bytes = 4 bytes CBOR + n bytes share + 4 bytes CRC
-                // checksum
-                G_bolos_ux_context.bip39_type =
-                    4 +
-                    (G_bolos_ux_context.sskr_words_buffer
+                if ((G_bolos_ux_context.sskr_words_buffer
                          [G_bolos_ux_context.sskr_words_buffer_length] &
-                     0x1F) +
-                    sizeof(uint32_t);
+                     0x1F) <= 24) {
+                    // SSKR bytes = 4 bytes CBOR + n bytes share + 4 bytes CRC
+                    // checksum. This is only a literal length for 0-23; 24
+                    // (one length byte follows) is corrected below once that
+                    // byte is read.
+                    G_bolos_ux_context.bip39_type =
+                        4 +
+                        (G_bolos_ux_context.sskr_words_buffer
+                             [G_bolos_ux_context.sskr_words_buffer_length] &
+                         0x1F) +
+                        sizeof(uint32_t);
+                } else {
+                    // 25-31 are reserved CBOR additional-info values
+                    // (two/four/eight-byte length, reserved, or indefinite
+                    // length) with no literal length of their own -- there is
+                    // nothing valid to compute here. Force the same maximum
+                    // bound used below for an out-of-range declared length,
+                    // so entry can still complete and
+                    // bolos_ux_sskr_hex_check() rejects it, instead of
+                    // treating the reserved value as if it encoded a
+                    // 25-to-31-byte payload.
+                    G_bolos_ux_context.bip39_type = SSKR_SHARE_MAX_WIRE_LENGTH;
+                }
                 break;
             case 4:
                 if ((G_bolos_ux_context.sskr_words_buffer[3] & 0x1F) == 24) {

--- a/src/bagl/nanox_enter_phrase.c
+++ b/src/bagl/nanox_enter_phrase.c
@@ -390,14 +390,31 @@ void screen_onboarding_restore_word_validate(void) {
         switch (G_bolos_ux_context.onboarding_step) {
             // 4th byte of CBOR header contains number of data bytes to follow
             case 3:
-                // SSKR bytes = 4 bytes CBOR + n bytes share + 4 bytes CRC
-                // checksum
-                G_bolos_ux_context.bip39_type =
-                    4 +
-                    (G_bolos_ux_context.sskr_words_buffer
+                if ((G_bolos_ux_context.sskr_words_buffer
                          [G_bolos_ux_context.sskr_words_buffer_length] &
-                     0x1F) +
-                    sizeof(uint32_t);
+                     0x1F) <= 24) {
+                    // SSKR bytes = 4 bytes CBOR + n bytes share + 4 bytes CRC
+                    // checksum. This is only a literal length for 0-23; 24
+                    // (one length byte follows) is corrected below once that
+                    // byte is read.
+                    G_bolos_ux_context.bip39_type =
+                        4 +
+                        (G_bolos_ux_context.sskr_words_buffer
+                             [G_bolos_ux_context.sskr_words_buffer_length] &
+                         0x1F) +
+                        sizeof(uint32_t);
+                } else {
+                    // 25-31 are reserved CBOR additional-info values
+                    // (two/four/eight-byte length, reserved, or indefinite
+                    // length) with no literal length of their own -- there is
+                    // nothing valid to compute here. Force the same maximum
+                    // bound used below for an out-of-range declared length,
+                    // so entry can still complete and
+                    // bolos_ux_sskr_hex_check() rejects it, instead of
+                    // treating the reserved value as if it encoded a
+                    // 25-to-31-byte payload.
+                    G_bolos_ux_context.bip39_type = SSKR_SHARE_MAX_WIRE_LENGTH;
+                }
                 break;
             case 4:
                 if ((G_bolos_ux_context.sskr_words_buffer[3] & 0x1F) == 24) {

--- a/src/nbgl/sskr_shares.c
+++ b/src/nbgl/sskr_shares.c
@@ -92,9 +92,24 @@ size_t sskr_shares_word_add(const char* const byteword) {
     switch (sskr_shares_current_word_number_get()) {
         // 4th byte of CBOR header contains number of data bytes to follow
         case 3:
-            // SSKR bytes = 4 bytes CBOR + n bytes share + 4 bytes CRC checksum
-            shares.final_size =
-                4 + (shares.buffer[shares.length] & 0x1F) + sizeof(uint32_t);
+            if ((shares.buffer[shares.length] & 0x1F) <= 24) {
+                // SSKR bytes = 4 bytes CBOR + n bytes share + 4 bytes CRC
+                // checksum. This is only a literal length for 0-23; 24 (one
+                // length byte follows) is corrected below once that byte is
+                // read.
+                shares.final_size = 4 + (shares.buffer[shares.length] & 0x1F) +
+                                    sizeof(uint32_t);
+            } else {
+                // 25-31 are reserved CBOR additional-info values (two/four/
+                // eight-byte length, reserved, or indefinite length) with no
+                // literal length of their own -- there is nothing valid to
+                // compute here. Force the same maximum bound used below for
+                // an out-of-range declared length, so entry can still
+                // complete and bolos_ux_sskr_hex_check() rejects it, instead
+                // of treating the reserved value as if it encoded a
+                // 25-to-31-byte payload.
+                shares.final_size = SSKR_SHARE_MAX_WIRE_LENGTH;
+            }
             break;
         case 4:
             if ((shares.buffer[3] & 0x1F) == 24) {

--- a/tests/unit/CMakeLists.txt
+++ b/tests/unit/CMakeLists.txt
@@ -228,6 +228,11 @@ target_compile_definitions(test_sskr_byteword_sentinel PRIVATE SCREEN_SIZE_WALLE
 target_include_directories(test_sskr_byteword_sentinel PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/../../src/common ${CMAKE_CURRENT_SOURCE_DIR}/../../src)
 target_link_libraries(test_sskr_byteword_sentinel PUBLIC cmocka gcov sskr sss testutils)
 
+add_executable(test_sskr_cbor_additional_info ./tests/sskr_cbor_additional_info.c ../../src/common/bip39/seed_rom_variables.c ../../src/common/bip39/seed_bip39.c ../../src/common/sskr/seed_rom_variables.c ../../src/common/sskr/seed_sskr.c ../../src/nbgl/sskr_shares.c)
+target_compile_definitions(test_sskr_cbor_additional_info PRIVATE SCREEN_SIZE_WALLET)
+target_include_directories(test_sskr_cbor_additional_info PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/../../src/common ${CMAKE_CURRENT_SOURCE_DIR}/../../src)
+target_link_libraries(test_sskr_cbor_additional_info PUBLIC cmocka gcov sskr sss testutils)
+
 add_executable(test_words ./tests/words.c ../../src/common/bip39/seed_rom_variables.c ../../src/common/bip39/seed_bip39.c ../../src/common/sskr/seed_rom_variables.c ../../src/common/sskr/seed_sskr.c)
 target_include_directories(test_words PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/../../src/common)
 target_link_libraries(test_words PUBLIC cmocka gcov testutils sskr sss)
@@ -271,6 +276,6 @@ target_compile_definitions(test_bip85_dice_roll PRIVATE HAVE_SHA3)
 target_include_directories(test_bip85_dice_roll PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/../../src $ENV{LEDGER_SECURE_SDK})
 target_link_libraries(test_bip85_dice_roll PUBLIC cmocka gcov testutils)
 
-foreach(target test_sss test_sss_recover_erase_length test_sskr test_sskr_share_len test_sskr_memzero test_sskr_shard_count test_sskr_generate_split_error test_sskr_combine_bounds test_sskr_combine_error test_sskr_entry_bounds test_sskr_byteword_sentinel test_bip39 test_roundtrip test_words test_base64 test_base85 test_bip85_dice_bits_per_roll test_bip85_dice_roll)
+foreach(target test_sss test_sss_recover_erase_length test_sskr test_sskr_share_len test_sskr_memzero test_sskr_shard_count test_sskr_generate_split_error test_sskr_combine_bounds test_sskr_combine_error test_sskr_entry_bounds test_sskr_byteword_sentinel test_sskr_cbor_additional_info test_bip39 test_roundtrip test_words test_base64 test_base85 test_bip85_dice_bits_per_roll test_bip85_dice_roll)
     add_test(NAME ${target} COMMAND ${target})
 endforeach()

--- a/tests/unit/tests/sskr_cbor_additional_info.c
+++ b/tests/unit/tests/sskr_cbor_additional_info.c
@@ -1,0 +1,150 @@
+/*
+ * Regression test for reserved/invalid CBOR additional-info bytes being
+ * misinterpreted as a literal share length in sskr_shares_word_add().
+ *
+ * The 4th byte of the SSKR CBOR header (buffer[3]) is a byte-string header:
+ * major type 2, plus a 5-bit additional-info field (buffer[3] & 0x1F).
+ * Per RFC 8949, that field means:
+ *
+ *   0-23    literal length, 0 to 23 bytes                  (short form)
+ *   24      one length byte follows (0x58)                 (long form)
+ *   25      two length bytes follow (0x59)                 (reserved here)
+ *   26      four length bytes follow (0x5A)                (reserved here)
+ *   27      eight length bytes follow (0x5B)                (reserved here)
+ *   28-30   reserved, no defined meaning
+ *   31      indefinite length (0x5F)                        (reserved here)
+ *
+ * sskr_shares_word_add() only ever special-cases 0-23 (case 3, taken
+ * literally) and 24 (case 4, corrected once the extra length byte is read).
+ * 25-31 fall through case 3's literal-length formula unmodified:
+ *
+ *     final_size = 4 + (buffer[3] & 0x1F) + sizeof(uint32_t);
+ *
+ * treating, say, additional-info 27 as if it meant "27 literal bytes follow",
+ * which is not what that CBOR encoding means at all -- there is no valid
+ * share of that shape, and there is no length to compute here. The entry
+ * still looks "complete" to sskr_shares_complete_check() once the (bogus,
+ * small) final_size is reached, well before the share is verified by
+ * bolos_ux_sskr_hex_check().
+ *
+ * No memory overflow results (final_size stays far below
+ * SSKR_SHARES_MAX_LENGTH either way -- this is not issue #62/PR #63's bug),
+ * but the entry is accepted at a word count that cannot correspond to any
+ * valid SSKR share, instead of being pinned to a bound that leaves the
+ * downstream CRC/tag check in bolos_ux_sskr_hex_check() a chance to reject
+ * it. The BAGL paths (src/bagl/nanos_enter_phrase.c,
+ * src/bagl/nanox_enter_phrase.c) contain the identical switch and take the
+ * same fix, verified by compilation only -- see the note in
+ * sskr_entry_bounds.c on why they cannot be driven from this harness.
+ */
+
+#include <stdarg.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include <stddef.h>
+#include <setjmp.h>
+#include <cmocka.h>
+#include <string.h>
+
+#include "testutils.h"
+#include "sskr/common_sskr.h"
+#include "sskr/sskr-constants.h"
+#include "../../../src/nbgl/sskr_shares.h"
+
+extern unsigned char const SSKR_WORDLIST[];
+
+/*
+ * sskr_shares.c also holds sskr_shares_from_bip39_mnemonic() and
+ * sskr_shares_check(), which reach into the BIP39 module and the seed
+ * comparison. Neither is on the entry path under test; these exist only so
+ * the object links, and each aborts if it is ever reached.
+ */
+char *bip39_mnemonic_get(void) { fail_msg("not on the entry path"); }
+size_t bip39_mnemonic_length_get(void) { fail_msg("not on the entry path"); }
+uint8_t bip39_mnemonic_final_size_get(void) { fail_msg("not on the entry path"); }
+bool compare_recovery_phrase(void) { fail_msg("not on the entry path"); }
+
+/* Largest a serialized share can be on the wire: CBOR long-form header
+ * (tag + 0x58 + length byte), the shard itself, and the CRC32. Also the
+ * bound the fix must fall back to for a reserved additional-info value. */
+#define MAX_SHARE_WIRE_LEN \
+    (5 + SSKR_METADATA_LENGTH_BYTES + SSKR_MAX_STRENGTH_BYTES + 4)
+
+/* ByteWord whose decoded value is `b`; the table holds 256 four-letter words. */
+static const char *word_for(uint8_t b)
+{
+    return (const char *) &SSKR_WORDLIST[(size_t) b * SSKR_BYTEWORD_LENGTH];
+}
+
+/*
+ * Feeds the 3-byte CBOR tag followed by a byte-string header whose
+ * additional-info field is `additional_info` (25-31: reserved forms with no
+ * literal length of their own). Returns how many words it consumed.
+ */
+static size_t feed_reserved_additional_info_header(uint8_t additional_info)
+{
+    assert_true(additional_info >= 25 && additional_info <= 31);
+
+    sskr_shares_word_add(word_for(0xD9)); /* CBOR tag */
+    sskr_shares_word_add(word_for(0x9D));
+    sskr_shares_word_add(word_for(0x75));
+    /* major type 2 (0x40) | additional-info */
+    sskr_shares_word_add(word_for((uint8_t)(0x40 | additional_info)));
+    return 4;
+}
+
+/*
+ * A reserved additional-info value (27 here: the 8-byte-length form, 0x5B)
+ * has no literal length to compute. Entry must not be considered complete
+ * before the same maximum wire length that a too-long declared long-form
+ * length is already clamped to elsewhere in this switch -- and must not
+ * complete any earlier than that, which is what today's literal-length
+ * fallback (final_size = 4 + 27 + 4 = 35) does.
+ */
+static void test_reserved_additional_info_is_not_taken_as_literal_length(void **state)
+{
+    (void) state;
+
+    sskr_shares_reset();
+    size_t fed = feed_reserved_additional_info_header(27);
+
+    for (size_t target = fed + 1; target <= MAX_SHARE_WIRE_LEN; target++) {
+        assert_false(sskr_shares_complete_check());
+        sskr_shares_word_add(word_for(0x00));
+        assert_int_equal(sskr_shares_current_word_number_get(), target);
+    }
+    assert_true(sskr_shares_complete_check());
+}
+
+/*
+ * Same property for the other reserved/invalid forms named in the CBOR
+ * spec: 25 (0x59, two length bytes), 26 (0x5A, four length bytes), 28-30
+ * (reserved, no meaning), and 31 (0x5F, indefinite length).
+ */
+static void test_all_reserved_additional_info_values_reach_max_wire_length(void **state)
+{
+    (void) state;
+
+    const uint8_t reserved[] = {25, 26, 28, 29, 30, 31};
+    for (size_t i = 0; i < sizeof(reserved) / sizeof(reserved[0]); i++) {
+        sskr_shares_reset();
+        size_t fed = feed_reserved_additional_info_header(reserved[i]);
+
+        for (size_t target = fed + 1; target < MAX_SHARE_WIRE_LEN; target++) {
+            assert_false(sskr_shares_complete_check());
+            sskr_shares_word_add(word_for(0x00));
+        }
+        assert_false(sskr_shares_complete_check());
+        sskr_shares_word_add(word_for(0x00));
+        assert_true(sskr_shares_complete_check());
+    }
+}
+
+int main(void)
+{
+    const struct CMUnitTest tests[] = {
+        cmocka_unit_test(test_reserved_additional_info_is_not_taken_as_literal_length),
+        cmocka_unit_test(test_all_reserved_additional_info_values_reach_max_wire_length),
+    };
+    return cmocka_run_group_tests(tests, NULL, NULL);
+}


### PR DESCRIPTION
## What this changes

`sskr_shares_word_add()` (NBGL) and the identical switch duplicated in the
two BAGL entry paths compute the SSKR share's expected word count from the
CBOR byte-string header's additional-info field (`buffer[3] & 0x1F`) as
though it were always a literal length. That's only correct for 0-23
(short form); 24 (one length byte follows) is already corrected once that
byte is read. Values 25-31 -- two/four/eight-byte length (RFC 8949),
reserved, and indefinite length -- fell through the same formula
unmodified and were treated as if they meant a literal 25-to-31-byte
payload, which none of those CBOR forms actually mean.

## Why

Not a memory-safety issue: `final_size` stays far below
`SSKR_SHARES_MAX_LENGTH` either way (#62 / PR #63 already bounds that
independently). It's a robustness gap matching the invariants already
tracked for a future unified CBOR parser (reject `0x59`/`0x5a`/`0x5b`,
reject reserved additional-info, reject indefinite length) -- an invalid
header was silently misinterpreted rather than cleanly rejected. This PR
is deliberately narrower than that full parser: it only fixes the
misinterpretation, without building `sskr_cbor_header_t` validation.

## Branch and scope

- Base SHA: `999d541`
- Target branch: `bip85`
- Devices: Flex (NBGL), Nano X / Nano S (BAGL)
- UI stack: NBGL (`src/nbgl/sskr_shares.c`) and BAGL
  (`src/bagl/nanos_enter_phrase.c`, `src/bagl/nanox_enter_phrase.c`)

## Security properties

- Remote channel: no -- local keypad/keyboard entry only
- Host-controlled input: yes -- the entered ByteWords/digits are
  attacker-influenced
- Secret output: no
- NVM writes: no
- Memory-safety impact: none -- `final_size` is bounded by
  `SSKR_SHARE_MAX_WIRE_LENGTH` (46), unrelated to the SSKR share buffer's
  much larger capacity (already bounded by #62/PR #63)

## Commits

1. `tests: reproduce reserved CBOR additional-info bytes accepted as a
   literal length`
2. `sskr: reject reserved CBOR additional-info bytes instead of a literal
   length`

## Verification

| Check | Command | Result |
|---|---|---|
| Unit | `ctest` in `tests/unit/build` (cmocka) | 19/19 pass |
| New test red before fix | `./test_sskr_cbor_additional_info` on commit 1 alone | fails as expected |
| ASan | not applicable | not applicable |
| UBSan | not applicable | not applicable |
| Speculos | not run | not run |
| Hardware | not run | not run |
| Builds | `flex` (NBGL), `nanox`, `nanos` (BAGL) | all compile and link |
| clang-format | `--dry-run -Werror` (v21) on the 3 touched source files | clean, aside from one pre-existing, unrelated line (`sskr_shares.c:88`, present on `bip85` before this PR -- the same v11/v21 disagreement already documented on prior PRs) |

## Before and after

Before: entering a share whose byte-string header declares additional-info
27 (`0x5B`) is accepted as "complete" once 35 words are entered (`4 + 27 +
4`), a length with no valid meaning for that CBOR encoding. Same for 25,
26, 28, 29, 30, 31, each landing on its own bogus small word count.

After: any of 25-31 forces the same maximum bound already used a few lines
below for an out-of-range long-form length (`SSKR_SHARE_MAX_WIRE_LENGTH`,
46 words), so entry only completes at a bounded, reachable count and
`bolos_ux_sskr_hex_check()`'s CRC/tag check is left to reject it.

## Limitations

BAGL paths (`nanos_enter_phrase.c`, `nanox_enter_phrase.c`) are
compile-tested only -- same limitation already documented for this switch's
prior fixes (bound-buffer fix in #63, ByteWord sentinel in #68). No
Speculos or physical-hardware run in this PR.

## Follow-up

A full, unified CBOR header parser (tag check, canonical-form check,
shard-length range check, single validation shared by both UI stacks
rather than duplicated ad hoc) remains a separate, larger piece of work --
tracked as its own roadmap item, not attempted here.