### PR TITLE
common_seed: erase the input root key on every early return, not just the success path

### DIFF
--- a/src/common/common_seed.c
+++ b/src/common/common_seed.c
@@ -31,6 +31,14 @@ extern unsigned int tool_type;
 bool compare_recovery_phrase(bool* reconstructed) {
     // convert mnemonic to hex-seed
     uint8_t buffer[64];
+    bool result = false;
+
+    // declared up front so goto cleanup can reach it from every early exit
+    uint8_t buffer_device[64];
+
+    // os_derive_bip32* do not accept NULL path, even with a size of 0, so we
+    // provide an empty path
+    const unsigned int empty_path = 0;
 
     *reconstructed = true;
 
@@ -51,7 +59,7 @@ bool compare_recovery_phrase(bool* reconstructed) {
         if (G_bolos_ux_context.words_buffer_length == 0) {
             // shards accepted by the CRC check but not combinable
             *reconstructed = false;
-            return false;
+            goto cleanup;
         }
     }
 #elif defined(HAVE_NBGL)
@@ -63,7 +71,7 @@ bool compare_recovery_phrase(bool* reconstructed) {
         if (!bip39_mnemonic_from_sskr_shares(buffer)) {
             // shards accepted by the CRC check but not combinable
             *reconstructed = false;
-            return false;
+            goto cleanup;
         }
     }
 #endif
@@ -82,21 +90,17 @@ bool compare_recovery_phrase(bool* reconstructed) {
     PRINTF("Root key from input:\n%.*H\n", 64, buffer);
 
     // get rootkey from device's seed
-    uint8_t buffer_device[64];
-
-    // os_derive_bip32* do not accept NULL path, even with a size of 0, so we
-    // provide an empty path
-    const unsigned int empty_path = 0;
     if (os_derive_bip32_no_throw(CX_CURVE_256K1, &empty_path, 0, buffer_device,
                                  buffer_device + 32) != CX_OK) {
         PRINTF("An error occurred while comparing the recovery phrase\n");
-        return 0;
+        goto cleanup;
     }
     PRINTF("Root key from device: \n%.*H\n", 64, buffer_device);
 
     // compare both rootkey
-    const bool result =
-        os_secure_memcmp(buffer, buffer_device, 64) ? false : true;
+    result = os_secure_memcmp(buffer, buffer_device, 64) ? false : true;
+
+cleanup:
     memzero(buffer_device, 64);
     memzero(buffer, 64);
 


### PR DESCRIPTION
## What this changes

`compare_recovery_phrase()` (`src/common/common_seed.c`) now routes every
exit through a single `cleanup:` label instead of three bare `return`
statements that skipped the buffer erasure.

## Why

`buffer[64]` holds the HMAC-SHA512("Bitcoin seed", seed)-derived root key of
the *entered* recovery phrase from partway through the function onward. The
only `memzero(buffer, 64)` sat on the final success path. Three early exits
skipped it entirely — none of them a `LEDGER_ASSERT` (which would terminate
the app and let BOLOS clear RAM on exit), just plain `return`s that leave
the app running with the secret still on this function's stack frame:

- two "shards accepted by CRC but not combinable" checks, before the HMAC
  step (lower severity — `buffer` at that point holds a PBKDF2-over-empty-
  mnemonic artifact, not the real input, but the same fix covers them at no
  extra cost);
- the `os_derive_bip32_no_throw()` failure check, *after* the HMAC step —
  the serious one: `buffer` already holds the real derived root key of the
  user's input at that point.

Found while auditing where secret buffers are created and erased across
the codebase, looking specifically for this class of gap: an exit path
that skips erasure.

## Branch and scope

- Base SHA: `9cd2ddb3cf254f98581636c168541372ba3b65a4`
- Target branch: `bip85`
- Devices: all (BAGL and NBGL both touched, guarded by existing `#if`)
- UI stack: both `HAVE_BAGL` and `HAVE_NBGL` paths modified

## Security properties

- Remote channel: none, local recovery-phrase comparison only
- Host-controlled input: recovery phrase / SSKR shards entered on-device
- Secret output: none added or removed; fixes erasure of the HMAC-derived
  root key of the entered phrase, already present in `buffer` before this
  change
- NVM writes: none
- Memory-safety impact: none (no size/bounds change) — this is a
  data-remanence fix, not a memory-safety fix

## Commits

1. `common_seed: erase the input root key on every early return, not just
   the success path` (single commit — mechanical restructuring, see
   Verification for why no red/green split applies here)

## Verification

| Check | Command | Result |
|---|---|---|
| Unit | `cmake -B build -H. && make -C build && ctest` (ledger-app-dev-tools) | 24/24 pass, unchanged — `common_seed.c` is in no test target |
| Build BAGL | `make BOLOS_SDK=$NANOX_SDK` (ledger-app-builder-lite) | compiles and links, 0 new warnings |
| Build NBGL | `make BOLOS_SDK=$FLEX_SDK` (ledger-app-builder-lite) | compiles and links, 0 new warnings |
| Format | `clang-format --dry-run -Werror src/common/common_seed.c` (v21) | clean |
| ASan / UBSan | — | not applicable (no test target exercises this file) |
| Speculos | — | not run |
| Hardware | — | not run |

No unit test is added: `compare_recovery_phrase()`'s only non-trivial
dependency, `os_derive_bip32_no_throw()`, is a real BOLOS `SYSCALL`
(`os_derive_bip32_no_throw()` → `os_derive_bip32_with_seed_no_throw()` →
`os_perso_derive_node_bip32_seed_key()`, both `static inline` in the SDK's
`os_seed.h`, the last one a genuine syscall stub) with no host-side
implementation — confirmed by reading the SDK headers inside the
`ledger-app-dev-tools` container. Same limitation already documented for
`bolos_ux_bip85_pwd_base64()` in #70: a mechanical fix with no pure formula
to extract and test in isolation.

## Before and after

Before: `return false;` / `return false;` / `return 0;` at the three early
exits, each skipping the trailing `memzero(buffer, 64)`.

After: all three replaced with `goto cleanup;`, landing on the same
`memzero(buffer_device, 64); memzero(buffer, 64);` the success path already
used — one return statement for the whole function.

```c
bool result = false;
uint8_t buffer_device[64];          // hoisted so every goto can reach it
const unsigned int empty_path = 0;  // hoisted, same reason
...
    goto cleanup;   // instead of `return false;` / `return 0;`
...
    result = os_secure_memcmp(buffer, buffer_device, 64) ? false : true;

cleanup:
    memzero(buffer_device, 64);
    memzero(buffer, 64);
    return result;
```

## Limitations

- BAGL and NBGL paths are compile-tested only (no functional/Speculos/
  hardware run) — same limitation as most of this campaign's non-crypto
  fixes.
- Does not address the two `LEDGER_ASSERT` calls in this same function
  (HMAC init/final failure) sitting between secret creation and erasure —
  lower severity since `LEDGER_ASSERT` terminates the app and BOLOS clears
  application RAM on exit; tracked separately as a distinct, lower-priority
  finding from the same audit.
- Does not touch the raw-secret `PRINTF`s already present in this function
  (`buffer` at line ~78/90 in the pre-fix file) — a separate, larger
  finding, out of scope for this PR.

## Follow-up

No `develop` port needed (this branch targets `bip85` by policy, and this
file is common to both branches with no BIP-85-specific behavior touched).
No UX decision required. No hardware campaign required for this specific
fix — reasoning covered under Limitations.
