### PR TITLE
debug: redact secret content from PRINTF trace statements

### DIFF
--- a/src/common/bip39/seed_bip39.c
+++ b/src/common/bip39/seed_bip39.c
@@ -46,7 +46,7 @@ void bolos_ux_bip39_mnemonic_to_seed(unsigned char* mnemonic,
     cx_pbkdf2_sha512(mnemonic_hash, mnemonic_length, passphrase,
                      BIP39_MNEMONIC_LENGTH, BIP39_PBKDF2_ROUNDS, seed, 64);
     memzero(mnemonic_hash, sizeof(mnemonic_hash));
-    PRINTF("BIP39 seed:\n %.*H\n", 64, seed);
+    PRINTF("BIP39 seed computed: 64 bytes\n");
 }
 
 unsigned int bolos_ux_bip39_mnemonic_decode(unsigned char* mnemonic,
@@ -58,7 +58,7 @@ unsigned int bolos_ux_bip39_mnemonic_decode(unsigned char* mnemonic,
     unsigned char buffer[32];
     unsigned char mask;
 
-    PRINTF("BIP39 mnemonic phrase:\n %.*s\n", mnemonic_length, mnemonic);
+    PRINTF("BIP39 mnemonic phrase: %u characters\n", mnemonic_length);
 
     for (i = 0; i < mnemonic_length; i++) {
         if (mnemonic[i] == ' ') {
@@ -136,7 +136,7 @@ unsigned int bolos_ux_bip39_mnemonic_decode(unsigned char* mnemonic,
     }
 
     // alright mnemonic is ok
-    PRINTF("BIP39 mnemonic decoded in hex:\n %.*H\n", bitslength, bits);
+    PRINTF("BIP39 mnemonic decoded: %u bytes\n", bitslength);
     return 1;
 }
 
@@ -183,7 +183,7 @@ unsigned int bolos_ux_bip39_mnemonic_encode(const uint8_t* seed,
     }
     memzero(bits, sizeof(bits));
 
-    PRINTF("BIP39 encoded mnemonic:\n %.*s\n", offset, out);
+    PRINTF("BIP39 mnemonic encoded: %u characters\n", offset);
     return offset;
 }
 
@@ -311,13 +311,13 @@ size_t bolos_ux_bip39_fill_with_candidates(const unsigned char* startingChars,
                                            const size_t startingCharsLength,
                                            char wordCandidatesBuffer[],
                                            const char* wordIndexorBuffer[]) {
-    PRINTF("Calculating nb of words starting with '%s' (size is '%d')\n",
-           startingChars, startingCharsLength);
+    PRINTF("Calculating nb of words starting with a %u-character prefix\n",
+           startingCharsLength);
     const size_t nbMatchingWords =
         MIN(bolos_ux_bip39_get_word_count_starting_with(startingChars,
                                                         startingCharsLength),
             NB_MAX_SUGGESTION_BUTTONS);
-    PRINTF("'%d' words start with '%s'\n", nbMatchingWords, startingChars);
+    PRINTF("'%d' words start with the given prefix\n", nbMatchingWords);
     if (nbMatchingWords == 0) {
         return 0;
     }
@@ -342,12 +342,13 @@ uint32_t bolos_ux_bip39_get_keyboard_mask(const unsigned char* prefix,
     uint32_t existing_mask =
         1 << 28;  // Starting with the 'return' keypad activated
     unsigned char next_letters[ALPHABET_LENGTH] = {0};
-    PRINTF("Looking for letter candidates following '%s'\n", prefix);
+    PRINTF("Looking for letter candidates following a %u-character prefix\n",
+           prefixLength);
     const size_t nb_letters =
         bolos_ux_bip39_get_word_next_letters_starting_with(prefix, prefixLength,
                                                            next_letters);
     next_letters[nb_letters] = '\0';
-    PRINTF("Next letters are in: %s\n", next_letters);
+    PRINTF("Found %u next-letter candidates\n", nb_letters);
     for (int i = 0; i < ALPHABET_LENGTH; i++) {
         for (size_t j = 0; j < nb_letters; j++) {
             if (KBD_LETTERS[i] == next_letters[j]) {

--- a/src/common/bip85/seed_bip85.c
+++ b/src/common/bip85/seed_bip85.c
@@ -230,15 +230,14 @@ bool bolos_ux_bip85_entropy(uint8_t* entropy, const unsigned int* path,
         PRINTF("An error occurred while generating BIP85 entropy\n");
         return 0;
     }
-    PRINTF("Root key from device: \n%.*H\n", 32, entropy);
+    PRINTF("Root key from device: 32 bytes\n");
 
     // Generate BIP85 entropy from root key
     if (!bip85_entropy_from_key(entropy, entropy, BIP85_ENTROPY_LENGTH)) {
         memzero(entropy, BIP85_ENTROPY_LENGTH);
         LEDGER_ASSERT(false, "HMAC failed");
     }
-    PRINTF("BIP85 entropy from root key:\n%.*H\n", BIP85_ENTROPY_LENGTH,
-           entropy);
+    PRINTF("BIP85 entropy from root key: %u bytes\n", BIP85_ENTROPY_LENGTH);
 
     return 1;
 }
@@ -265,7 +264,7 @@ bool bolos_ux_bip85_drng_with_seed(uint8_t* seed, size_t seed_length,
         PRINTF("SHAKE256 hash error\n");
         return 0;
     }
-    PRINTF("BIP85 DRNG output:\n%.*H\n", digest_length, digest);
+    PRINTF("BIP85 DRNG output: %u bytes\n", digest_length);
 
     return 1;
 }
@@ -328,7 +327,7 @@ uint8_t bolos_ux_bip85_bip39(uint8_t* hex_out, uint8_t language, uint8_t words,
     memcpy(hex_out, buffer, words * 4 / 3);
     memzero(buffer, BIP85_ENTROPY_LENGTH);
 
-    PRINTF("BIP85 BIP39 hex output:\n%.*H\n", words * 4 / 3, hex_out);
+    PRINTF("BIP85 BIP39 hex output: %u bytes\n", words * 4 / 3);
     return words * 4 / 3;
 }
 
@@ -352,7 +351,7 @@ void bolos_ux_bip85_hex(uint8_t* hex_out, uint8_t num_bytes,
     memcpy(hex_out, buffer, num_bytes);
     memzero(buffer, BIP85_ENTROPY_LENGTH);
 
-    PRINTF("BIP85 HEX output:\n%.*H\n", num_bytes, hex_out);
+    PRINTF("BIP85 HEX output: %u bytes\n", num_bytes);
 }
 
 uint8_t bolos_ux_bip85_pwd_base64(char* pwd, uint8_t pwd_len,
@@ -384,7 +383,7 @@ uint8_t bolos_ux_bip85_pwd_base64(char* pwd, uint8_t pwd_len,
     memzero(buffer_ent, BIP85_ENTROPY_LENGTH);
     memzero(buffer_pwd, BASE64_ENCODE_LENGTH);
 
-    PRINTF("BIP85 PWD BASE64 output: %s\n", pwd);
+    PRINTF("BIP85 PWD BASE64 output: %u characters\n", pwd_len);
 
     return pwd_len;
 }
@@ -418,7 +417,7 @@ uint8_t bolos_ux_bip85_pwd_base85(char* pwd, uint8_t pwd_len,
     memzero(buffer_ent, BIP85_ENTROPY_LENGTH);
     memzero(buffer_pwd, BASE85_ENCODE_LENGTH);
 
-    PRINTF("BIP85 PWD BASE85 output: %s\n", pwd);
+    PRINTF("BIP85 PWD BASE85 output: %u characters\n", pwd_len);
 
     return pwd_len;
 }

--- a/src/common/common_seed.c
+++ b/src/common/common_seed.c
@@ -75,7 +75,7 @@ bool compare_recovery_phrase(bool* reconstructed) {
         }
     }
 #endif
-    PRINTF("Input seed:\n %.*H\n", 64, buffer);
+    PRINTF("Input seed: 64 bytes\n");
 
     // get rootkey from hex-seed
     cx_hmac_sha512_t ctx;
@@ -87,7 +87,7 @@ bool compare_recovery_phrase(bool* reconstructed) {
     LEDGER_ASSERT(cx_hmac_no_throw((cx_hmac_t*)&ctx, CX_LAST, buffer, 64,
                                    buffer, 64) == CX_OK,
                   "HMAC failed");
-    PRINTF("Root key from input:\n%.*H\n", 64, buffer);
+    PRINTF("Root key from input: 64 bytes\n");
 
     // get rootkey from device's seed
     if (os_derive_bip32_no_throw(CX_CURVE_256K1, &empty_path, 0, buffer_device,
@@ -95,7 +95,7 @@ bool compare_recovery_phrase(bool* reconstructed) {
         PRINTF("An error occurred while comparing the recovery phrase\n");
         goto cleanup;
     }
-    PRINTF("Root key from device: \n%.*H\n", 64, buffer_device);
+    PRINTF("Root key from device: 64 bytes\n");
 
     // compare both rootkey
     result = os_secure_memcmp(buffer, buffer_device, 64) ? false : true;

--- a/src/common/sskr/seed_sskr.c
+++ b/src/common/sskr/seed_sskr.c
@@ -96,7 +96,7 @@ unsigned int bolos_ux_sskr_combine(unsigned char* sskr_shares_hex,
         return 0;
     }
 
-    PRINTF("SSKR decoded shares:\n %.*H\n", output_len, output);
+    PRINTF("SSKR decoded shares: %d bytes\n", output_len);
     return (unsigned int)output_len;
 }
 
@@ -106,8 +106,7 @@ void bolos_ux_sskr_to_seed_convert(unsigned char* sskr_shares_hex,
                                    unsigned char* words_buffer,
                                    unsigned int* words_buffer_length,
                                    unsigned char* seed) {
-    PRINTF("SSKR share in hex:\n %.*H\n", sskr_shares_hex_length,
-           sskr_shares_hex);
+    PRINTF("SSKR share in hex: %u bytes\n", sskr_shares_hex_length);
 
     uint8_t seed_buffer[SSKR_MAX_STRENGTH_BYTES] = {0};
     uint8_t seed_buffer_len =
@@ -142,7 +141,7 @@ unsigned int bolos_ux_sskr_generate(uint8_t groups_threshold,
         return 0;
     }
 
-    PRINTF("SSKR generate input:\n %.*H\n", seed_len, seed);
+    PRINTF("SSKR generate input: %u bytes\n", seed_len);
     // convert seed to SSKR shares
     int16_t share_count = sskr_generate_shards(
         groups_threshold, groups, groups_len, seed, seed_len, share_len,
@@ -159,7 +158,7 @@ unsigned int bolos_ux_sskr_generate(uint8_t groups_threshold,
         return 0;
     }
 
-    PRINTF("SSKR generate output:\n %.*H\n", share_buffer_len, share_buffer);
+    PRINTF("SSKR generate output: %u bytes\n", share_buffer_len);
 
     return share_count;
 }
@@ -185,7 +184,7 @@ unsigned int bolos_ux_sskr_share_hex_decode(unsigned char* input,
             output[position++] = ' ';
         }
     }
-    PRINTF("SSKR share:\n %.*s\n", output_len, output);
+    PRINTF("SSKR share: %u bytes\n", output_len);
     return position;
 }
 
@@ -434,13 +433,13 @@ size_t bolos_ux_sskr_fill_with_candidates(const unsigned char* startingChars,
                                           const size_t startingCharsLength,
                                           char wordCandidatesBuffer[],
                                           const char* wordIndexorBuffer[]) {
-    PRINTF("Calculating nb of words starting with '%s' (size is '%d')\n",
-           startingChars, startingCharsLength);
+    PRINTF("Calculating nb of words starting with a %u-character prefix\n",
+           startingCharsLength);
     const size_t nbMatchingWords =
         MIN(bolos_ux_sskr_get_word_count_starting_with(startingChars,
                                                        startingCharsLength),
             NB_MAX_SUGGESTION_BUTTONS);
-    PRINTF("'%d' words start with '%s'\n", nbMatchingWords, startingChars);
+    PRINTF("'%d' words start with the given prefix\n", nbMatchingWords);
     if (nbMatchingWords == 0) {
         return 0;
     }
@@ -465,11 +464,12 @@ uint32_t bolos_ux_sskr_get_keyboard_mask(const unsigned char* prefix,
     uint32_t existing_mask =
         1 << 28;  // Starting with the 'return' keypad activated
     unsigned char next_letters[ALPHABET_LENGTH] = {0};
-    PRINTF("Looking for letter candidates following '%s'\n", prefix);
+    PRINTF("Looking for letter candidates following a %u-character prefix\n",
+           prefixLength);
     const size_t nb_letters = bolos_ux_sskr_get_word_next_letters_starting_with(
         prefix, prefixLength, next_letters);
     next_letters[nb_letters] = '\0';
-    PRINTF("Next letters are in: %s\n", next_letters);
+    PRINTF("Found %u next-letter candidates\n", nb_letters);
     for (int i = 0; i < ALPHABET_LENGTH; i++) {
         for (size_t j = 0; j < nb_letters; j++) {
             if (KBD_LETTERS[i] == next_letters[j]) {

--- a/src/nbgl/bip39_mnemonic.c
+++ b/src/nbgl/bip39_mnemonic.c
@@ -98,7 +98,7 @@ size_t bip39_mnemonic_word_add(const char* const buffer, const size_t size) {
     mnemonic.word_lengths[mnemonic.current_word_index] = size;
     PRINTF("Number of words in the mnemonic: '%d'\n",
            bip39_mnemonic_current_word_number_get());
-    PRINTF("Current mnemonic: '%s'\n", &mnemonic.buffer[0]);
+    PRINTF("Current mnemonic length: %zu characters\n", mnemonic.length);
     return bip39_mnemonic_current_word_number_get();
 }
 
@@ -113,8 +113,7 @@ bool bip39_mnemonic_check(bool* match) {
     if (!bip39_mnemonic_complete_check()) {
         return false;
     }
-    PRINTF("Checking the following mnemonic: '%s' (size %d)\n",
-           &mnemonic.buffer[0], mnemonic.length);
+    PRINTF("Checking the mnemonic: %zu characters\n", mnemonic.length);
 
     if (bolos_ux_bip39_mnemonic_check((unsigned char*)&mnemonic.buffer[0],
                                       mnemonic.length) == false) {
@@ -140,7 +139,7 @@ bool bip39_mnemonic_from_sskr_shares(unsigned char* seed) {
         &mnemonic.length, seed);
 
     if (mnemonic.length > 0) {
-        PRINTF("BIP39 mnemonic: %.*s\n", mnemonic.length, bip39_mnemonic_get());
+        PRINTF("BIP39 mnemonic: %zu characters\n", mnemonic.length);
     }
 
     // a zero length means the shards could not be combined
@@ -154,7 +153,7 @@ void bip39_mnemonic_encode(const uint8_t* seed, uint8_t seed_len) {
         BIP39_MNEMONIC_MAX_LENGTH);
 
     if (mnemonic.length > 0) {
-        PRINTF("BIP39 mnemonic: %.*s\n", mnemonic.length, bip39_mnemonic_get());
+        PRINTF("BIP39 mnemonic: %zu characters\n", mnemonic.length);
     }
 }
 

--- a/src/nbgl/sskr_shares.c
+++ b/src/nbgl/sskr_shares.c
@@ -146,7 +146,7 @@ size_t sskr_shares_word_add(const char* const byteword) {
 
     PRINTF("Current number of words in the share: '%d'\n",
            sskr_shares_current_word_number_get());
-    PRINTF("Current shares buffer: '%.*H'\n", shares.length, &shares.buffer[0]);
+    PRINTF("Current shares buffer length: %zu bytes\n", shares.length);
 
     return sskr_shares_current_word_number_get();
 }
@@ -186,8 +186,7 @@ void sskr_shares_from_bip39_mnemonic(void) {
         PRINTF("SSKR share buffer length is %d\n", shares.length);
         for (uint8_t share = 0; share < shares.count; share++) {
             PRINTF("SSKR share %d:\n", share + 1);
-            PRINTF("%.*s\n", shares.length / shares.count,
-                   shares.buffer + share * shares.length / shares.count);
+            PRINTF("(%zu bytes)\n", shares.length / shares.count);
         }
     }
 }
@@ -215,8 +214,7 @@ bool sskr_shares_check(bool* match) {
         return false;
     }
 
-    PRINTF("Checking the following shares: '%.*H' (size %d)\n", shares.length,
-           &shares.buffer[0], shares.length);
+    PRINTF("Checking the shares buffer: %zu bytes\n", shares.length);
 
     if (bolos_ux_sskr_hex_check((unsigned char*)sskr_shares_get(),
                                 sskr_shares_length_get(),


### PR DESCRIPTION
Several `PRINTF()` calls in the BIP-39/BIP-85/SSKR seed-recovery paths log the raw content of secret material: the input seed, HMAC-derived root keys (from both the entered recovery phrase and the device), BIP-85 entropy and DRNG output, generated/decoded mnemonics, generated passwords (Base64/Base85), SSKR shares (hex and raw), and the letter-by-letter prefix typed into the on-screen keyboard during BIP-39/SSKR autocomplete.

`PRINTF` compiles to nothing (`#define PRINTF(...)`) unless `HAVE_PRINTF` is set, so none of this reaches a release build. The residual risk is narrow — a debug build running against a real user secret, observed on the USB/screen output channel at that exact moment — but logging raw secret material even under a debug flag is a defense-in-depth gap this app shouldn't have, however narrow the window.

Rather than deleting these lines, each is truncated to a non-sensitive metric already available at the call site (byte count, character count, or word count) instead of the secret content. This keeps almost all of the original debugging value — you can still see that a step ran, and with what size — while making it structurally impossible to print the secret, even in a debug build.

34 sites across six files, one mechanical pattern:
- `src/common/common_seed.c`
- `src/common/bip39/seed_bip39.c`
- `src/common/bip85/seed_bip85.c`
- `src/common/sskr/seed_sskr.c`
- `src/nbgl/bip39_mnemonic.c`
- `src/nbgl/sskr_shares.c`

## Test plan

No unit test: pure logging change with no behavior to verify red/green.

- [x] `clang-format --dry-run -Werror` on all 6 touched files: clean (no new violations)
- [x] NBGL (`flex`) build: clean, zero warnings
- [x] BAGL (`nanox`) build: clean, zero warnings
- [x] cmocka unit suite: 24/24 passing