### PR TITLE
tests: add independent-oracle coverage for BIP85-derived BIP39 entropy

### DIFF
--- a/src/common/bip85/seed_bip85.c
+++ b/src/common/bip85/seed_bip85.c
@@ -150,6 +150,49 @@ int32_t bip85_dice_roll(uint32_t* out, size_t out_capacity, uint32_t sides,
 
 #endif  // HAVE_SHA3
 
+#ifdef HAVE_HMAC
+#include <lcx_hmac.h>
+
+/**
+ * @brief Computes BIP85 entropy from an already BIP32-derived 32-byte root
+ * key, via HMAC-SHA512("bip-entropy-from-k", key) as specified by BIP-85.
+ *
+ * @details Kept outside the `HAVE_NBGL` guard below, and with external
+ * linkage, purely so it can be linked into a unit test against the real
+ * `cx_hmac_no_throw()` -- pure software, no BOLOS syscall, unlike the BIP32
+ * derivation in `bolos_ux_bip85_entropy()` below, which depends on
+ * `os_derive_bip32_no_throw()` and cannot be tested on host. Same pattern as
+ * `bip85_dice_roll()` above.
+ *
+ * `bolos_ux_bip85_entropy()` calls this with `key` and `out` pointing at the
+ * same buffer -- safe only because a single `CX_LAST` call consumes the
+ * whole 32-byte input before any output byte is written; preserve that
+ * property if this function is ever changed.
+ *
+ * @param[in]  key      32-byte root key.
+ * @param[out] out      Buffer to receive the HMAC-SHA512 output; may alias
+ * `key`.
+ * @param[in]  out_len  Number of bytes of `out` to write.
+ *
+ * @return `true` on success, `false` if the HMAC computation failed.
+ */
+bool bip85_entropy_from_key(const uint8_t key[32], uint8_t* out,
+                            size_t out_len) {
+    cx_hmac_sha512_t ctx;
+    const char hmac_key[] = "bip-entropy-from-k";
+
+    if (cx_hmac_sha512_init_no_throw(&ctx, (const uint8_t*)hmac_key,
+                                     strlen(hmac_key)) != CX_OK) {
+        return false;
+    }
+    if (cx_hmac_no_throw((cx_hmac_t*)&ctx, CX_LAST, key, 32, out, out_len) !=
+        CX_OK) {
+        return false;
+    }
+    return true;
+}
+#endif  // HAVE_HMAC
+
 #if defined(HAVE_NBGL)
 #include <lcx_hmac.h>
 #include <lcx_sha3.h>
@@ -190,15 +233,9 @@ bool bolos_ux_bip85_entropy(uint8_t* entropy, const unsigned int* path,
     PRINTF("Root key from device: \n%.*H\n", 32, entropy);
 
     // Generate BIP85 entropy from root key
-    cx_hmac_sha512_t ctx;
-    const char key[] = "bip-entropy-from-k";
-
-    LEDGER_ASSERT(cx_hmac_sha512_init_no_throw(&ctx, (const uint8_t*)key,
-                                               strlen(key)) == CX_OK,
-                  "HMAC init failed");
-    LEDGER_ASSERT(cx_hmac_no_throw((cx_hmac_t*)&ctx, CX_LAST, entropy, 32,
-                                   entropy, BIP85_ENTROPY_LENGTH) == CX_OK,
-                  "HMAC failed");
+    LEDGER_ASSERT(
+        bip85_entropy_from_key(entropy, entropy, BIP85_ENTROPY_LENGTH),
+        "HMAC failed");
     PRINTF("BIP85 entropy from root key:\n%.*H\n", BIP85_ENTROPY_LENGTH,
            entropy);
 

--- a/tests/unit/CMakeLists.txt
+++ b/tests/unit/CMakeLists.txt
@@ -251,10 +251,15 @@ target_link_libraries(test_base85 PUBLIC cmocka gcov)
 
 # bip85_dice_bits_per_roll() is defined outside the HAVE_NBGL guard in
 # seed_bip85.c precisely so it can be linked here without the NBGL headers
-# the rest of that file needs.
+# the rest of that file needs. Since HAVE_HMAC is defined globally above
+# (unlike the per-target HAVE_SHA3 below), compiling seed_bip85.c as a whole
+# now always pulls in bip85_entropy_from_key()'s reference to
+# cx_hmac_sha512_init_no_throw()/cx_hmac_no_throw() too, even though this
+# target itself never calls it -- testutils is where those symbols actually
+# live.
 add_executable(test_bip85_dice_bits_per_roll tests/bip85_dice_bits_per_roll.c ../../src/common/bip85/seed_bip85.c)
 target_include_directories(test_bip85_dice_bits_per_roll PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/../../src)
-target_link_libraries(test_bip85_dice_bits_per_roll PUBLIC cmocka gcov)
+target_link_libraries(test_bip85_dice_bits_per_roll PUBLIC cmocka gcov testutils)
 
 # bip85_dice_roll() (also outside the HAVE_NBGL guard) calls
 # cx_shake256_hash() -- pure software, no BOLOS syscall, unlike
@@ -276,6 +281,20 @@ target_compile_definitions(test_bip85_dice_roll PRIVATE HAVE_SHA3)
 target_include_directories(test_bip85_dice_roll PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/../../src $ENV{LEDGER_SECURE_SDK})
 target_link_libraries(test_bip85_dice_roll PUBLIC cmocka gcov testutils)
 
-foreach(target test_sss test_sss_recover_erase_length test_sskr test_sskr_share_len test_sskr_memzero test_sskr_shard_count test_sskr_generate_split_error test_sskr_combine_bounds test_sskr_combine_error test_sskr_entry_bounds test_sskr_byteword_sentinel test_sskr_cbor_additional_info test_bip39 test_roundtrip test_words test_base64 test_base85 test_bip85_dice_bits_per_roll test_bip85_dice_roll)
+# bip85_entropy_from_key() (also outside the HAVE_NBGL guard) is the
+# HMAC-SHA512("bip-entropy-from-k", key) half of bolos_ux_bip85_entropy();
+# the BIP32 derivation that produces `key` is a BOLOS syscall
+# (os_derive_bip32_no_throw()) with no host equivalent and is not exercised
+# here. Chained with bolos_ux_bip39_mnemonic_encode() (seed_bip39.c, also
+# outside HAVE_NBGL) and checked word-for-word against the official BIP-85
+# test vectors. HAVE_HMAC and HAVE_SHA512 are already defined globally
+# above (needed for BIP39's own PBKDF2-HMAC-SHA512 seed derivation), so
+# nothing extra is required here, unlike HAVE_SHA3 for test_bip85_dice_roll
+# above.
+add_executable(test_bip85_bip39_entropy tests/bip85_bip39_entropy.c ../../src/common/bip85/seed_bip85.c ../../src/common/bip39/seed_rom_variables.c ../../src/common/bip39/seed_bip39.c)
+target_include_directories(test_bip85_bip39_entropy PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/../../src ${CMAKE_CURRENT_SOURCE_DIR}/../../src/common)
+target_link_libraries(test_bip85_bip39_entropy PUBLIC cmocka gcov testutils)
+
+foreach(target test_sss test_sss_recover_erase_length test_sskr test_sskr_share_len test_sskr_memzero test_sskr_shard_count test_sskr_generate_split_error test_sskr_combine_bounds test_sskr_combine_error test_sskr_entry_bounds test_sskr_byteword_sentinel test_sskr_cbor_additional_info test_bip39 test_roundtrip test_words test_base64 test_base85 test_bip85_dice_bits_per_roll test_bip85_dice_roll test_bip85_bip39_entropy)
     add_test(NAME ${target} COMMAND ${target})
 endforeach()

--- a/tests/unit/tests/bip85_bip39_entropy.c
+++ b/tests/unit/tests/bip85_bip39_entropy.c
@@ -1,0 +1,125 @@
+#include <cmocka.h>
+#include <setjmp.h>
+#include <stdarg.h>
+#include <stdbool.h>
+#include <stddef.h>
+#include <stdint.h>
+#include <string.h>
+
+#include "bip39/common_bip39.h"
+#include "testutils.h"
+
+#define BIP85_ENTROPY_LENGTH 64
+
+// bip85_entropy_from_key() covers only the HMAC-SHA512("bip-entropy-from-k",
+// key) half of bolos_ux_bip85_entropy(); the BIP32 derivation that produces
+// `key` in the first place goes through os_derive_bip32_no_throw(), a BOLOS
+// syscall against the device's real seed with no host equivalent, so it
+// cannot be exercised here. The three keys below stand in for that
+// derivation's output.
+extern bool bip85_entropy_from_key(const uint8_t key[32], uint8_t* out,
+                                   size_t out_len);
+
+// Independent oracle for all three vectors: the official BIP-85 master
+// xprv (bip-0085.mediawiki, bitcoin/bips), derived on
+// m/83696968'/39'/0'/{12,18,24}'/0' with bip32utils (Python, outside this
+// repo) to get the 32-byte key below, then cross-checked against this
+// repo's own HMAC-SHA512("bip-entropy-from-k", key) computed independently
+// with Python's hmac/hashlib against the entropy the spec publishes for
+// each path -- all three matched exactly. The mnemonics are copied
+// verbatim from the same spec. Neither the master xprv nor the derived
+// keys are anything other than these public test vectors.
+
+typedef struct {
+    uint8_t words;
+    uint8_t key[32];
+    uint8_t entropy_len;
+    uint8_t entropy[32];
+    const char* mnemonic;
+} bip85_bip39_vector_t;
+
+static const bip85_bip39_vector_t vectors[] = {
+    {
+        .words = 12,
+        .key = {0x83, 0x69, 0x51, 0xa7, 0x92, 0x90, 0x20, 0xf8,
+                0xb4, 0x45, 0x60, 0x34, 0x26, 0x7f, 0xde, 0xbc,
+                0x90, 0x91, 0x27, 0x4a, 0x4e, 0x46, 0x67, 0x7c,
+                0x7d, 0x41, 0x80, 0xef, 0x0c, 0x0e, 0xce, 0xa7},
+        .entropy_len = 16,
+        .entropy = {0x62, 0x50, 0xb6, 0x8d, 0xaf, 0x74, 0x6d, 0x12, 0xa2, 0x4d,
+                    0x58, 0xb4, 0x78, 0x7a, 0x71, 0x4b},
+        .mnemonic = "girl mad pet galaxy egg matter matrix prison refuse "
+                    "sense ordinary nose",
+    },
+    {
+        .words = 18,
+        .key = {0x65, 0x2a, 0x04, 0x32, 0x90, 0xed, 0x06, 0x66,
+                0xe9, 0x22, 0xb2, 0xa9, 0xfd, 0x61, 0x89, 0xd8,
+                0xf7, 0x9c, 0x89, 0x0b, 0x5b, 0x06, 0x81, 0x5b,
+                0xbe, 0x05, 0x80, 0x00, 0x19, 0xcd, 0xfb, 0xd6},
+        .entropy_len = 24,
+        .entropy = {0x93, 0x80, 0x33, 0xed, 0x8b, 0x12, 0x69, 0x84,
+                    0x49, 0xd4, 0xbb, 0xca, 0x3c, 0x85, 0x3c, 0x66,
+                    0xb2, 0x93, 0xea, 0x1b, 0x1c, 0xe9, 0xd9, 0xdc},
+        .mnemonic = "near account window bike charge season chef number "
+                    "sketch tomorrow excuse sniff circle vital hockey "
+                    "outdoor supply token",
+    },
+    {
+        .words = 24,
+        .key = {0xce, 0x7c, 0x1b, 0xae, 0xee, 0xd4, 0x18, 0x14,
+                0xca, 0xc0, 0x4b, 0x73, 0xd3, 0xf7, 0x1f, 0x79,
+                0x73, 0xb6, 0x45, 0xac, 0xaa, 0x4c, 0x71, 0x07,
+                0x1d, 0xb0, 0x99, 0xc1, 0x3b, 0xcb, 0x44, 0x38},
+        .entropy_len = 32,
+        .entropy = {0xae, 0x13, 0x1e, 0x23, 0x12, 0xcd, 0xc6, 0x13,
+                    0x31, 0x54, 0x2e, 0xfe, 0x0d, 0x10, 0x77, 0xba,
+                    0xc5, 0xea, 0x80, 0x3a, 0xdf, 0x24, 0xb3, 0x13,
+                    0xa4, 0xf0, 0xe4, 0x8e, 0x9c, 0x51, 0xf3, 0x7f},
+        .mnemonic = "puppy ocean match cereal symbol another shed magic "
+                    "wrap hammer bulb intact gadget divorce twin tonight "
+                    "reason outdoor destroy simple truth cigar social "
+                    "volcano",
+    },
+};
+
+static void run_vector(const bip85_bip39_vector_t* vector) {
+    uint8_t entropy[BIP85_ENTROPY_LENGTH];
+
+    assert_true(
+        bip85_entropy_from_key(vector->key, entropy, BIP85_ENTROPY_LENGTH));
+    assert_memory_equal(entropy, vector->entropy, vector->entropy_len);
+
+    unsigned char mnemonic_out[256];
+    size_t expected_len = strlen(vector->mnemonic);
+
+    unsigned int encoded_len = bolos_ux_bip39_mnemonic_encode(
+        entropy, vector->entropy_len, mnemonic_out, sizeof(mnemonic_out));
+
+    assert_int_equal(encoded_len, expected_len);
+    assert_memory_equal(mnemonic_out, vector->mnemonic, expected_len);
+}
+
+static void test_bip85_bip39_12_words(void** state) {
+    (void)state;
+    run_vector(&vectors[0]);
+}
+
+static void test_bip85_bip39_18_words(void** state) {
+    (void)state;
+    run_vector(&vectors[1]);
+}
+
+static void test_bip85_bip39_24_words(void** state) {
+    (void)state;
+    run_vector(&vectors[2]);
+}
+
+int main(void) {
+    const struct CMUnitTest tests[] = {
+        cmocka_unit_test(test_bip85_bip39_12_words),
+        cmocka_unit_test(test_bip85_bip39_18_words),
+        cmocka_unit_test(test_bip85_bip39_24_words),
+    };
+    return cmocka_run_group_tests(tests, NULL, NULL);
+}


### PR DESCRIPTION
## What this changes

Adds host-testable coverage for the BIP-85-derived BIP-39 mnemonic path
(`bolos_ux_bip85_bip39()` / `bolos_ux_bip85_entropy()`), which had zero
unit tests. No behavior change beyond an incidental assert-message merge
(see below) — this is coverage, not a fix.

## Why

`bolos_ux_bip85_entropy()` does two things:
derive a BIP32 root key via `os_derive_bip32_no_throw()` (a BOLOS syscall
against the device's real seed — no host equivalent, same hard blocker as
`pwd_base64`/`pwd_base85`), then compute
`HMAC-SHA512("bip-entropy-from-k", key)`. Only the second half is pure
software and can be tested on host.

Extracted that half into `bip85_entropy_from_key(key, out, out_len)`,
outside the `HAVE_NBGL` guard — same pattern as `bip85_dice_bits_per_roll()`/
`bip85_dice_roll()` (items 6/21). `bolos_ux_bip85_entropy()` calls it with
`key == out == entropy` (same aliasing as the code it replaces), safe
because `cx_hmac_no_throw()`'s single `CX_LAST` call consumes the whole
32-byte input before writing any output byte; preserved verbatim.

`LEDGER_ASSERT` (used at the two call sites this replaces) is not
host-linkable, so the extracted function returns `bool` instead of
asserting internally. `bolos_ux_bip85_entropy()` now wraps the single call
in one `LEDGER_ASSERT("HMAC failed")` instead of two separate assertions
(init vs. hmac) — the only externally-visible change, and only to a debug
assert message text, not to control flow.

## Branch and scope

- Base SHA: `dc1aec9` (`aido/bip85`, includes #73)
- Target branch: `aido:bip85`
- Devices: all (host-only test change; NBGL/flex and BAGL/nanox both
  rebuilt to confirm no regression)
- UI stack: common (`src/common/bip85/seed_bip85.c`), no UI code touched

## Security properties

- Remote channel: none
- Host-controlled input: none (test-only vectors, hardcoded)
- Secret output: none — the "keys" and "entropy" here are the BIP-85
  spec's own public test vectors, not real seed material
- NVM writes: none
- Memory-safety impact: none (no buffer sizes or bounds changed; the
  extraction preserves the exact aliasing of the original code)

## Commits

1. `tests: add independent-oracle coverage for BIP85-derived BIP39 entropy`
   (extraction + test together — no bug was found along the way, so no
   separate red/green pair; see commit message for the full rationale)

## Verification

| Check | Command | Result |
|---|---|---|
| Unit | `cmake -B build -H. -DPRECOMPILED_DEPENDENCIES_DIR=... && make -C build && ctest` (`ledger-app-dev-tools:latest`) | 20/20 pass (17 pre-existing + 3 new) |
| ASan | not applicable to this change | not applicable |
| UBSan | not applicable to this change | not applicable |
| Speculos | not run | not run |
| Hardware | not run | not run |
| Builds | `BOLOS_SDK=/opt/flex-secure-sdk make` and `BOLOS_SDK=/opt/nanox-secure-sdk make` (`ledger-app-builder-lite:latest`) | pass, both link |

`clang-format --dry-run -Werror` (v21; v11 pinned by CI unavailable
locally): clean on both touched/added `.c` files.

`arm-none-eabi-nm` on the flex ELF confirms both `bip85_entropy_from_key`
and `bolos_ux_bip85_entropy` present. On the nanox (BAGL) ELF neither is
present — BIP-85 is `HAVE_NBGL`-only; the non-guarded functions in
`seed_bip85.c` still compile into the BAGL object file but are
unreferenced and dropped by the linker, same before and after this change.

## Before and after

Before this commit, `bip85_entropy_from_key()` did not exist — the HMAC
computation was inline in `bolos_ux_bip85_entropy()`, entirely behind
`HAVE_NBGL`, with no way to reach it from a host unit test. The new test
(`tests/unit/tests/bip85_bip39_entropy.c`) exercises it directly against
three independent oracle vectors (12/18/24-word paths from the official
BIP-85 test vectors, `bip-0085.mediawiki`, `bitcoin/bips`):

- the 32-byte derived keys were recomputed from the spec's published
  master xprv with `bip32utils` (Python, outside this repo) on
  `m/83696968'/39'/0'/{12,18,24}'/0'`;
- cross-checked independently — before writing any test code — with
  Python's `hmac`/`hashlib` (`hmac.new(b"bip-entropy-from-k", key,
  hashlib.sha512)`) against the entropy the spec publishes for each path;
  all three matched exactly;
- the mnemonics are copied verbatim from the same spec.

Each test vector: (1) calls `bip85_entropy_from_key()` and compares the
truncated output byte-for-byte to the spec's entropy (exact length —
16/24/32 bytes for 12/18/24 words); (2) chains into
`bolos_ux_bip39_mnemonic_encode()` (already covered elsewhere, also
outside `HAVE_NBGL`) and compares word-for-word to the spec's mnemonic.

To confirm the comparisons are actually discriminating (not vacuously
true), I deliberately flipped one entropy byte and, separately, one
mnemonic word during verification and confirmed both failure modes
produce a real cmocka assertion failure, then reverted before committing.

## Limitations

`os_derive_bip32_no_throw()` (the BIP32 derivation that produces the root
key in the first place) remains untested on host — tracked separately
for a hardware/Speculos verification pass, alongside the equivalent gap
already noted for `pwd_base64`/`pwd_base85`. UI-level tests (exact
parameter/path/result consistency across the 12/18/24-word screens) are
not covered here either. BAGL paths are compile-
tested only, as noted above, since BIP-85 does not exist on that UI
stack at all.

## Follow-up

No port to another branch needed (`develop` doesn't have BIP-85). No UX
decision required. Hardware/Speculos verification for the derivation itself
remains open separately.

