### PR TITLE
tests: cover the SSKR combine multi-group/identifier/threshold invariants

### DIFF
--- a/tests/unit/CMakeLists.txt
+++ b/tests/unit/CMakeLists.txt
@@ -210,6 +210,10 @@ add_executable(test_sskr_combine_error ./tests/sskr_combine_error.c ../../src/co
 target_include_directories(test_sskr_combine_error PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/../../src/common)
 target_link_libraries(test_sskr_combine_error PUBLIC cmocka gcov sskr sss testutils)
 
+add_executable(test_sskr_combine_invariants ./tests/sskr_combine_invariants.c ../../src/common/bip39/seed_rom_variables.c ../../src/common/bip39/seed_bip39.c ../../src/common/sskr/seed_rom_variables.c ../../src/common/sskr/seed_sskr.c)
+target_include_directories(test_sskr_combine_invariants PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/../../src/common)
+target_link_libraries(test_sskr_combine_invariants PUBLIC cmocka gcov sskr sss testutils)
+
 add_executable(test_bip39 ./tests/bip39.c ../../src/common/bip39/seed_rom_variables.c  ../../src/common/bip39/seed_bip39.c)
 target_include_directories(test_bip39 PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/../../src/common)
 target_link_libraries(test_bip39 PUBLIC cmocka gcov testutils)
@@ -295,6 +299,6 @@ add_executable(test_bip85_bip39_entropy tests/bip85_bip39_entropy.c ../../src/co
 target_include_directories(test_bip85_bip39_entropy PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/../../src ${CMAKE_CURRENT_SOURCE_DIR}/../../src/common)
 target_link_libraries(test_bip85_bip39_entropy PUBLIC cmocka gcov testutils)
 
-foreach(target test_sss test_sss_recover_erase_length test_sskr test_sskr_share_len test_sskr_memzero test_sskr_shard_count test_sskr_generate_split_error test_sskr_combine_bounds test_sskr_combine_error test_sskr_entry_bounds test_sskr_byteword_sentinel test_sskr_cbor_additional_info test_bip39 test_roundtrip test_words test_base64 test_base85 test_bip85_dice_bits_per_roll test_bip85_dice_roll test_bip85_bip39_entropy)
+foreach(target test_sss test_sss_recover_erase_length test_sskr test_sskr_share_len test_sskr_memzero test_sskr_shard_count test_sskr_generate_split_error test_sskr_combine_bounds test_sskr_combine_error test_sskr_combine_invariants test_sskr_entry_bounds test_sskr_byteword_sentinel test_sskr_cbor_additional_info test_bip39 test_roundtrip test_words test_base64 test_base85 test_bip85_dice_bits_per_roll test_bip85_dice_roll test_bip85_bip39_entropy)
     add_test(NAME ${target} COMMAND ${target})
 endforeach()

--- a/tests/unit/tests/sskr_combine_invariants.c
+++ b/tests/unit/tests/sskr_combine_invariants.c
@@ -1,0 +1,131 @@
+/*
+ * Regression coverage for the shard-set invariants enforced inside
+ * sskr_combine_shards_internal() (src/common/sskr/sskr.c) before shares are
+ * ever handed to Shamir interpolation. All three checks already exist and
+ * already return SSKR_ERROR_INVALID_SHARD_SET; grepping tests/unit/tests for
+ * *.c before writing this file found no existing test that reaches any of them.
+ * This is coverage on already-correct code, not a bug fix.
+ *
+ * - a multi-group shard set (differing group_index) is rejected because
+ *   SSKR_MAX_GROUP_COUNT is 1 in this port: the second distinct group_index
+ *   trips `next_group >= SSKR_MAX_GROUP_COUNT` (sskr.c:473);
+ * - shards carrying a different identifier are rejected on the very first
+ *   metadata comparison (sskr.c:441);
+ * - shards carrying a different group_threshold are rejected by the same
+ *   comparison (sskr.c:442).
+ *
+ * The helper below extends the one in sskr_combine_error.c (which hardcodes
+ * a 1-of-1 group and group_index 0) with the parameters needed to build
+ * these three scenarios: identifier, group_index, group_threshold and
+ * group_count are now all caller-controlled, using the same wire layout
+ * documented in sskr_serialize_shard() (sskr.c) and matched here byte for
+ * byte.
+ */
+
+#include <stdarg.h>
+#include <stdint.h>
+#include <stddef.h>
+#include <setjmp.h>
+#include <cmocka.h>
+#include <string.h>
+
+#include "testutils.h"
+#include "sskr/common_sskr.h"
+#include "sskr/sskr-constants.h"
+
+#define SHARD_VALUE_LEN (16)
+#define SHARD_LEN       (SSKR_METADATA_LENGTH_BYTES + SHARD_VALUE_LEN)
+/* 3-byte CBOR tag + 1-byte header, then the shard, then the CRC32 */
+#define CBOR_LEN        (4)
+#define CRC_LEN         (4)
+#define WIRE_LEN        (CBOR_LEN + SHARD_LEN + CRC_LEN)
+
+/* Builds the wire form bolos_ux_sskr_combine() expects: CBOR header, shard,
+ * CRC32. Every field of the shard's metadata is caller-controlled so the
+ * same helper can build both consistent and inconsistent shard pairs. */
+static void build_wire_shard(uint8_t out[WIRE_LEN], uint16_t identifier,
+                             uint8_t group_index, uint8_t group_threshold,
+                             uint8_t group_count, uint8_t member_index,
+                             uint8_t member_threshold)
+{
+    out[0] = 0xD9;
+    out[1] = 0x9D;
+    out[2] = 0x75;                       // CBOR tag #6.40309
+    out[3] = 0x40 | (SHARD_LEN & 0x1F);  // byte string, short form
+
+    out[CBOR_LEN + 0] = (uint8_t) (identifier >> 8);
+    out[CBOR_LEN + 1] = (uint8_t) (identifier & 0xFF);
+    out[CBOR_LEN + 2] = (uint8_t) ((((group_threshold - 1) & 0x0F) << 4) |
+                                    ((group_count - 1) & 0x0F));
+    out[CBOR_LEN + 3] = (uint8_t) (((group_index & 0x0F) << 4) |
+                                    ((member_threshold - 1) & 0x0F));
+    out[CBOR_LEN + 4] = member_index & 0x0F;  // reserved nibble stays zero
+    memset(&out[CBOR_LEN + SSKR_METADATA_LENGTH_BYTES], 0x42, SHARD_VALUE_LEN);
+
+    /* The CRC is not checked by bolos_ux_sskr_combine() itself, but keeping
+     * the frame honest documents that these bytes are a legitimate shard. */
+    memset(&out[CBOR_LEN + SHARD_LEN], 0x00, CRC_LEN);
+}
+
+/* Two well-formed shards, same identifier and group_threshold, but a
+ * different group_index (0 and 1) -- a two-group set. SSKR_MAX_GROUP_COUNT
+ * is 1 in this port, so this must be rejected, never silently combined. */
+static void test_combine_rejects_multi_group_set(void **state)
+{
+    (void) state;
+
+    uint8_t wire[2 * WIRE_LEN];
+    uint8_t output[32];
+
+    build_wire_shard(&wire[0], 0xABCD, 0, 1, 2, 0, 2);
+    build_wire_shard(&wire[WIRE_LEN], 0xABCD, 1, 1, 2, 0, 2);
+
+    unsigned int len = bolos_ux_sskr_combine(wire, sizeof(wire), 2, output);
+
+    assert_int_equal(len, 0);
+}
+
+/* Two well-formed shards that otherwise look interchangeable (same group,
+ * distinct member indices) but come from different backups: the identifier
+ * differs. Must never be combined into a bogus secret. */
+static void test_combine_rejects_shards_from_different_backups(void **state)
+{
+    (void) state;
+
+    uint8_t wire[2 * WIRE_LEN];
+    uint8_t output[32];
+
+    build_wire_shard(&wire[0], 0xABCD, 0, 1, 1, 0, 2);
+    build_wire_shard(&wire[WIRE_LEN], 0xABCE, 0, 1, 1, 1, 2);
+
+    unsigned int len = bolos_ux_sskr_combine(wire, sizeof(wire), 2, output);
+
+    assert_int_equal(len, 0);
+}
+
+/* Two well-formed shards, same identifier, but declaring a different
+ * group_threshold (1 vs 2) -- an inconsistent shard set. */
+static void test_combine_rejects_inconsistent_group_threshold(void **state)
+{
+    (void) state;
+
+    uint8_t wire[2 * WIRE_LEN];
+    uint8_t output[32];
+
+    build_wire_shard(&wire[0], 0xABCD, 0, 1, 1, 0, 2);
+    build_wire_shard(&wire[WIRE_LEN], 0xABCD, 0, 2, 2, 1, 2);
+
+    unsigned int len = bolos_ux_sskr_combine(wire, sizeof(wire), 2, output);
+
+    assert_int_equal(len, 0);
+}
+
+int main(void)
+{
+    const struct CMUnitTest tests[] = {
+        cmocka_unit_test(test_combine_rejects_multi_group_set),
+        cmocka_unit_test(test_combine_rejects_shards_from_different_backups),
+        cmocka_unit_test(test_combine_rejects_inconsistent_group_threshold),
+    };
+    return cmocka_run_group_tests(tests, NULL, NULL);
+}


### PR DESCRIPTION
## What this changes

Adds coverage for three shard-set consistency checks inside
`sskr_combine_shards_internal()` (`src/common/sskr/sskr.c`) that had no
test reaching them: a multi-group shard set (distinct `group_index`
values), shards carrying different `identifier`s, and shards carrying
different `group_threshold`s. All three are already correctly rejected
with `SSKR_ERROR_INVALID_SHARD_SET` — this is coverage on already-correct
code, not a bug fix.

## Why

These are natural invariants to verify for shard-set consistency:
multiple groups, inconsistent thresholds, shards from different backups.
Grepping `tests/unit/tests/*.c` before
writing this found no existing test for any of the three. `SSKR_MAX_GROUP_COUNT`
is 1 in this port, so a second distinct `group_index` must be refused —
exactly the property an externally-sourced multi-group set needs: clean
rejection when unsupported, never corruption.

## Branch and scope

- Base SHA: `origin/bip85@77983ef`
- Target branch: `bip85`
- Devices: none (host unit tests only)
- UI stack: none touched

## Security properties

- Remote channel: none
- Host-controlled input: none (test-only change)
- Secret output: none
- NVM writes: none
- Memory-safety impact: none — no source under `src/` is modified

## Commits

1. `tests: cover the SSKR combine multi-group/identifier/threshold invariants`
   (coverage-only; no red/green split since nothing here is a bug fix)

## Verification

| Check | Command | Result |
|---|---|---|
| Unit | `cmake -B build -H. && make -C build && ctest` (ledger-app-dev-tools:latest) | 20/20 pass (excludes `test_bip85_bip39_entropy`, a pre-existing, unrelated failure on this same base — see #75) |
| ASan/UBSan | not applicable | this is a control-flow assertion test, not a memory-safety one |
| Speculos | not run | test-only change, no UI path involved |
| Hardware | not run | test-only change |
| Builds | not rebuilt (NBGL/BAGL) | no `src/` file touched |

## Before and after

Not applicable in the red/green sense — all three checks already return
`SSKR_ERROR_INVALID_SHARD_SET`; this PR only adds assertions that reach
them and check the caller-visible result (`bolos_ux_sskr_combine()`
returning 0).

## Limitations

Test-only. Does not touch `src/common/sskr/sskr.c` itself.

## Follow-up

None specific to this PR. Other shard-set invariants (zero shards,
capacity/capacity+1, duplicate shard, duplicate member index, group count
beyond `SSS_MAX_SHARE_COUNT`, interpolation/digest failure, erased output
on error) are already covered elsewhere or remain open separately — this
PR alone doesn't close out SSKR combine coverage (see companion PR for
interoperability vectors).
