### PR TITLE
tests: add a Speculos-based check for BIP39 mnemonic buffer clearing on cancel

### DIFF
--- a/tests/speculos/README.md
+++ b/tests/speculos/README.md
@@ -1,0 +1,189 @@
+# Speculos-based regression checks
+
+Manual, first-of-its-kind checks that run the real app under Speculos and
+inspect its actual RAM over a GDB connection, rather than reading source
+code and hoping. `tests/functional/` (Ragger/pytest) already covers "does
+the right thing show on screen" — this directory is for a different
+question: "is a secret still sitting in memory after the user backed out?"
+
+Not wired into CI or the cmocka harness. Run by hand when touching secret
+buffer lifecycle code in the NBGL UI layer.
+
+## Contents
+
+- `rsp_client.py` — a ~100-line GDB Remote Serial Protocol client (stdlib
+  only, no real `gdb` binary needed).
+- `verify_bip39_cancel_clears_buffer.py` — the check itself.
+
+## Prerequisites
+
+1. Docker, with network access to `ghcr.io`.
+2. The `flex` build, already compiled:
+
+   ```bash
+   docker run --rm -v "$(pwd)":/app \
+     ghcr.io/ledgerhq/ledger-app-builder/ledger-app-builder-lite:latest \
+     bash -c 'BOLOS_SDK=/opt/flex-secure-sdk make -j4'
+   ```
+
+## Running
+
+```bash
+python3 tests/speculos/verify_bip39_cancel_clears_buffer.py
+```
+
+Takes a few minutes (see "Why is this so slow" below). Prints a snapshot
+table and a `PASS`/`FAIL` line, exits 1 on failure. The script starts and
+always tears down its own Speculos container (`speculos-bip39-cancel-test`)
+— safe to re-run, and safe to Ctrl-C (though a stray container may need
+`docker rm -f speculos-bip39-cancel-test` after a hard interrupt).
+
+## What it checks
+
+"Check BIP39" screen, flex layout: type a word, confirm it (so it lands in
+the real `mnemonic` buffer, `src/nbgl/bip39_mnemonic.c`), start a second
+word without confirming it, then cancel (back button) before finishing.
+Reads raw memory before and after to confirm the confirmed word doesn't
+survive the cancel.
+
+**This exercises `bip39_mnemonic_word_remove()` /
+`bip39_mnemonic_shrink()`, not `bip39_mnemonic_reset()`.** Worth spelling
+out because it wasn't the initial assumption: reading `ui.c`
+(`bip39_keyboard_dispatcher`), the back button calls
+`bip39_mnemonic_word_remove()`, which internally calls
+`bip39_mnemonic_shrink()` — *that's* what actually does the
+`memzero()` for a real "typed a word, changed my mind" cancel.
+`bip39_mnemonic_reset()` is only invoked when backing out of the *first*
+word (nothing confirmed yet), to leave the screen entirely — a real call,
+confirmed by this script too, but by construction the buffer is already
+empty by the time it runs (shrink already cleared it on the way there), so
+on its own it doesn't prove much. Both are exercised here; neither showed
+a problem.
+
+The check on "after" content is a byte-string containment check for the
+typed word (`b"abandon" not in after`), **not** "the whole struct reads as
+zero". `mnemonic.current_word_index` is deliberately left at its
+`(size_t)-1` "no word" sentinel by `shrink()` — legitimate bookkeeping, not
+a leak. Checking for an all-zero struct would be the wrong invariant and
+would (did, in an earlier version of this script) produce a false FAIL.
+
+## What you'd see on a real failure
+
+The typed word's bytes turning up in the "after" snapshot, e.g.:
+
+```
+FAIL: 'abandon' is still present in the mnemonic buffer after cancelling -- typed content was not cleared:
+  6162616e646f6e00...
+```
+
+That's a real bug (secret residue in RAM after the user cancelled) — not
+an infrastructure problem. Don't dismiss it as flakiness; the memory read
+happens synchronously at a breakpoint, there's no timing race to blame.
+
+## Gotchas this script works around
+
+None of this was documented anywhere before this script existed; recorded
+here so the next person (or the next scenario) doesn't have to
+rediscover it the hard way.
+
+### 1. The published Speculos debug image is broken, and the fix isn't "done" once
+
+`ghcr.io/ledgerhq/speculos:latest`'s `-d` (debug/GDB) mode passes
+`-singlestep` to `qemu-arm-static`, an option removed from the bundled
+QEMU (10.0.8; confirmed via `qemu-arm -help`, no `singlestep` option
+listed). The script extracts `main.py` from the image at run time and
+replaces `-singlestep` with `-one-insn-per-tb` (the modern equivalent) —
+see `prepare_patched_speculos_main()`. This alone gets you a working GDB
+port, but is *not* sufficient to keep the app usable while attached — see
+next point.
+
+### 2. A live GDB connection freezes the app solid, unless you tell it to ignore SIGILL
+
+This app's BOLOS syscall trampolines (crypto, display, timing — anything
+that becomes a real `SVC` on hardware) are implemented, under Speculos, as
+deliberately illegal Thumb instructions that trap with `SIGILL`; the
+launcher's own signal handler normally catches these and emulates the
+syscall. The moment *any* GDB client is attached, QEMU's gdbstub reports
+every single one of these traps as a stop instead of letting the launcher
+handle it — and with a plain `continue` that's never told otherwise, the
+target just sits there at the very first syscall of boot, forever. Screen
+never renders, taps never register, no error, no timeout — it just never
+makes progress. (Confirmed by explicitly closing the GDB socket mid-flight
+and watching the exact same target immediately boot and render normally —
+this really is about the connection being open, not slowness.)
+
+Fix: every "continue" is a *redeliver-the-signal* continue
+(`Cxx`, `RSP.cont_with_signal(4)`), which is what a real interactive
+`gdb` session would do too after `handle SIGILL nostop noprint pass`. A
+background thread does this in a loop so the main script can drive the
+touch UI while it's running. Expect **thousands** of these per screen
+interaction (`_pump()` round-trips through Python for every one) — this is
+also why a run takes a few minutes instead of a few seconds. There's no
+known way to avoid this overhead with this Speculos build; budget for it,
+don't try to shrink the scenario to compensate.
+
+### 3. Async Ctrl-C interrupts are not reliable here; breakpoints are
+
+An earlier version of this script tried to grab a memory snapshot "at the
+right moment" by sending the RSP interrupt byte (`\x03`) whenever the
+navigation script decided the timing was right (e.g. right before pressing
+"back"). This didn't work reliably: the app spends most of its idle time
+blocked in a genuine host-level blocking syscall (waiting for the next
+touch event), and the interrupt byte only got noticed once *something*
+woke the CPU dispatch loop back up — not on any predictable schedule.
+
+What works: software breakpoints (`Z0`/`z0`) on the three functions of
+interest, hit synchronously by the CPU itself the moment it actually
+executes that code — no timing assumption needed. `MemorySampler` also
+sets a temporary breakpoint at the return address (from `LR`) so it can
+snapshot memory both at entry (secret still present) and after return
+(should be cleared), the RSP-level equivalent of gdb's `finish`.
+
+### 4. The app's global variables are not at their linked address at runtime
+
+The obvious approach — take the `mnemonic` symbol's address from
+`nm` (`0xda7a0004` at the time of writing) and read that address over
+GDB — silently returns all-zero garbage. Not an error, just the wrong
+memory, which is worse (it looks like a false "PASS" for the buffer being
+cleared, when really you're reading memory nothing ever touches).
+
+The code is compiled position-independent; globals are addressed
+`R9`-relative, not via their linked address. Disassembly of
+`bip39_mnemonic_reset()` makes this explicit:
+
+```
+ldr   r0, [pc, #24]     ; r0 = 4  (this word: mnemonic's offset in .bss)
+add.w r4, r9, r0        ; r4 = &mnemonic = R9 + 4
+```
+
+So the real address is `R9 + (link_addr_of_mnemonic - link_addr_of_.bss)`,
+with `R9` read live from the running target (`RSP.read_regs()[9]`) —
+never computed from `/proc/<pid>/maps` or any other static guess. Code
+addresses (for breakpoints) are a separate, simpler story: the linked code
+base (`0xC0DE0000` for this SDK's flex scatter-loading) maps 1:1-offset to
+`0x40000000` at runtime — confirmed by successfully hitting breakpoints
+placed with that translation, and stable across every container restart
+observed. `code_runtime_addr()` in the script does this translation; the
+script never hardcodes an actual breakpoint address, only the two base
+constants, and resolves everything else from `nm`/`readelf` against
+whatever `app.elf` was actually built.
+
+## Adapting to stax/apex or another scenario
+
+The touch coordinates in `navigate_and_cancel()` are flex-only
+(480×600). `tests/functional/keypad.py` and `genericlayout.py` have the
+equivalent stax/apex positions if this needs extending — note those are
+Ragger-side helpers and aren't reused here directly, since this script
+doesn't go through Ragger at all (see the top-level project notes on why:
+the GDB/breakpoint machinery has nothing to do with Ragger's
+navigator/backend layer, and mixing the two adds coupling for no benefit
+in a single-scenario script like this one).
+
+`rsp_client.py` and the `MemorySampler` breakpoint-snapshot pattern in
+`verify_bip39_cancel_clears_buffer.py` are generic — reusable for other
+secret-buffer-lifecycle scenarios (SSKR shares, BIP-85 passwords, the
+stack-based `buffer[64]` in `compare_recovery_phrase()`, etc.) without
+needing to re-solve any of the four gotchas above. A stack buffer would
+need one more thing this script didn't: its address changes per call, so
+you'd resolve it the same way as `mnemonic` (register-relative, likely SP-
+or frame-pointer-relative) rather than reading a fixed offset once.

--- a/tests/speculos/rsp_client.py
+++ b/tests/speculos/rsp_client.py
@@ -1,0 +1,102 @@
+"""Minimal GDB Remote Serial Protocol (RSP) client.
+
+Talks directly to the gdbstub speculos/QEMU exposes on the debug port
+(``-d``, port 1234), without depending on a real ``gdb`` binary. Stdlib only.
+
+Only implements what verify_bip39_cancel_clears_buffer.py needs: resume
+execution, insert/remove a software breakpoint, single-step, read general
+registers, read memory, and redeliver a signal (used to pass SIGILL through
+-- see the README in this directory for why that's required).
+"""
+import socket
+
+
+class RSP:
+    def __init__(self, host="localhost", port=1234, timeout=40):
+        self.s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+        self.s.settimeout(timeout)
+        self.s.connect((host, port))
+
+    def _checksum(self, data: bytes) -> bytes:
+        return ("%02x" % (sum(data) % 256)).encode()
+
+    def _send_packet(self, data: bytes):
+        self.s.sendall(b"$" + data + b"#" + self._checksum(data))
+
+    def _read_byte(self):
+        b = self.s.recv(1)
+        if not b:
+            raise ConnectionError("socket closed")
+        return b
+
+    def _read_ack(self):
+        b = self._read_byte()
+        while b not in (b"+", b"-"):
+            b = self._read_byte()
+        return b
+
+    def _read_packet(self):
+        b = self._read_byte()
+        while b != b"$":
+            b = self._read_byte()
+        data = ""
+        while True:
+            b = self._read_byte()
+            if b == b"#":
+                break
+            data += b.decode()
+        self.s.recv(2)  # 2 hex checksum bytes, not verified
+        self.s.sendall(b"+")
+        return data
+
+    def send_command(self, cmd: str) -> str:
+        self._send_packet(cmd.encode())
+        if self._read_ack() != b"+":
+            raise RuntimeError(f"command {cmd!r} was NACKed")
+        return self._read_packet()
+
+    def cont(self):
+        """Resume execution. Does not wait for a stop-reply -- the stub
+        won't send one until the target actually stops again."""
+        self._send_packet(b"c")
+
+    def cont_with_signal(self, sig: int):
+        """Resume, redelivering signal `sig` to the guest instead of
+        swallowing it. Used to pass SIGILL through."""
+        self._send_packet(f"C{sig:02x}".encode())
+
+    def wait_stop(self) -> str:
+        """Block until the next stop-reply packet and return it raw
+        (e.g. 'T05...' or 'S05')."""
+        return self._read_packet()
+
+    @staticmethod
+    def stop_signal(reply: str) -> int:
+        return int(reply[1:3], 16)
+
+    def insert_bp(self, addr: int, kind: int = 2):
+        if self.send_command(f"Z0,{addr:x},{kind}") != "OK":
+            raise RuntimeError(f"insert_bp(0x{addr:x}) failed")
+
+    def remove_bp(self, addr: int, kind: int = 2):
+        if self.send_command(f"z0,{addr:x},{kind}") != "OK":
+            raise RuntimeError(f"remove_bp(0x{addr:x}) failed")
+
+    def step(self):
+        """Single-step one instruction; blocks for the resulting stop-reply."""
+        self._send_packet(b"s")
+        if self._read_ack() != b"+":
+            raise RuntimeError("step was NACKed")
+        return self._read_packet()
+
+    def read_regs(self) -> list:
+        """r0..r15 as unsigned 32-bit ints (r9=data base, r13=SP, r14=LR, r15=PC)."""
+        raw = self.send_command("g")
+        words = [raw[i:i + 8] for i in range(0, len(raw), 8)]
+        return [int.from_bytes(bytes.fromhex(w), "little") for w in words]
+
+    def read_mem(self, addr: int, length: int) -> bytes:
+        reply = self.send_command(f"m{addr:x},{length:x}")
+        if reply.startswith("E"):
+            raise RuntimeError(f"read_mem(0x{addr:x}, {length}) failed: {reply}")
+        return bytes.fromhex(reply)

--- a/tests/speculos/verify_bip39_cancel_clears_buffer.py
+++ b/tests/speculos/verify_bip39_cancel_clears_buffer.py
@@ -1,0 +1,370 @@
+#!/usr/bin/env python3
+"""Speculos regression check: cancelling mid-entry on the "Check BIP39"
+screen must not leave typed mnemonic content behind in RAM.
+
+Scenario: type one word, confirm it (lands in the `mnemonic` static buffer,
+src/nbgl/bip39_mnemonic.c), start typing a second word but don't confirm it,
+then press "back" until the entry screen is left. Read the raw `mnemonic`
+buffer over a GDB connection before and after, on the real running app --
+not the source, the actual bytes in RAM.
+
+Usage:
+    docker run --rm -v "$(pwd)":/app \\
+      ghcr.io/ledgerhq/ledger-app-builder/ledger-app-builder-lite:latest \\
+      bash -c 'BOLOS_SDK=/opt/flex-secure-sdk make -j4'   # build first, once
+    python3 tests/speculos/verify_bip39_cancel_clears_buffer.py
+
+Exit code 0 and "PASS" printed if the typed word no longer appears anywhere
+in the buffer after cancelling. Exit code 1 and "FAIL" if it does -- that is
+a real bug (a secret mnemonic word staying resident in RAM after the user
+backed out), not a test infrastructure problem.
+
+See README.md in this directory for what this script works around (the
+Speculos debug image, GDB-vs-SIGILL, and how the target's own RAM address
+is found) and why.
+"""
+import json
+import os
+import socket
+import subprocess
+import sys
+import tempfile
+import threading
+import time
+import urllib.request
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+from rsp_client import RSP
+
+REPO_ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", ".."))
+ELF_PATH = os.path.join(REPO_ROOT, "build", "flex", "bin", "app.elf")
+BUILDER_IMAGE = "ghcr.io/ledgerhq/ledger-app-builder/ledger-app-builder-lite:latest"
+SPECULOS_IMAGE = "ghcr.io/ledgerhq/speculos:latest"
+CONTAINER_NAME = "speculos-bip39-cancel-test"
+API_PORT = 5001
+GDB_PORT = 1234
+BASE_URL = f"http://localhost:{API_PORT}"
+
+# Link-time code base for the flex target (from the SDK's scatter-loading)
+# vs. the address speculos's launcher actually maps it at. Verified
+# empirically via /proc/<pid>/maps and confirmed by successfully hitting
+# breakpoints there -- see README.md. Only code addresses need this
+# translation; the `mnemonic` buffer's real address is found a different
+# way at runtime -- see MemorySampler._pump() and README.md.
+CODE_LINK_BASE = 0xC0DE0000
+CODE_RUNTIME_BASE = 0x40000000
+
+SIGILL = 4
+SOCKET_TIMEOUT = 40
+
+
+def die(msg):
+    print(f"FAIL: {msg}", file=sys.stderr)
+    sys.exit(1)
+
+
+def check_build():
+    if not os.path.isfile(ELF_PATH):
+        die(
+            "build/flex/bin/app.elf not found. Build it first:\n\n"
+            '  docker run --rm -v "$(pwd)":/app \\\n'
+            f"    {BUILDER_IMAGE} \\\n"
+            "    bash -c 'BOLOS_SDK=/opt/flex-secure-sdk make -j4'\n"
+        )
+
+
+def docker_run_tool(*args):
+    return subprocess.run(
+        ["docker", "run", "--rm", "-v", f"{os.path.dirname(ELF_PATH)}:/app",
+         BUILDER_IMAGE, *args],
+        capture_output=True, text=True, check=True,
+    ).stdout
+
+
+def resolve_symbols():
+    """nm -S the built ELF (never hardcode addresses -- they shift on any
+    source change to this file). Returns {name: (address, size)}."""
+    out = docker_run_tool("nm", "-S", "/app/app.elf")
+    wanted = {"bip39_mnemonic_reset", "bip39_mnemonic_word_remove",
+              "bip39_mnemonic_word_add", "mnemonic"}
+    syms = {}
+    for line in out.splitlines():
+        parts = line.split()
+        if len(parts) == 4 and parts[3] in wanted:
+            syms[parts[3]] = (int(parts[0], 16), int(parts[1], 16))
+        elif len(parts) == 3 and parts[2] in wanted:
+            syms[parts[2]] = (int(parts[0], 16), 0)
+    missing = wanted - syms.keys()
+    if missing:
+        die(f"could not resolve symbols in app.elf: {missing} "
+            "(did bip39_mnemonic.c change function/variable names?)")
+    return syms
+
+
+def resolve_bss_base():
+    out = docker_run_tool("readelf", "-S", "/app/app.elf")
+    for line in out.splitlines():
+        parts = line.split()
+        if ".bss" in parts:
+            return int(parts[parts.index(".bss") + 2], 16)
+    die("could not find .bss section in app.elf")
+
+
+def code_runtime_addr(link_addr):
+    """Translate a linked code address to where speculos's launcher
+    actually maps it. `link_addr` may carry the Thumb bit (bit 0, per ARM
+    ELF convention for Thumb function symbols) -- stripped here since it's
+    not part of the real memory address."""
+    even = link_addr & ~1
+    return CODE_RUNTIME_BASE + (even - CODE_LINK_BASE)
+
+
+def prepare_patched_speculos_main(scratch_dir):
+    """The published ghcr.io/ledgerhq/speculos:latest image's debug mode
+    (`-d`, used to get a GDB port) is broken: its main.py passes
+    `-singlestep` to qemu-arm-static, an option removed from the bundled
+    QEMU (10.0.8). Patch it to use `-one-insn-per-tb`, the modern
+    replacement for the same purpose. See README.md."""
+    patched = os.path.join(scratch_dir, "main.py")
+    cid = subprocess.run(["docker", "create", SPECULOS_IMAGE],
+                          capture_output=True, text=True, check=True).stdout.strip()
+    try:
+        subprocess.run(["docker", "cp", f"{cid}:/speculos/speculos/main.py", patched], check=True)
+    finally:
+        subprocess.run(["docker", "rm", cid], capture_output=True)
+    with open(patched) as f:
+        content = f.read()
+    if "'-singlestep'" not in content:
+        die("speculos main.py no longer contains '-singlestep' -- "
+            "the image changed, this patch needs re-checking by hand")
+    content = content.replace("'-singlestep'", "'-one-insn-per-tb'")
+    with open(patched, "w") as f:
+        f.write(content)
+    return patched
+
+
+def start_container(patched_main_py):
+    subprocess.run(["docker", "rm", "-f", CONTAINER_NAME], capture_output=True)
+    subprocess.run([
+        "docker", "run", "-d", "--name", CONTAINER_NAME,
+        "-p", f"{GDB_PORT}:1234", "-p", f"{API_PORT}:5001",
+        "-v", f"{os.path.dirname(ELF_PATH)}:/app",
+        "-v", f"{patched_main_py}:/speculos/speculos/main.py",
+        SPECULOS_IMAGE, "-m", "flex", "--display", "headless",
+        "--api-port", "5001", "-d", "/app/app.elf",
+    ], check=True, capture_output=True)
+
+
+def stop_container():
+    subprocess.run(["docker", "rm", "-f", CONTAINER_NAME], capture_output=True)
+
+
+def tap(x, y, delay=0.1):
+    body = json.dumps({"action": "press-and-release", "x": x, "y": y, "delay": delay}).encode()
+    req = urllib.request.Request(f"{BASE_URL}/finger", data=body,
+                                  headers={"Content-Type": "application/json"}, method="POST")
+    urllib.request.urlopen(req).read()
+    time.sleep(0.4)
+
+
+def screen_texts():
+    data = json.loads(urllib.request.urlopen(f"{BASE_URL}/events?currentscreenonly=true").read())
+    return [e["text"] for e in data["events"]]
+
+
+class MemorySampler:
+    """Runs the app to completion under GDB by passing every SIGILL trap
+    straight through (the app's BOLOS syscall trampolines are deliberate
+    illegal instructions -- see README.md), and takes a synchronous memory
+    snapshot of `mnemonic` at the entry and return of each watched
+    function, keyed by function name.
+
+    Breakpoints are used (not an async Ctrl-C interrupt) because the app
+    spends most of its time blocked in a real host syscall waiting for the
+    next touch event; an injected interrupt byte was found not to be
+    processed until *something* wakes the CPU's dispatch loop up again --
+    unreliable. A breakpoint fires synchronously, exactly when the CPU
+    itself reaches that instruction, with no such timing dependency.
+    """
+
+    def __init__(self, watch_addrs, mnemonic_offset, mnemonic_len):
+        self.rsp = RSP(timeout=SOCKET_TIMEOUT)
+        self.watch = watch_addrs  # {runtime_addr: name}
+        self.mnemonic_offset = mnemonic_offset
+        self.mnemonic_len = mnemonic_len
+        self.snapshots = []  # (name, before_bytes, after_bytes), in hit order
+        self._pending_return = None  # (ret_addr, name, before_bytes)
+        self._thread = threading.Thread(target=self._pump, daemon=True)
+
+    def start(self):
+        for addr in self.watch:
+            self.rsp.insert_bp(addr, kind=2)
+        self.rsp.cont()
+        self._thread.start()
+
+    def _pump(self):
+        while True:
+            try:
+                reply = self.rsp.wait_stop()
+            except socket.timeout:
+                continue  # genuinely idle, no SIGILL traffic right now
+            except (ConnectionError, OSError):
+                return  # container torn down from under us, nothing left to pump
+            if self.rsp.stop_signal(reply) == SIGILL:
+                self.rsp.cont_with_signal(SIGILL)
+                continue
+
+            regs = self.rsp.read_regs()
+            pc = regs[15] & ~1
+            mnemonic_addr = regs[9] + self.mnemonic_offset
+
+            if self._pending_return and pc == self._pending_return[0]:
+                ret_addr, name, before = self._pending_return
+                after = self.rsp.read_mem(mnemonic_addr, self.mnemonic_len)
+                self.snapshots.append((name, before, after))
+                self.rsp.remove_bp(ret_addr, kind=2)
+                self._pending_return = None
+                self.rsp.cont()
+                continue
+
+            if pc in self.watch:
+                name = self.watch[pc]
+                ret_addr = regs[14] & ~1
+                before = self.rsp.read_mem(mnemonic_addr, self.mnemonic_len)
+                self.rsp.insert_bp(ret_addr, kind=2)
+                self._pending_return = (ret_addr, name, before)
+                # step over the breakpoint we're sitting on before resuming,
+                # or we'd hit it again immediately without progressing
+                self.rsp.remove_bp(pc, kind=2)
+                self.rsp.step()
+                self.rsp.insert_bp(pc, kind=2)
+                self.rsp.cont()
+                continue
+
+            # unrelated stop (shouldn't normally happen); don't get stuck
+            self.rsp.cont()
+
+
+def navigate_and_cancel():
+    """Coordinates are for the flex layout only (480x600, touch UI). See
+    README.md for how these were found and how to adapt to stax/apex."""
+    time.sleep(3)  # let the app finish booting before the first tap
+    tap(371, 436)  # home screen: "Select Tool"
+    time.sleep(1)
+    tap(358, 524)  # "BIP39 Check"
+    time.sleep(1)
+    tap(387, 524)  # "12 words"
+    time.sleep(1)
+
+    # word 1: type "aban", confirm the "abandon" suggestion -> lands in
+    # mnemonic.buffer via bip39_mnemonic_word_add()
+    for x, y in [(40, 474), (207, 546), (40, 474), (256, 546)]:
+        tap(x, y)
+    tap(176, 300)
+
+    # word 2: type "aba" but never confirm it -- this is the "cancel while
+    # typing" moment the scenario is about
+    for x, y in [(40, 474), (207, 546), (40, 474)]:
+        tap(x, y)
+
+    texts = screen_texts()
+    if "abandon" not in texts:
+        die(f"expected 'abandon' suggestion on screen before cancelling, got: {texts}")
+
+    # back out: 1st tap removes the confirmed word (bip39_mnemonic_word_remove
+    # -> bip39_mnemonic_shrink, the real per-word clearing path), 2nd tap
+    # exits the screen entirely (bip39_mnemonic_reset, defense in depth)
+    tap(48, 48)
+    time.sleep(1)
+    tap(48, 48)
+    time.sleep(1)
+
+
+def main():
+    check_build()
+    print("Resolving symbols from build/flex/bin/app.elf ...")
+    syms = resolve_symbols()
+    bss_base = resolve_bss_base()
+    mnemonic_addr, mnemonic_len = syms["mnemonic"]
+    mnemonic_offset = mnemonic_addr - bss_base
+    watch = {
+        code_runtime_addr(syms["bip39_mnemonic_word_add"][0]): "bip39_mnemonic_word_add",
+        code_runtime_addr(syms["bip39_mnemonic_word_remove"][0]): "bip39_mnemonic_word_remove",
+        code_runtime_addr(syms["bip39_mnemonic_reset"][0]): "bip39_mnemonic_reset",
+    }
+    print(f"  mnemonic buffer: offset R9+0x{mnemonic_offset:x}, {mnemonic_len} bytes")
+    for addr, name in watch.items():
+        print(f"  breakpoint: 0x{addr:x} ({name})")
+
+    sampler = None
+    with tempfile.TemporaryDirectory() as scratch:
+        print("Patching Speculos debug image (singlestep -> one-insn-per-tb) ...")
+        patched_main = prepare_patched_speculos_main(scratch)
+
+        print("Starting Speculos ...")
+        start_container(patched_main)
+        try:
+            time.sleep(2)
+            sampler = MemorySampler(watch, mnemonic_offset, mnemonic_len)
+            sampler.start()
+            print("Navigating: home -> BIP39 Check -> 12 words -> type+confirm "
+                  "'abandon' -> type partial 'aba' -> cancel (back x2) ...")
+            print("(this is slow -- every guest syscall round-trips through this "
+                  "script while GDB is attached; a full run takes a few minutes)")
+            navigate_and_cancel()
+            time.sleep(2)
+        finally:
+            stop_container()
+
+    if sampler is None or not sampler.snapshots:
+        die("no breakpoint ever fired -- navigation didn't reach the expected "
+            "code paths (did the UI flow change?)")
+
+    print(f"\nCaptured {len(sampler.snapshots)} snapshots:")
+    add_hit = None
+    remove_hit = None
+    for name, before, after in sampler.snapshots:
+        nz_before = sum(1 for b in before if b)
+        nz_after = sum(1 for b in after if b)
+        print(f"  {name}: before_nonzero={nz_before}/{len(before)} "
+              f"after_nonzero={nz_after}/{len(after)}")
+        if name == "bip39_mnemonic_word_add" and add_hit is None:
+            add_hit = (before, after)
+        if name == "bip39_mnemonic_word_remove" and remove_hit is None:
+            remove_hit = (before, after)
+
+    if add_hit is None:
+        die("bip39_mnemonic_word_add was never hit -- 'abandon' was never confirmed")
+    if b"abandon" not in add_hit[1]:
+        die("confirming 'abandon' did not write it into the mnemonic buffer -- "
+            "test setup is broken, this isn't the bug under test")
+    print("\n  confirmed: 'abandon' is present in RAM right after being typed "
+          "(as expected -- this is what makes the next check meaningful)")
+
+    if remove_hit is None:
+        die("bip39_mnemonic_word_remove was never hit -- cancel didn't reach "
+            "the buffer-clearing code path at all")
+    before, after = remove_hit
+    if b"abandon" not in before:
+        die("bip39_mnemonic_word_remove fired without 'abandon' present before "
+            "it -- navigation/timing assumption is wrong, re-check the scenario")
+    # NOTE: the struct is *not* expected to be all-zero here -- e.g.
+    # current_word_index is deliberately left at its (size_t)-1 "no word"
+    # sentinel by bip39_mnemonic_shrink(), which is legitimate bookkeeping,
+    # not a leak. The actual security property is that the *secret content*
+    # (the word itself) is gone, so that's what's checked -- not "the whole
+    # struct reads as zero".
+    if b"abandon" in after:
+        print("\nFAIL: 'abandon' is still present in the mnemonic buffer "
+              "after cancelling -- typed content was not cleared:")
+        print(f"  {after.hex()}")
+        sys.exit(1)
+
+    print("\nPASS: 'abandon' is no longer present in the mnemonic buffer "
+          "after cancelling (bip39_mnemonic_word_remove -> bip39_mnemonic_shrink "
+          "zeroed it)")
+    sys.exit(0)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

- First Speculos-driven test in this repo. Types a word into the "Check BIP39" entry screen, confirms it, starts a second word without confirming it, then cancels before finishing entry. Reads the app's actual RAM over a GDB connection (not the source) to confirm the typed word does not survive the cancel.
- Result: no bug found, but the assumption about *which* function does the clearing was wrong going in, and the test corrects that. The back button calls `bip39_mnemonic_word_remove()` -> `bip39_mnemonic_shrink()` (`src/nbgl/bip39_mnemonic.c`), which is what actually zeroes the buffer on this path. `bip39_mnemonic_reset()` is only invoked once no confirmed word is left to remove (exiting the screen entirely) -- by that point the buffer is already empty, so it's defense in depth rather than the real clearing mechanism. Both call sites are exercised; neither showed a problem.

## What's new

- `tests/speculos/rsp_client.py` -- a small (~100 line) GDB Remote Serial Protocol client, stdlib only, used to talk to Speculos's debug port directly.
- `tests/speculos/verify_bip39_cancel_clears_buffer.py` -- the check itself. Resolves every address it needs from `nm`/`readelf` against the actual built binary (nothing hardcoded), patches and launches its own Speculos container, drives the touch UI, and asserts on raw memory content before/after cancelling. Exits 1 with a clear message if the typed word is still present after cancel.
- `tests/speculos/README.md` -- how to run it, what a real failure looks like, and four non-obvious things this had to work around (documented so a future scenario doesn't have to rediscover them): the published Speculos debug image being broken, a live GDB connection freezing the app solid unless SIGILL is explicitly passed through (this app's syscall trampolines are deliberate illegal instructions), why an async Ctrl-C interrupt isn't reliable here (breakpoints are used instead), and how this app's globals are actually addressed at runtime (R9-relative, not their linked address).

## Scope

Not wired into CI or the existing cmocka harness -- this is the first time Speculos has been used in this repo at all, so it's a manual, run-by-hand script for now rather than an automated gate. Flex layout only (touch coordinates); stax/apex would need their own coordinates but the GDB/breakpoint machinery is reusable as-is.

## Test plan

- [x] Ran the script standalone end to end against a fresh `flex` build; confirmed `PASS` with the typed word ("abandon") present in RAM right after being typed and absent after cancelling.
- [x] No `src/` changes in this PR -- pure test addition, no impact on NBGL/BAGL builds or the existing unit test suite.