### PR TITLE
bip39: make seed_rom_variables.h self-contained for the WIDE qualifier

### DIFF
--- a/src/common/bip39/seed_rom_variables.h
+++ b/src/common/bip39/seed_rom_variables.h
@@ -32,6 +32,15 @@
 
 #define BIP39_PBKDF2_ROUNDS 2048
 
+// `WIDE` is normally provided by the SDK's arch.h, pulled in transitively
+// through os.h. Host unit tests that include this header without os.h (or
+// whose own "testutils.h" include happens to come after this one) need it
+// defined too; the fallback keeps it self-contained, with the same empty
+// expansion arch.h uses. Same pattern as bip85/seed_rom_variables.h.
+#ifndef WIDE
+#define WIDE
+#endif
+
 extern unsigned char const WIDE BIP39_WORDLIST[BIP39_WORDLIST_LENGTH];
 extern unsigned short const WIDE BIP39_WORDLIST_OFFSETS[BIP39_WORDLIST_OFFSETS_LENGTH];
 extern unsigned char const WIDE BIP39_MNEMONIC[BIP39_MNEMONIC_LENGTH];


### PR DESCRIPTION
## What this changes

Makes `src/common/bip39/seed_rom_variables.h` define its own fallback for
the `WIDE` qualifier (`#ifndef WIDE / #define WIDE / #endif`), the same
pattern already applied to `src/common/bip85/seed_rom_variables.h`.

## Why

`tests/unit/tests/bip85_bip39_entropy.c` (PR #74, already merged)
includes `"bip39/common_bip39.h"` before `"testutils.h"`. `common_bip39.h`
pulls in this header, which uses `WIDE` on `BIP39_WORDLIST`/
`BIP39_WORDLIST_OFFSETS`/`BIP39_MNEMONIC` without defining it itself. `WIDE`
is only defined once `testutils.h` is reached, so with that include order
the target fails to build:

```
error: expected '=', ',', ';', 'asm' or '__attribute__' before 'BIP39_WORDLIST'
```

This is currently broken on `origin/bip85@77983ef` — `test_bip85_bip39_entropy`
does not build, and is excluded from the "N/N pass" counts in the two
companion PRs (#75, #76) opened alongside this one, both of which discovered this failure while establishing a clean test baseline for
unrelated work.

## Branch and scope

- Base SHA: `origin/bip85@77983ef`
- Target branch: `bip85`
- Devices: `flex` (NBGL), `nanox` (BAGL) — compiled and linked, unaffected
  either way since `BIP39_WORDLIST` etc. are already linked correctly in
  the real firmware build (`os.h`/`arch.h` provide `WIDE` there); this
  change only affects host-only translation units.
- UI stack: none (header-only, preprocessor fallback)

## Security properties

- Remote channel: none
- Host-controlled input: none
- Secret output: none
- NVM writes: none
- Memory-safety impact: none — adds a preprocessor macro fallback only,
  no change to any function body or data layout

## Commits

1. `bip39: make seed_rom_variables.h self-contained for the WIDE qualifier`
   (single commit; no red/green split applicable to a one-line macro guard
   in an already-broken build — the "before" state is simply "does not
   compile")

## Verification

| Check | Command | Result |
|---|---|---|
| Unit | `cmake -B build -H. && make -C build && ctest` (ledger-app-dev-tools:latest) | 20/20 pass, including `test_bip85_bip39_entropy` (previously would not build) |
| ASan/UBSan | not applicable | preprocessor-only change |
| Speculos | not run | no UI path involved |
| Hardware | not run | no UI path involved |
| Builds | `make BOLOS_SDK=$FLEX_SDK`, `make BOLOS_SDK=$NANOX_SDK` (ledger-app-builder-lite:latest) | both compile and link |

## Before and after

Before: `test_bip85_bip39_entropy` fails to compile with the error above,
on a clean `origin/bip85@77983ef` clone, independent of any other change.

After: same target builds and its 3 test vectors pass.

## Limitations

None beyond what's already scoped: this only fixes the build failure for
this one host test target. No BAGL/NBGL behavior can regress from this
change since `WIDE` already resolves correctly there via `os.h`/`arch.h`;
the fallback is dead code on those targets, mirroring the already-merged
`bip85/seed_rom_variables.h` precedent.

## Follow-up

None.
