### PR TITLE
ci: add ASan/UBSan/-O2/-Os/char-signedness matrix for the unit test suite

### DIFF
--- a/.github/workflows/unit-tests-matrix.yml
+++ b/.github/workflows/unit-tests-matrix.yml
@@ -1,0 +1,84 @@
+name: Unit test configuration matrix
+
+# Sweeps the cmocka unit test suite (tests/unit) across build configurations
+# that unit_tests.yml does not cover: ASan, UBSan, -O2, -Os, -fsigned-char
+# and -funsigned-char. The default configuration (Debug, -O0) is already
+# exercised by unit_tests.yml on every pull request, so it is intentionally
+# not repeated here.
+#
+# Each matrix entry builds OpenSSL (a unit test dependency, fetched and
+# compiled from source by tests/unit/CMakeLists.txt) once with no special
+# flags, then reconfigures using -DPRECOMPILED_DEPENDENCIES_DIR to reuse
+# that build unchanged and apply the job-specific flags only to the actual
+# test suite. Without this, CMAKE_C_FLAGS/CMAKE_EXE_LINKER_FLAGS passed to
+# the top-level cmake invocation would also apply to OpenSSL's build,
+# needlessly recompiling a third-party dependency with flags it was never
+# meant to receive.
+#
+# This sweep is heavier than unit_tests.yml (6 OpenSSL builds + 6 full test
+# builds), so it does not run on every pull request; it runs on push to the
+# integration branches and on demand.
+
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - bip85
+      - develop
+
+jobs:
+  unit_tests_matrix:
+    name: ${{ matrix.name }}
+    runs-on: ubuntu-latest
+    container:
+      image: ghcr.io/ledgerhq/ledger-app-builder/ledger-app-dev-tools:latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - name: ASan
+            cflags: "-fsanitize=address -fno-omit-frame-pointer"
+            ldflags: "-fsanitize=address"
+          - name: UBSan
+            cflags: "-fsanitize=undefined -fno-sanitize-recover=all"
+            ldflags: "-fsanitize=undefined"
+          - name: "-O2"
+            cflags: "-O2"
+            ldflags: ""
+          - name: "-Os"
+            cflags: "-Os"
+            ldflags: ""
+          - name: "-fsigned-char"
+            cflags: "-fsigned-char"
+            ldflags: ""
+          - name: "-funsigned-char"
+            cflags: "-funsigned-char"
+            ldflags: ""
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Build OpenSSL dependency (no matrix flags)
+        working-directory: tests/unit
+        run: |
+          cmake -Bbuild-deps -H.
+          make -C build-deps openssl -j"$(nproc)"
+
+      - name: Configure unit tests with matrix flags
+        working-directory: tests/unit
+        run: |
+          cmake -Bbuild -H. \
+            -DPRECOMPILED_DEPENDENCIES_DIR="$(pwd)/build-deps/install" \
+            -DCMAKE_C_FLAGS="${{ matrix.cflags }}" \
+            -DCMAKE_EXE_LINKER_FLAGS="${{ matrix.ldflags }}"
+
+      - name: Build unit tests
+        working-directory: tests/unit
+        run: make -C build -j"$(nproc)"
+
+      - name: Run unit tests
+        working-directory: tests/unit
+        env:
+          CTEST_OUTPUT_ON_FAILURE: 1
+        run: ctest --test-dir build

--- a/.github/workflows/unit-tests-matrix.yml
+++ b/.github/workflows/unit-tests-matrix.yml
@@ -15,6 +15,14 @@ name: Unit test configuration matrix
 # needlessly recompiling a third-party dependency with flags it was never
 # meant to receive.
 #
+# The -O2/-Os entries use CMAKE_BUILD_TYPE=Release with CMAKE_C_FLAGS_RELEASE
+# instead of CMAKE_C_FLAGS, and the default Debug build type used by the
+# other entries. tests/unit/CMakeLists.txt hardcodes -O0 into
+# CMAKE_C_FLAGS_DEBUG, which is applied after CMAKE_C_FLAGS on the actual
+# compile command line -- passing an -O level via CMAKE_C_FLAGS under the
+# default Debug build type would silently lose to that -O0 (the last -O
+# flag on the command line wins). Release sidesteps that line entirely.
+#
 # This sweep is heavier than unit_tests.yml (6 OpenSSL builds + 6 full test
 # builds), so it does not run on every pull request; it runs on push to the
 # integration branches and on demand.
@@ -37,21 +45,27 @@ jobs:
       matrix:
         include:
           - name: ASan
+            build_type: Debug
             cflags: "-fsanitize=address -fno-omit-frame-pointer"
             ldflags: "-fsanitize=address"
           - name: UBSan
+            build_type: Debug
             cflags: "-fsanitize=undefined -fno-sanitize-recover=all"
             ldflags: "-fsanitize=undefined"
           - name: "-O2"
+            build_type: Release
             cflags: "-O2"
             ldflags: ""
           - name: "-Os"
+            build_type: Release
             cflags: "-Os"
             ldflags: ""
           - name: "-fsigned-char"
+            build_type: Debug
             cflags: "-fsigned-char"
             ldflags: ""
           - name: "-funsigned-char"
+            build_type: Debug
             cflags: "-funsigned-char"
             ldflags: ""
 
@@ -68,10 +82,25 @@ jobs:
       - name: Configure unit tests with matrix flags
         working-directory: tests/unit
         run: |
-          cmake -Bbuild -H. \
-            -DPRECOMPILED_DEPENDENCIES_DIR="$(pwd)/build-deps/install" \
-            -DCMAKE_C_FLAGS="${{ matrix.cflags }}" \
-            -DCMAKE_EXE_LINKER_FLAGS="${{ matrix.ldflags }}"
+          if [ "${{ matrix.build_type }}" = "Release" ]; then
+            # CMAKE_C_FLAGS_DEBUG hardcodes -O0 (tests/unit/CMakeLists.txt) and
+            # is applied after CMAKE_C_FLAGS on the actual compile command, so
+            # -O0 would silently win over an -O level passed via CMAKE_C_FLAGS
+            # under the default Debug build type (last -O flag on the command
+            # line wins). Switching to Release and setting
+            # CMAKE_C_FLAGS_RELEASE directly avoids that Debug-only line
+            # entirely, so the matrix flag is the only -O level applied.
+            cmake -Bbuild -H. \
+              -DPRECOMPILED_DEPENDENCIES_DIR="$(pwd)/build-deps/install" \
+              -DCMAKE_BUILD_TYPE=Release \
+              -DCMAKE_C_FLAGS_RELEASE="${{ matrix.cflags }}" \
+              -DCMAKE_EXE_LINKER_FLAGS="${{ matrix.ldflags }}"
+          else
+            cmake -Bbuild -H. \
+              -DPRECOMPILED_DEPENDENCIES_DIR="$(pwd)/build-deps/install" \
+              -DCMAKE_C_FLAGS="${{ matrix.cflags }}" \
+              -DCMAKE_EXE_LINKER_FLAGS="${{ matrix.ldflags }}"
+          fi
 
       - name: Build unit tests
         working-directory: tests/unit

--- a/.github/workflows/unit-tests-matrix.yml
+++ b/.github/workflows/unit-tests-matrix.yml
@@ -39,7 +39,7 @@ jobs:
     name: ${{ matrix.name }}
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/ledgerhq/ledger-app-builder/ledger-app-dev-tools:latest
+      image: ghcr.io/ledgerhq/ledger-app-builder/ledger-app-builder-lite:latest
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
## Summary

Adds a new workflow (`unit-tests-matrix.yml`) that runs the existing cmocka unit test suite (`tests/unit`) under six build configurations not covered by `unit_tests.yml`: ASan, UBSan, `-O2`, `-Os`, `-fsigned-char` and `-funsigned-char`. The default configuration (Debug, `-O0`) already runs on every pull request via `unit_tests.yml`, so it is intentionally not repeated here.

## Why a separate workflow, and why not on every PR

`unit_tests.yml` delegates to the shared `reusable_unit_tests.yml`, which has no notion of a build-flag matrix, so this couldn't be added there without either modifying that external, shared workflow or inlining custom job logic anyway. A separate file also keeps this change at zero risk to the always-on per-PR gate.

This sweep is heavier than the existing per-PR job (six OpenSSL builds plus six full test builds), so it triggers on push to `bip85`/`develop` and on manual dispatch, not on every pull request -- keeping the usual review loop fast. Same pattern as the fork's own `fork-integration-ci.yml`.

## The OpenSSL flag-leak problem

`tests/unit/CMakeLists.txt` compiles OpenSSL from source and makes it inherit `CMAKE_C_FLAGS` and the project's global `COMPILE_OPTIONS`. Passing sanitizer/optimization flags straight to the top-level `cmake` invocation would also recompile OpenSSL with them -- unnecessary build time, and a real risk of OpenSSL's own build breaking on flags it was never meant to receive.

Each matrix job instead builds OpenSSL first with no special flags into its own build directory, then reconfigures the real test build with the already-supported `-DPRECOMPILED_DEPENDENCIES_DIR` pointing at that install, applying the job-specific flags only to the test suite itself. No changes to `CMakeLists.txt` were needed.

## The -O2/-Os subtlety

`CMAKE_C_FLAGS_DEBUG` hardcodes `-O0`, and under the default Debug build type it is applied *after* `CMAKE_C_FLAGS` on the actual compile command line -- so passing `-O2`/`-Os` via `CMAKE_C_FLAGS` would have silently lost to that `-O0` (gcc/clang honor the last `-O` flag). Those two matrix entries use `-DCMAKE_BUILD_TYPE=Release` with `-DCMAKE_C_FLAGS_RELEASE` instead, which bypasses that Debug-only line entirely.

## Verification

All 6 jobs run and pass (24/24 tests each) on the actual `ledger-app-builder-lite` image (same image `unit_tests.yml` uses via the reusable workflow), verified via manual `workflow_dispatch` runs on this branch:
- https://github.com/buzzromain/app-seed-tool/actions/runs/30404476197