### PR TITLE
tests: cover BIP-39 decode/encode edge cases outside BIP-85 (unknown word, bad checksum, wrong length, insufficient buffer, roundtrip)

### DIFF
--- a/tests/unit/tests/bip39.c
+++ b/tests/unit/tests/bip39.c
@@ -1,36 +1,183 @@
-#include <stdarg.h>
-#include <stdint.h>
-#include <stddef.h>
-#include <setjmp.h>
 #include <cmocka.h>
+#include <setjmp.h>
+#include <stdarg.h>
+#include <stddef.h>
+#include <stdint.h>
+#include <string.h>
 
-#include "testutils.h"
 #include "bip39/common_bip39.h"
+#include "testutils.h"
 
-const unsigned char bip39_mnemonic[] = "toe priority custom gauge jacket theme arrest bargain gloom wide ill fit eagle prepare capable fish limb cigar reform other priority speak rough imitate";
+const unsigned char bip39_mnemonic[] =
+    "toe priority custom gauge jacket theme arrest bargain gloom wide ill fit "
+    "eagle prepare capable fish limb cigar reform other priority speak rough "
+    "imitate";
 
-const unsigned char seed[] = {0x27, 0x18, 0x6B, 0x7F, 0x5A, 0xA1, 0xD6, 0xC2,
-                              0xBC, 0x81, 0xCA, 0x9A, 0xB8, 0xD4, 0x3A, 0x47,
-                              0x8F, 0xDB, 0x80, 0xD5, 0x26, 0x04, 0x9D, 0x7A,
-                              0x28, 0x09, 0x89, 0xCA, 0x02, 0xDA, 0x86, 0xA2,
-                              0xB3, 0xB2, 0x7D, 0xD0, 0x08, 0x02, 0xA5, 0xC7,
-                              0x96, 0xCA, 0x4A, 0x0E, 0x51, 0x58, 0x45, 0x66,
-                              0x7D, 0xEE, 0x32, 0xE7, 0x6A, 0xED, 0x18, 0x49,
-                              0x8D, 0xEA, 0x8A, 0x20, 0x61, 0xFA, 0x0D, 0x9A};
+const unsigned char seed[] = {
+    0x27, 0x18, 0x6B, 0x7F, 0x5A, 0xA1, 0xD6, 0xC2, 0xBC, 0x81, 0xCA,
+    0x9A, 0xB8, 0xD4, 0x3A, 0x47, 0x8F, 0xDB, 0x80, 0xD5, 0x26, 0x04,
+    0x9D, 0x7A, 0x28, 0x09, 0x89, 0xCA, 0x02, 0xDA, 0x86, 0xA2, 0xB3,
+    0xB2, 0x7D, 0xD0, 0x08, 0x02, 0xA5, 0xC7, 0x96, 0xCA, 0x4A, 0x0E,
+    0x51, 0x58, 0x45, 0x66, 0x7D, 0xEE, 0x32, 0xE7, 0x6A, 0xED, 0x18,
+    0x49, 0x8D, 0xEA, 0x8A, 0x20, 0x61, 0xFA, 0x0D, 0x9A};
 
-static void test_bip39(void **state) {
+static void test_bip39(void** state) {
     uint8_t buffer[64] = {0};
 
-    bolos_ux_bip39_mnemonic_to_seed(bip39_mnemonic,
-                                    sizeof(bip39_mnemonic) - 1,
+    bolos_ux_bip39_mnemonic_to_seed(bip39_mnemonic, sizeof(bip39_mnemonic) - 1,
                                     buffer);
 
     assert_memory_equal(buffer, seed, sizeof(seed));
 }
 
+// All twelve words exist in the wordlist; only the last word differs from
+// the valid vector (whose last word is "nose") -- the checksum byte no
+// longer matches, so decode() must reject it despite every word being
+// individually valid.
+static const unsigned char bip39_bad_checksum_mnemonic[] =
+    "girl mad pet galaxy egg matter matrix prison refuse sense ordinary "
+    "abandon";
+
+static void test_bip39_decode_bad_checksum(void** state) {
+    (void)state;
+    unsigned char bits[32 + 1];
+
+    unsigned int result = bolos_ux_bip39_mnemonic_decode(
+        bip39_bad_checksum_mnemonic, sizeof(bip39_bad_checksum_mnemonic) - 1,
+        bits, sizeof(bits));
+
+    assert_int_equal(result, 0);
+}
+
+// Same phrase as above, but the last word is replaced with a string that
+// does not appear in the BIP-39 English wordlist.
+static const unsigned char bip39_unknown_word_mnemonic[] =
+    "girl mad pet galaxy egg matter matrix prison refuse sense ordinary "
+    "notarealbip39word";
+
+static void test_bip39_decode_unknown_word(void** state) {
+    (void)state;
+    unsigned char bits[32 + 1];
+
+    unsigned int result = bolos_ux_bip39_mnemonic_decode(
+        bip39_unknown_word_mnemonic, sizeof(bip39_unknown_word_mnemonic) - 1,
+        bits, sizeof(bits));
+
+    assert_int_equal(result, 0);
+}
+
+// bolos_ux_bip39_mnemonic_decode() rejects a phrase purely on word count
+// before looking at word content, so the content here does not matter --
+// only the number of space-separated words.
+static void test_bip39_decode_wrong_length(void** state) {
+    (void)state;
+    static const unsigned int word_counts[] = {11, 13, 17, 19, 20, 23, 25};
+    unsigned char bits[32 + 1];
+    unsigned char mnemonic[9 * 25];
+
+    for (size_t i = 0; i < sizeof(word_counts) / sizeof(word_counts[0]); i++) {
+        unsigned int words = word_counts[i];
+        size_t offset = 0;
+
+        for (unsigned int w = 0; w < words; w++) {
+            memcpy(mnemonic + offset, "abandon", 7);
+            offset += 7;
+            if (w < words - 1) {
+                mnemonic[offset++] = ' ';
+            }
+        }
+
+        unsigned int result = bolos_ux_bip39_mnemonic_decode(
+            mnemonic, offset, bits, sizeof(bits));
+
+        assert_int_equal(result, 0);
+    }
+}
+
+// 16 bytes of entropy encode to a 74-character mnemonic; an output buffer of
+// 10 bytes is far too small for even the first two words, so encode() must
+// fail cleanly (return 0) instead of writing past the buffer it was given.
+static void test_bip39_encode_insufficient_buffer(void** state) {
+    (void)state;
+    static const uint8_t entropy[16] = {0x00, 0x01, 0x02, 0x03, 0x04, 0x05,
+                                        0x06, 0x07, 0x08, 0x09, 0x0a, 0x0b,
+                                        0x0c, 0x0d, 0x0e, 0x0f};
+    unsigned char out[10];
+
+    unsigned int result = bolos_ux_bip39_mnemonic_encode(
+        entropy, sizeof(entropy), out, sizeof(out));
+
+    assert_int_equal(result, 0);
+}
+
+// The three entropy/mnemonic pairs below are the same independently-verified
+// vectors already used by tests/bip85_bip39_entropy.c (12/18/24 words).
+static void run_roundtrip(const uint8_t* entropy, uint8_t entropy_len,
+                          const char* mnemonic) {
+    unsigned char encoded[256];
+    size_t mnemonic_len = strlen(mnemonic);
+
+    unsigned int encoded_len = bolos_ux_bip39_mnemonic_encode(
+        entropy, entropy_len, encoded, sizeof(encoded));
+
+    assert_int_equal(encoded_len, mnemonic_len);
+    assert_memory_equal(encoded, mnemonic, mnemonic_len);
+
+    unsigned char bits[32 + 1];
+    unsigned int decode_result = bolos_ux_bip39_mnemonic_decode(
+        (const unsigned char*)mnemonic, mnemonic_len, bits, sizeof(bits));
+
+    assert_int_equal(decode_result, 1);
+    assert_memory_equal(bits, entropy, entropy_len);
+}
+
+static void test_bip39_roundtrip_12_words(void** state) {
+    (void)state;
+    static const uint8_t entropy[16] = {0x62, 0x50, 0xb6, 0x8d, 0xaf, 0x74,
+                                        0x6d, 0x12, 0xa2, 0x4d, 0x58, 0xb4,
+                                        0x78, 0x7a, 0x71, 0x4b};
+
+    run_roundtrip(entropy, sizeof(entropy),
+                  "girl mad pet galaxy egg matter matrix prison refuse "
+                  "sense ordinary nose");
+}
+
+static void test_bip39_roundtrip_18_words(void** state) {
+    (void)state;
+    static const uint8_t entropy[24] = {
+        0x93, 0x80, 0x33, 0xed, 0x8b, 0x12, 0x69, 0x84, 0x49, 0xd4, 0xbb, 0xca,
+        0x3c, 0x85, 0x3c, 0x66, 0xb2, 0x93, 0xea, 0x1b, 0x1c, 0xe9, 0xd9, 0xdc};
+
+    run_roundtrip(entropy, sizeof(entropy),
+                  "near account window bike charge season chef number "
+                  "sketch tomorrow excuse sniff circle vital hockey "
+                  "outdoor supply token");
+}
+
+static void test_bip39_roundtrip_24_words(void** state) {
+    (void)state;
+    static const uint8_t entropy[32] = {
+        0xae, 0x13, 0x1e, 0x23, 0x12, 0xcd, 0xc6, 0x13, 0x31, 0x54, 0x2e,
+        0xfe, 0x0d, 0x10, 0x77, 0xba, 0xc5, 0xea, 0x80, 0x3a, 0xdf, 0x24,
+        0xb3, 0x13, 0xa4, 0xf0, 0xe4, 0x8e, 0x9c, 0x51, 0xf3, 0x7f};
+
+    run_roundtrip(entropy, sizeof(entropy),
+                  "puppy ocean match cereal symbol another shed magic "
+                  "wrap hammer bulb intact gadget divorce twin tonight "
+                  "reason outdoor destroy simple truth cigar social "
+                  "volcano");
+}
+
 int main(void) {
     const struct CMUnitTest tests[] = {
-        cmocka_unit_test(test_bip39)
+        cmocka_unit_test(test_bip39),
+        cmocka_unit_test(test_bip39_decode_unknown_word),
+        cmocka_unit_test(test_bip39_decode_bad_checksum),
+        cmocka_unit_test(test_bip39_decode_wrong_length),
+        cmocka_unit_test(test_bip39_encode_insufficient_buffer),
+        cmocka_unit_test(test_bip39_roundtrip_12_words),
+        cmocka_unit_test(test_bip39_roundtrip_18_words),
+        cmocka_unit_test(test_bip39_roundtrip_24_words),
     };
     return cmocka_run_group_tests(tests, NULL, NULL);
 }


### PR DESCRIPTION
## What this changes

Extends the existing `tests/unit/tests/bip39.c` (registered `test_bip39`
CMake target, no `CMakeLists.txt` change needed) with 7 new tests, on top
of the single pre-existing test:

- `test_bip39_decode_unknown_word`
- `test_bip39_decode_bad_checksum`
- `test_bip39_decode_wrong_length` (11/13/17/19/20/23/25 words)
- `test_bip39_encode_insufficient_buffer`
- `test_bip39_roundtrip_12_words` / `_18_words` / `_24_words`

## Why

`bolos_ux_bip39_mnemonic_decode()`/`_check()`/`_encode()` had no coverage
independent of the BIP-85-derived applications, which were the only
BIP-39 paths tested so far (`test_bip85_bip39_entropy`). None of these
functions are behind `HAVE_NBGL` or call `os_derive_bip32_no_throw()`, so
all of this is testable on host.

**Asymmetry noticed and deliberately not treated as a bug here**:
`bolos_ux_bip39_mnemonic_encode()` accepts 15/21-word secrets (160/224
bits), but `bolos_ux_bip39_mnemonic_decode()`/`_check()` reject them (the
word-count check only allows 12/18/24). This is not changed in this PR: a
Ledger seed is only ever generated at 12/18/24 words (128/192/256 bits,
the standard across the hardware-wallet ecosystem), and this app's own
SSKR generation path (`bolos_ux_bip39_to_sskr_convert()`,
`src/common/sskr/seed_sskr.c`) already goes through `decode()` first, which
caps the secret at 16/24/32 bytes before anything else happens. The only
lengths reachable by an actual user are 12/18/24, so this asymmetry isn't a
priority fix in this product context -- flagging it here so it isn't
mistaken for an oversight.

## Branch and scope

- Base SHA: `c94e9ba677c7d93fb4f8ade06d3873cc87c13d4b`
- Target branch: `bip85`
- Devices: none (host-only unit test)
- UI stack: none

## Security properties

- Remote channel: none
- Host-controlled input: none (fixed test vectors only)
- Secret output: none (test binary only, no device build)
- NVM writes: none
- Memory-safety impact: none (test-only addition, no `src/` file touched)

## Commits

1. Test only (pure coverage on already-correct code, no bug found -- single commit)

## Verification

| Check | Command | Result |
|---|---|---|
| Unit | `cmake -B build -H. && make -C build && cd build && CTEST_OUTPUT_ON_FAILURE=1 ctest` | pass (23/23, 8/8 within `test_bip39`) |
| Format | `clang-format --dry-run -Werror tests/unit/tests/bip39.c` | pass |
| ASan/UBSan | n/a | not applicable |
| Speculos | n/a | not run |
| Hardware | n/a | not run |
| Builds | host cmocka only | pass |

Test vectors: the bad-checksum/unknown-word phrases reuse the same 12-word
base phrase already used elsewhere in this repo's tests (only the last word
changed); the insufficient-buffer vector's 16-byte entropy and 74-character
mnemonic, and the three roundtrip vectors (12/18/24 words), are the same
independently-verified vectors already used by
`tests/bip85_bip39_entropy.c`. No new cryptographic vectors introduced.

## Before and after

Pure coverage addition on already-correct code -- no discriminating
before/after (nothing was broken). Note: this file predates clang-format
enforcement (same known v11/v21 disagreement already documented for other
test files in this project's history), so bringing the touched file into
compliance also reformatted the pre-existing `test_bip39` code already in
the file -- not a behavioral change, whitespace/wrapping only.

## Limitations

- Does not touch the encode/decode 15/21-word asymmetry (see above) --
  deliberately out of scope.
- Does not cover passphrase-related behavior (already tracked separately,
  `aido/app-seed-tool#25`).
- Does not cover comparison against the Ledger's active seed, error
  injection, or UI-level cancel/back paths -- those require Speculos or
  hardware and are tracked in the hardware campaign.

## Follow-up

None required for this PR specifically.
