### PR TITLE
bip85: erase secret buffers before every LEDGER_ASSERT that could terminate the app with one still live

### DIFF
--- a/src/common/bip85/seed_bip85.c
+++ b/src/common/bip85/seed_bip85.c
@@ -233,9 +233,10 @@ bool bolos_ux_bip85_entropy(uint8_t* entropy, const unsigned int* path,
     PRINTF("Root key from device: \n%.*H\n", 32, entropy);
 
     // Generate BIP85 entropy from root key
-    LEDGER_ASSERT(
-        bip85_entropy_from_key(entropy, entropy, BIP85_ENTROPY_LENGTH),
-        "HMAC failed");
+    if (!bip85_entropy_from_key(entropy, entropy, BIP85_ENTROPY_LENGTH)) {
+        memzero(entropy, BIP85_ENTROPY_LENGTH);
+        LEDGER_ASSERT(false, "HMAC failed");
+    }
     PRINTF("BIP85 entropy from root key:\n%.*H\n", BIP85_ENTROPY_LENGTH,
            entropy);
 
@@ -292,12 +293,16 @@ void bolos_ux_bip85_drng_test(uint8_t* digest, size_t digest_length,
 
     uint8_t buffer[BIP85_ENTROPY_LENGTH];
 
-    LEDGER_ASSERT(bolos_ux_bip85_entropy(buffer, path, ARRAYLEN(path)) == 1,
-                  "BIP85 entropy failed");
+    if (bolos_ux_bip85_entropy(buffer, path, ARRAYLEN(path)) != 1) {
+        memzero(buffer, BIP85_ENTROPY_LENGTH);
+        LEDGER_ASSERT(false, "BIP85 entropy failed");
+    }
 
-    LEDGER_ASSERT(bolos_ux_bip85_drng_with_seed(buffer, BIP85_ENTROPY_LENGTH,
-                                                digest, digest_length) == 1,
-                  "BIP85 SHAKE256 hash failed");
+    if (bolos_ux_bip85_drng_with_seed(buffer, BIP85_ENTROPY_LENGTH, digest,
+                                      digest_length) != 1) {
+        memzero(buffer, BIP85_ENTROPY_LENGTH);
+        LEDGER_ASSERT(false, "BIP85 SHAKE256 hash failed");
+    }
 
     memzero(buffer, BIP85_ENTROPY_LENGTH);
 }
@@ -315,8 +320,10 @@ uint8_t bolos_ux_bip85_bip39(uint8_t* hex_out, uint8_t language, uint8_t words,
 
     uint8_t buffer[BIP85_ENTROPY_LENGTH];
 
-    LEDGER_ASSERT(bolos_ux_bip85_entropy(buffer, path, ARRAYLEN(path)) == 1,
-                  "BIP85 entropy failed");
+    if (bolos_ux_bip85_entropy(buffer, path, ARRAYLEN(path)) != 1) {
+        memzero(buffer, BIP85_ENTROPY_LENGTH);
+        LEDGER_ASSERT(false, "BIP85 entropy failed");
+    }
 
     memcpy(hex_out, buffer, words * 4 / 3);
     memzero(buffer, BIP85_ENTROPY_LENGTH);
@@ -337,8 +344,10 @@ void bolos_ux_bip85_hex(uint8_t* hex_out, uint8_t num_bytes,
 
     uint8_t buffer[BIP85_ENTROPY_LENGTH];
 
-    LEDGER_ASSERT(bolos_ux_bip85_entropy(buffer, path, ARRAYLEN(path)) == 1,
-                  "BIP85 entropy failed");
+    if (bolos_ux_bip85_entropy(buffer, path, ARRAYLEN(path)) != 1) {
+        memzero(buffer, BIP85_ENTROPY_LENGTH);
+        LEDGER_ASSERT(false, "BIP85 entropy failed");
+    }
 
     memcpy(hex_out, buffer, num_bytes);
     memzero(buffer, BIP85_ENTROPY_LENGTH);
@@ -357,14 +366,17 @@ uint8_t bolos_ux_bip85_pwd_base64(char* pwd, uint8_t pwd_len,
                                  0x80000000 | index};
     uint8_t buffer_ent[BIP85_ENTROPY_LENGTH];
 
-    LEDGER_ASSERT(bolos_ux_bip85_entropy(buffer_ent, path, ARRAYLEN(path)) == 1,
-                  "BIP85 entropy failed");
+    if (bolos_ux_bip85_entropy(buffer_ent, path, ARRAYLEN(path)) != 1) {
+        memzero(buffer_ent, BIP85_ENTROPY_LENGTH);
+        LEDGER_ASSERT(false, "BIP85 entropy failed");
+    }
 
     char buffer_pwd[BASE64_ENCODE_LENGTH];
 
-    LEDGER_ASSERT(
-        base64_encode_64bytes(buffer_ent, buffer_pwd) == BASE64_ENCODE_LENGTH,
-        "Base64 encoding failed");
+    if (base64_encode_64bytes(buffer_ent, buffer_pwd) != BASE64_ENCODE_LENGTH) {
+        memzero(buffer_ent, BIP85_ENTROPY_LENGTH);
+        LEDGER_ASSERT(false, "Base64 encoding failed");
+    }
 
     memcpy(pwd, buffer_pwd, pwd_len);
     pwd[pwd_len] = '\0';  // Add string termination character
@@ -388,14 +400,17 @@ uint8_t bolos_ux_bip85_pwd_base85(char* pwd, uint8_t pwd_len,
                                  0x80000000 | index};
     uint8_t buffer_ent[BIP85_ENTROPY_LENGTH];
 
-    LEDGER_ASSERT(bolos_ux_bip85_entropy(buffer_ent, path, ARRAYLEN(path)) == 1,
-                  "BIP85 entropy failed");
+    if (bolos_ux_bip85_entropy(buffer_ent, path, ARRAYLEN(path)) != 1) {
+        memzero(buffer_ent, BIP85_ENTROPY_LENGTH);
+        LEDGER_ASSERT(false, "BIP85 entropy failed");
+    }
 
     char buffer_pwd[BASE85_ENCODE_LENGTH];
 
-    LEDGER_ASSERT(
-        base85_encode_64bytes(buffer_ent, buffer_pwd) == BASE85_ENCODE_LENGTH,
-        "Base85 encoding failed");
+    if (base85_encode_64bytes(buffer_ent, buffer_pwd) != BASE85_ENCODE_LENGTH) {
+        memzero(buffer_ent, BIP85_ENTROPY_LENGTH);
+        LEDGER_ASSERT(false, "Base85 encoding failed");
+    }
 
     memcpy(pwd, buffer_pwd, pwd_len);
     pwd[pwd_len] = '\0';  // Add string termination character
@@ -422,8 +437,10 @@ int32_t bolos_ux_bip85_dice(uint32_t* out, size_t out_capacity, uint32_t sides,
 
     uint8_t buffer_ent[BIP85_ENTROPY_LENGTH];
 
-    LEDGER_ASSERT(bolos_ux_bip85_entropy(buffer_ent, path, ARRAYLEN(path)) == 1,
-                  "BIP85 entropy failed");
+    if (bolos_ux_bip85_entropy(buffer_ent, path, ARRAYLEN(path)) != 1) {
+        memzero(buffer_ent, BIP85_ENTROPY_LENGTH);
+        LEDGER_ASSERT(false, "BIP85 entropy failed");
+    }
 
     int32_t produced =
         bip85_dice_roll(out, out_capacity, sides, rolls, buffer_ent);


### PR DESCRIPTION
## What this changes

In `src/common/bip85/seed_bip85.c`, every `LEDGER_ASSERT(cond, msg)` that
sits between a secret being written into a local buffer and that buffer
being erased is now preceded by an explicit erase on the failure path:

```c
LEDGER_ASSERT(cond, "msg");
```
becomes
```c
if (!(cond)) {
    memzero(buffer, len);
    LEDGER_ASSERT(false, "msg");
}
```

Same termination behavior and message on failure — the app still halts
immediately — the only difference is the buffer is explicitly zeroed right
before that happens.

## Why

`LEDGER_ASSERT` terminates the app immediately if its condition is false,
skipping any code — including `memzero()` — that comes after it in the
function. Several functions in this file run a secret (the device root
key or BIP-85 entropy, 32 or 64 bytes) through a local buffer and then
call an operation guarded by `LEDGER_ASSERT` before reaching that
`memzero()`.

Severity is low: BOLOS clears application RAM when the app terminates, so
this isn't an exploitable leak by itself. But relying only on that global
wipe means there's no defense in depth if that assumption ever turns out
to be wrong on some target, so it's worth closing explicitly, same
reasoning as #80 (`compare_recovery_phrase()` cleanup in
`common_seed.c`).

Ten sites are affected, not just the three obvious ones I initially
flagged: the HMAC assert in `bolos_ux_bip85_entropy()`, and the
Base64/Base85 encoding asserts in the two password functions, all clearly
hold a live secret. But every function that calls
`bolos_ux_bip85_entropy()` (`drng_test`, `bip39`, `hex`, both password
encoders, `dice`) repeats the identical
`LEDGER_ASSERT(bolos_ux_bip85_entropy(buffer, ...) == 1, "BIP85 entropy
failed")` pattern — seven more sites where the buffer's exact content on
that failure path isn't fully determined (the underlying BIP32 derivation
syscall may or may not have written into it before failing), but is never
provably empty either. All ten are fixed the same way rather than trying
to reason case-by-case about which ones definitely still hold a secret.

Plain parameter-bounds checks (`sides`/`rolls` in `bolos_ux_bip85_dice()`,
`words` in `bolos_ux_bip85_bip39()`, `pwd_len` in both password functions,
`num_bytes` in `bolos_ux_bip85_hex()`) are untouched — they validate input
before any secret exists, so there's nothing for them to protect.

## Branch and scope

- Base SHA: `3918c48ad8f4a07a99284ee728f385ed4fa7b520`
- Target branch: `bip85`
- Devices: NBGL only (`stax`/`flex`/`apex`) — this part of BIP-85 lives
  entirely inside a single `#if defined(HAVE_NBGL)` block with no BAGL
  counterpart
- UI stack: NBGL

## Security properties

- Remote channel: none, local BIP-85 derivation only
- Host-controlled input: none beyond existing on-device parameters
  (index, length, language, dice sides/rolls) already validated elsewhere
  in this file
- Secret output: none added or removed — fixes erasure of already-present
  secret buffers on ten specific failure paths
- NVM writes: none
- Memory-safety impact: none (no size/bounds change) — this is a
  data-remanence hardening fix, not a memory-safety fix

## Commits

1. `bip85: erase secret buffers before every LEDGER_ASSERT that could
   terminate the app with one still live` (single commit — same
   mechanical pattern repeated ten times, no red/green split applies, see
   Verification)

## Verification

| Check | Command | Result |
|---|---|---|
| Format | `clang-format --dry-run -Werror src/common/bip85/seed_bip85.c` (v21) | clean |
| Build NBGL | `make BOLOS_SDK=$FLEX_SDK` (ledger-app-builder-lite) | compiles and links, 0 warnings/errors, "Using NBGL" confirmed |
| Unit | `cmake -B build -H. && make -C build && ctest` (ledger-app-dev-tools) | 24/24 pass, including the three targets that compile this file in full (`test_bip85_dice_bits_per_roll`, `test_bip85_dice_roll`, `test_bip85_bip39_entropy`) |
| ASan / UBSan | — | not applicable (no test target exercises the ten changed lines — see Limitations) |
| Speculos | — | not run |
| Hardware | — | not run |

No unit test is added for the fix itself: every affected function
ultimately calls `os_derive_bip32_no_throw()`, a real BOLOS `SYSCALL` with
no host-side implementation, same limitation already documented on #70
and #80 — a mechanical fix with no pure formula to extract and test in
isolation.

## Before and after

Before, e.g. in `bolos_ux_bip85_entropy()`:
```c
LEDGER_ASSERT(
    bip85_entropy_from_key(entropy, entropy, BIP85_ENTROPY_LENGTH),
    "HMAC failed");
```

After:
```c
if (!bip85_entropy_from_key(entropy, entropy, BIP85_ENTROPY_LENGTH)) {
    memzero(entropy, BIP85_ENTROPY_LENGTH);
    LEDGER_ASSERT(false, "HMAC failed");
}
```

Same pattern applied to the other nine sites (`bolos_ux_bip85_drng_test()`
×2, `bolos_ux_bip85_bip39()`, `bolos_ux_bip85_hex()`,
`bolos_ux_bip85_pwd_base64()` ×2, `bolos_ux_bip85_pwd_base85()` ×2,
`bolos_ux_bip85_dice()`).

## Limitations

- No functional/Speculos/hardware run demonstrating the erase actually
  happens on a real failure — these `LEDGER_ASSERT` conditions are not
  independently triggerable from the host, and are only compile/link
  verified here.
- Does not address the raw-secret `PRINTF` calls already present in this
  same file (e.g. root key and entropy dumped to the debug log) — a
  separate, larger, cross-file finding, out of scope for this PR.
- Does not touch `bolos_ux_bip85_dice()` beyond its entropy-derivation
  assert — the rest of that function already returns a signed error code
  rather than asserting.

## Follow-up

No `develop` port needed (BIP-85-only code, this branch targets `bip85`
by policy). No UX decision required. No hardware campaign required for
this specific fix — see Limitations.