### PR TITLE
sskr: bound groups_len and erase combine output on failure

### DIFF
--- a/src/common/sskr/seed_sskr.c
+++ b/src/common/sskr/seed_sskr.c
@@ -37,6 +37,9 @@
 int16_t bolos_ux_sskr_size_get(uint8_t bip39_type, uint8_t groups_threshold,
                                unsigned int* group_descriptor,
                                uint8_t groups_len, uint8_t* share_len) {
+    if (groups_len > SSKR_MAX_GROUP_COUNT) {
+        return SSKR_ERROR_INVALID_GROUP_LENGTH;
+    }
     sskr_group_descriptor_t groups[SSKR_MAX_GROUP_COUNT];
     for (uint8_t i = 0; i < groups_len; i++) {
         groups[i].threshold =
@@ -128,6 +131,9 @@ unsigned int bolos_ux_sskr_generate(uint8_t groups_threshold,
                                     unsigned int share_buffer_len,
                                     uint8_t share_len_expected,
                                     int16_t share_count_expected) {
+    if (groups_len > SSKR_MAX_GROUP_COUNT) {
+        return 0;
+    }
     sskr_group_descriptor_t groups[SSKR_MAX_GROUP_COUNT];
 
     for (uint8_t i = 0; i < (uint8_t)groups_len; i++) {

--- a/src/common/sskr/sskr.c
+++ b/src/common/sskr/sskr.c
@@ -557,6 +557,7 @@ static int16_t sskr_combine_shards_internal(sskr_shard_t* shards,
     memzero(groups, sizeof(groups));
 
     if (error) {
+        memzero(buffer, buffer_len);
         return error;
     }
 

--- a/tests/unit/CMakeLists.txt
+++ b/tests/unit/CMakeLists.txt
@@ -210,6 +210,16 @@ add_executable(test_sskr_combine_error ./tests/sskr_combine_error.c ../../src/co
 target_include_directories(test_sskr_combine_error PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/../../src/common)
 target_link_libraries(test_sskr_combine_error PUBLIC cmocka gcov sskr sss testutils)
 
+# Built with AddressSanitizer: like test_sskr_combine_bounds, this is about
+# what the code writes (past the fixed-size `groups[SSKR_MAX_GROUP_COUNT]`
+# local array), not what it returns, so the sanitizer is the assertion for
+# the two oversized-groups_len cases.
+add_executable(test_sskr_generate_bound_groups ./tests/sskr_generate_bound_groups.c ../../src/common/bip39/seed_rom_variables.c ../../src/common/bip39/seed_bip39.c ../../src/common/sskr/seed_rom_variables.c ../../src/common/sskr/seed_sskr.c)
+target_include_directories(test_sskr_generate_bound_groups PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/../../src ${CMAKE_CURRENT_SOURCE_DIR}/../../src/common ${CMAKE_CURRENT_SOURCE_DIR}/../../src/common/sskr/sss)
+target_compile_options(test_sskr_generate_bound_groups PRIVATE -fsanitize=address -fno-omit-frame-pointer)
+target_link_options(test_sskr_generate_bound_groups PRIVATE -fsanitize=address)
+target_link_libraries(test_sskr_generate_bound_groups PUBLIC cmocka gcov testutils sskr sss)
+
 # Blockchain Commons 128-bit vector, raw Shamir math level (no CBOR/CRC).
 add_executable(test_sskr_interop_bc128 tests/sskr_interop_bc128.c)
 target_link_libraries(test_sskr_interop_bc128 PUBLIC cmocka gcov testutils sskr sss)
@@ -321,6 +331,6 @@ add_executable(test_bip85_hex_vector tests/bip85_hex_vector.c ../../src/common/b
 target_include_directories(test_bip85_hex_vector PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/../../src)
 target_link_libraries(test_bip85_hex_vector PUBLIC cmocka gcov testutils)
 
-foreach(target test_sss test_sss_recover_erase_length test_sskr test_sskr_share_len test_sskr_memzero test_sskr_shard_count test_sskr_generate_split_error test_sskr_combine_bounds test_sskr_combine_error test_sskr_combine_invariants test_sskr_interop_bc128 test_sskr_interop_bc128_bytewords test_sskr_entry_bounds test_sskr_byteword_sentinel test_sskr_cbor_additional_info test_bip39 test_roundtrip test_words test_base64 test_base85 test_bip85_dice_bits_per_roll test_bip85_dice_roll test_bip85_bip39_entropy test_bip85_hex_vector)
+foreach(target test_sss test_sss_recover_erase_length test_sskr test_sskr_share_len test_sskr_memzero test_sskr_shard_count test_sskr_generate_split_error test_sskr_generate_bound_groups test_sskr_combine_bounds test_sskr_combine_error test_sskr_combine_invariants test_sskr_interop_bc128 test_sskr_interop_bc128_bytewords test_sskr_entry_bounds test_sskr_byteword_sentinel test_sskr_cbor_additional_info test_bip39 test_roundtrip test_words test_base64 test_base85 test_bip85_dice_bits_per_roll test_bip85_dice_roll test_bip85_bip39_entropy test_bip85_hex_vector)
     add_test(NAME ${target} COMMAND ${target})
 endforeach()

--- a/tests/unit/CMakeLists.txt
+++ b/tests/unit/CMakeLists.txt
@@ -198,6 +198,9 @@ target_link_libraries(test_sskr_shard_count PUBLIC cmocka gcov sskr sss testutil
 add_executable(test_sskr_generate_split_error tests/sskr_generate_split_error.c)
 target_link_libraries(test_sskr_generate_split_error PUBLIC cmocka gcov sskr sss testutils)
 
+add_executable(test_sskr_combine_erase_on_failure tests/sskr_combine_erase_on_failure.c)
+target_link_libraries(test_sskr_combine_erase_on_failure PUBLIC cmocka gcov sskr sss testutils)
+
 # Built with AddressSanitizer: this one is about what the code writes, not
 # what it returns, so the sanitizer is the assertion.
 add_executable(test_sskr_combine_bounds ./tests/sskr_combine_bounds.c ../../src/common/bip39/seed_rom_variables.c ../../src/common/bip39/seed_bip39.c ../../src/common/sskr/seed_rom_variables.c ../../src/common/sskr/seed_sskr.c)
@@ -331,6 +334,6 @@ add_executable(test_bip85_hex_vector tests/bip85_hex_vector.c ../../src/common/b
 target_include_directories(test_bip85_hex_vector PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/../../src)
 target_link_libraries(test_bip85_hex_vector PUBLIC cmocka gcov testutils)
 
-foreach(target test_sss test_sss_recover_erase_length test_sskr test_sskr_share_len test_sskr_memzero test_sskr_shard_count test_sskr_generate_split_error test_sskr_generate_bound_groups test_sskr_combine_bounds test_sskr_combine_error test_sskr_combine_invariants test_sskr_interop_bc128 test_sskr_interop_bc128_bytewords test_sskr_entry_bounds test_sskr_byteword_sentinel test_sskr_cbor_additional_info test_bip39 test_roundtrip test_words test_base64 test_base85 test_bip85_dice_bits_per_roll test_bip85_dice_roll test_bip85_bip39_entropy test_bip85_hex_vector)
+foreach(target test_sss test_sss_recover_erase_length test_sskr test_sskr_share_len test_sskr_memzero test_sskr_shard_count test_sskr_generate_split_error test_sskr_generate_bound_groups test_sskr_combine_erase_on_failure test_sskr_combine_bounds test_sskr_combine_error test_sskr_combine_invariants test_sskr_interop_bc128 test_sskr_interop_bc128_bytewords test_sskr_entry_bounds test_sskr_byteword_sentinel test_sskr_cbor_additional_info test_bip39 test_roundtrip test_words test_base64 test_base85 test_bip85_dice_bits_per_roll test_bip85_dice_roll test_bip85_bip39_entropy test_bip85_hex_vector)
     add_test(NAME ${target} COMMAND ${target})
 endforeach()

--- a/tests/unit/CMakeLists.txt
+++ b/tests/unit/CMakeLists.txt
@@ -201,6 +201,12 @@ target_link_libraries(test_sskr_generate_split_error PUBLIC cmocka gcov sskr sss
 add_executable(test_sskr_combine_erase_on_failure tests/sskr_combine_erase_on_failure.c)
 target_link_libraries(test_sskr_combine_erase_on_failure PUBLIC cmocka gcov sskr sss testutils)
 
+add_executable(test_sskr_count_shards_invariants tests/sskr_count_shards_invariants.c)
+target_link_libraries(test_sskr_count_shards_invariants PUBLIC cmocka gcov sskr sss testutils)
+
+add_executable(test_sskr_generate_erase_on_split_failure tests/sskr_generate_erase_on_split_failure.c)
+target_link_libraries(test_sskr_generate_erase_on_split_failure PUBLIC cmocka gcov sskr sss testutils)
+
 # Built with AddressSanitizer: this one is about what the code writes, not
 # what it returns, so the sanitizer is the assertion.
 add_executable(test_sskr_combine_bounds ./tests/sskr_combine_bounds.c ../../src/common/bip39/seed_rom_variables.c ../../src/common/bip39/seed_bip39.c ../../src/common/sskr/seed_rom_variables.c ../../src/common/sskr/seed_sskr.c)
@@ -334,6 +340,6 @@ add_executable(test_bip85_hex_vector tests/bip85_hex_vector.c ../../src/common/b
 target_include_directories(test_bip85_hex_vector PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/../../src)
 target_link_libraries(test_bip85_hex_vector PUBLIC cmocka gcov testutils)
 
-foreach(target test_sss test_sss_recover_erase_length test_sskr test_sskr_share_len test_sskr_memzero test_sskr_shard_count test_sskr_generate_split_error test_sskr_generate_bound_groups test_sskr_combine_erase_on_failure test_sskr_combine_bounds test_sskr_combine_error test_sskr_combine_invariants test_sskr_interop_bc128 test_sskr_interop_bc128_bytewords test_sskr_entry_bounds test_sskr_byteword_sentinel test_sskr_cbor_additional_info test_bip39 test_roundtrip test_words test_base64 test_base85 test_bip85_dice_bits_per_roll test_bip85_dice_roll test_bip85_bip39_entropy test_bip85_hex_vector)
+foreach(target test_sss test_sss_recover_erase_length test_sskr test_sskr_share_len test_sskr_memzero test_sskr_shard_count test_sskr_generate_split_error test_sskr_generate_bound_groups test_sskr_combine_erase_on_failure test_sskr_count_shards_invariants test_sskr_generate_erase_on_split_failure test_sskr_combine_bounds test_sskr_combine_error test_sskr_combine_invariants test_sskr_interop_bc128 test_sskr_interop_bc128_bytewords test_sskr_entry_bounds test_sskr_byteword_sentinel test_sskr_cbor_additional_info test_bip39 test_roundtrip test_words test_base64 test_base85 test_bip85_dice_bits_per_roll test_bip85_dice_roll test_bip85_bip39_entropy test_bip85_hex_vector)
     add_test(NAME ${target} COMMAND ${target})
 endforeach()

--- a/tests/unit/tests/sskr_combine_erase_on_failure.c
+++ b/tests/unit/tests/sskr_combine_erase_on_failure.c
@@ -1,0 +1,95 @@
+/*
+ * Regression test for the un-erased output buffer on the failure path of
+ * sskr_combine_shards_internal() (src/common/sskr/sskr.c).
+ *
+ * The generation side already gets this right: sskr_generate_shards() does
+ * `memzero(output, buffer_size); return 0;` before returning on any error.
+ * The combination side's internal function cleans up its own working
+ * buffers (group_shares/gx/gy/groups) on every failure, but never the
+ * caller's `buffer` -- the very thing a failed combine is supposed to leave
+ * clean, in case the caller reuses the same buffer across attempts.
+ *
+ * Forcing a genuine interpolation failure without touching the crypto math
+ * itself: interpolate()'s first action is cx_bn_lock(), which fails
+ * immediately if a BN context is already locked (same technique as
+ * sss_recover_erase_length.c). A single group in this port
+ * (SSKR_MAX_GROUP_COUNT == 1) always has group_threshold == 1, which makes
+ * the outer, group-of-groups sss_recover_secret() call take the
+ * threshold-1 shortcut (plain copy, no interpolate()) -- so the failure
+ * has to come from the per-group *member* recovery call instead, which
+ * needs member_threshold >= 2 to reach interpolate() at all. Two shards of
+ * a single 2-of-2 group are enough.
+ *
+ * buffer_len (32, deliberately larger than the 16-byte secret) rather than
+ * secret_len is what must be erased: the real caller,
+ * bolos_ux_sskr_combine(), always passes SSKR_MAX_STRENGTH_BYTES (32) as
+ * buffer_len while secret_len can be as low as SSKR_MIN_STRENGTH_BYTES
+ * (16), so erasing only secret_len would leave up to 16 bytes of whatever
+ * the buffer held before this call.
+ */
+
+#include <cmocka.h>
+#include <cx.h>
+#include <setjmp.h>
+#include <stdarg.h>
+#include <stddef.h>
+#include <stdint.h>
+#include <string.h>
+
+#include "sskr-constants.h"
+#include "sskr.h"
+#include "sss-constants.h"
+#include "testutils.h"
+
+#define SHARD_VALUE_LEN (SSKR_MIN_STRENGTH_BYTES)
+#define SHARD_LEN (SSKR_METADATA_LENGTH_BYTES + SHARD_VALUE_LEN)
+#define BUFFER_LEN (SSKR_MAX_STRENGTH_BYTES)
+
+/* One shard of a single 2-of-2 group: group_threshold 1, group_count 1,
+ * group_index 0, member_threshold 2. member_index is the only field that
+ * differs between the two shards built for this test. */
+static void build_shard(uint8_t raw[SHARD_LEN], uint8_t member_index) {
+    raw[0] = 0xAB;
+    raw[1] = 0xCD;
+    raw[2] = 0x00;  // (group_threshold - 1) << 4 | (group_count - 1) -> 1-of-1
+    raw[3] = (uint8_t)(0x00 |
+                       ((2 - 1) & 0x0F));  // group_index 0, member_threshold 2
+    raw[4] = member_index;                 // reserved nibble stays zero
+    memset(&raw[SSKR_METADATA_LENGTH_BYTES], 0x42 + member_index,
+           SHARD_VALUE_LEN);
+}
+
+static void test_combine_erases_buffer_on_interpolation_failure(void** state) {
+    (void)state;
+
+    uint8_t raw_a[SHARD_LEN];
+    uint8_t raw_b[SHARD_LEN];
+    build_shard(raw_a, 0);
+    build_shard(raw_b, 1);
+    const uint8_t* shards[2] = {raw_a, raw_b};
+
+    uint8_t buffer[BUFFER_LEN];
+    memset(buffer, 0xFF, sizeof(buffer));
+
+    /* Force interpolate()'s own cx_bn_lock() to fail: it refuses to lock an
+     * already-locked context. Its cleanup path unlocks whatever is locked
+     * when it bails out, so this releases the lock again on the way out --
+     * no matching unlock needed here. */
+    assert_int_equal(cx_bn_lock(1, 0), CX_OK);
+
+    int16_t result =
+        sskr_combine_shards(shards, SHARD_LEN, 2, buffer, sizeof(buffer));
+
+    assert_int_equal(result, SSS_ERROR_INTERPOLATION_FAILURE);
+
+    uint8_t expected[BUFFER_LEN];
+    memset(expected, 0x00, sizeof(expected));
+    assert_memory_equal(buffer, expected, sizeof(buffer));
+}
+
+int main(void) {
+    const struct CMUnitTest tests[] = {
+        cmocka_unit_test(test_combine_erases_buffer_on_interpolation_failure),
+    };
+    return cmocka_run_group_tests(tests, NULL, NULL);
+}

--- a/tests/unit/tests/sskr_count_shards_invariants.c
+++ b/tests/unit/tests/sskr_count_shards_invariants.c
@@ -1,0 +1,54 @@
+/*
+ * Coverage for two sskr_count_shards() (src/common/sskr/sskr.c) rejections
+ * that are already implemented correctly but, per a grep of every existing
+ * test source file, never exercised by any existing test:
+ *
+ *   - group_threshold > groups_len -> SSKR_ERROR_INVALID_GROUP_THRESHOLD
+ *   - a group's member threshold > its member count ->
+ *     SSKR_ERROR_INVALID_MEMBER_THRESHOLD
+ *
+ * This is coverage on already-correct code, not a bug fix -- both checks
+ * read exactly as intended in sskr_count_shards().
+ */
+
+#include <cmocka.h>
+#include <setjmp.h>
+#include <stdarg.h>
+#include <stddef.h>
+#include <stdint.h>
+
+#include "sskr-constants.h"
+#include "sskr.h"
+#include "testutils.h"
+
+static void test_count_shards_rejects_group_threshold_above_group_count(
+    void** state) {
+    (void)state;
+
+    const sskr_group_descriptor_t groups[] = {{.threshold = 1, .count = 1}};
+
+    int16_t result = sskr_count_shards(2, groups, 1);
+
+    assert_int_equal(result, SSKR_ERROR_INVALID_GROUP_THRESHOLD);
+}
+
+static void test_count_shards_rejects_member_threshold_above_member_count(
+    void** state) {
+    (void)state;
+
+    const sskr_group_descriptor_t groups[] = {{.threshold = 3, .count = 2}};
+
+    int16_t result = sskr_count_shards(1, groups, 1);
+
+    assert_int_equal(result, SSKR_ERROR_INVALID_MEMBER_THRESHOLD);
+}
+
+int main(void) {
+    const struct CMUnitTest tests[] = {
+        cmocka_unit_test(
+            test_count_shards_rejects_group_threshold_above_group_count),
+        cmocka_unit_test(
+            test_count_shards_rejects_member_threshold_above_member_count),
+    };
+    return cmocka_run_group_tests(tests, NULL, NULL);
+}

--- a/tests/unit/tests/sskr_generate_bound_groups.c
+++ b/tests/unit/tests/sskr_generate_bound_groups.c
@@ -1,0 +1,154 @@
+/*
+ * Regression test for the missing upper bound on `groups_len` in
+ * bolos_ux_sskr_generate() and bolos_ux_sskr_size_get() (seed_sskr.c).
+ *
+ * Both functions declare a fixed-size local array
+ *
+ *     sskr_group_descriptor_t groups[SSKR_MAX_GROUP_COUNT];
+ *
+ * and fill it in a loop bounded only by the caller-supplied `groups_len`,
+ * never checked against SSKR_MAX_GROUP_COUNT (1 in this port) before the
+ * loop runs. sskr_count_shards(), called afterwards, validates other things
+ * but never this. A groups_len above SSKR_MAX_GROUP_COUNT writes past the
+ * end of `groups` -- a real stack overflow -- before any other check has a
+ * chance to run.
+ *
+ * Not reachable today: the only existing caller,
+ * bolos_ux_bip39_to_sskr_convert() (same file), hard-codes groups_len = 1.
+ * Both are public entry points nonetheless, same standing as the other
+ * defensive bounds already added elsewhere in this file's callees (see
+ * sskr_shard_count.c, sskr_generate_split_error.c).
+ *
+ * Verification technique: these are plain indexed writes (`groups[i].x =
+ * ...`), not a memzero()/explicit_bzero() call, so -- unlike the
+ * memzero-based overrun in sss_recover_erase_length.c, which this
+ * toolchain's ASan does not catch -- AddressSanitizer's ordinary
+ * stack-buffer-overflow instrumentation does apply here. Confirmed by
+ * running this file under ASan before the fix: it aborts with a
+ * stack-buffer-overflow report at the `groups[i].threshold = ...` store,
+ * exactly like the existing test_sskr_combine_bounds target. A
+ * canary-struct technique (sss_recover_erase_length.c's approach) does not
+ * apply: `groups` is entirely local to the function under test, so no
+ * caller-supplied struct can be laid out adjacent to it.
+ *
+ * seed_sskr.c is compiled directly into this target (rather than linked)
+ * so ASan instruments its stack frames, matching test_sskr_combine_bounds.
+ */
+
+#include <cmocka.h>
+#include <setjmp.h>
+#include <stdarg.h>
+#include <stddef.h>
+#include <stdint.h>
+#include <string.h>
+
+#include "constants.h"
+#include "sskr/sskr-constants.h"
+#include "testutils.h"
+
+#define SECRET_LEN (SSKR_MIN_STRENGTH_BYTES)
+
+/* bolos_ux_sskr_generate() and bolos_ux_sskr_size_get() are public entry
+ * points (external linkage) but only ever called from within seed_sskr.c
+ * itself, so neither is declared in common_sskr.h. */
+extern int16_t bolos_ux_sskr_size_get(uint8_t bip39_type,
+                                      uint8_t groups_threshold,
+                                      unsigned int* group_descriptor,
+                                      uint8_t groups_len, uint8_t* share_len);
+
+extern unsigned int bolos_ux_sskr_generate(
+    uint8_t groups_threshold, unsigned int* group_descriptor,
+    uint8_t groups_len, unsigned char* seed, unsigned int seed_len,
+    uint8_t* share_len, unsigned char* share_buffer,
+    unsigned int share_buffer_len, uint8_t share_len_expected,
+    int16_t share_count_expected);
+
+/*
+ * One more group than `groups[SSKR_MAX_GROUP_COUNT]` (and hence
+ * SSKR_MAX_GROUP_COUNT itself) can hold. The values themselves do not
+ * matter -- the array-filling loop runs before any of them are used --
+ * only that groups_len exceeds the array's capacity.
+ */
+static void test_size_get_does_not_overrun_on_oversized_groups_len(
+    void** state) {
+    (void)state;
+
+    const unsigned int group_descriptor[] = {2, 2, 1, 1};
+    uint8_t share_len = 0;
+
+    /* No assertion on the return value: see the file header. The point is
+     * that this call completes without writing past `groups`. */
+    (void)bolos_ux_sskr_size_get(BIP39_MNEMONIC_SIZE_12, 1,
+                                 (unsigned int*)group_descriptor,
+                                 SSKR_MAX_GROUP_COUNT + 1, &share_len);
+}
+
+static void test_generate_does_not_overrun_on_oversized_groups_len(
+    void** state) {
+    (void)state;
+
+    const unsigned int group_descriptor[] = {2, 2, 1, 1};
+    uint8_t seed[SECRET_LEN] = {0};
+    uint8_t share_buffer[(SECRET_LEN + SSKR_METADATA_LENGTH_BYTES) * 4];
+    uint8_t share_len = 0;
+
+    (void)bolos_ux_sskr_generate(
+        1, (unsigned int*)group_descriptor, SSKR_MAX_GROUP_COUNT + 1, seed,
+        SECRET_LEN, &share_len, share_buffer, sizeof(share_buffer), 0, 0);
+}
+
+/*
+ * A groups_len at exactly the capacity must still be accepted, so that the
+ * fix cannot be an off-by-one that turns away the one configuration this
+ * port supports. share_len_expected/share_count_expected are computed the
+ * same way bolos_ux_bip39_to_sskr_convert() does: via bolos_ux_sskr_size_get()
+ * for the same descriptor.
+ */
+static void test_size_get_accepts_groups_len_at_capacity(void** state) {
+    (void)state;
+
+    const unsigned int group_descriptor[] = {1, 1};
+    uint8_t share_len = 0;
+
+    int16_t share_count = bolos_ux_sskr_size_get(
+        BIP39_MNEMONIC_SIZE_12, 1, (unsigned int*)group_descriptor,
+        SSKR_MAX_GROUP_COUNT, &share_len);
+
+    assert_int_equal(share_count, 1);
+    assert_int_equal(
+        share_len, BIP39_MNEMONIC_SIZE_12 * 4 / 3 + SSKR_METADATA_LENGTH_BYTES);
+}
+
+static void test_generate_accepts_groups_len_at_capacity(void** state) {
+    (void)state;
+
+    const unsigned int group_descriptor[] = {1, 1};
+    uint8_t seed[SECRET_LEN] = {0};
+    uint8_t share_buffer[(SECRET_LEN + SSKR_METADATA_LENGTH_BYTES) * 4] = {0};
+    uint8_t share_len = 0;
+    uint8_t share_len_expected = 0;
+
+    int16_t share_count_expected = bolos_ux_sskr_size_get(
+        BIP39_MNEMONIC_SIZE_12, 1, (unsigned int*)group_descriptor,
+        SSKR_MAX_GROUP_COUNT, &share_len_expected);
+
+    unsigned int share_count = bolos_ux_sskr_generate(
+        1, (unsigned int*)group_descriptor, SSKR_MAX_GROUP_COUNT, seed,
+        SECRET_LEN, &share_len, share_buffer, sizeof(share_buffer),
+        share_len_expected, share_count_expected);
+
+    assert_int_equal(share_count, 1);
+    assert_int_equal(share_len, SECRET_LEN + SSKR_METADATA_LENGTH_BYTES);
+}
+
+int main(void) {
+    const struct CMUnitTest tests[] = {
+        cmocka_unit_test(
+            test_size_get_does_not_overrun_on_oversized_groups_len),
+        cmocka_unit_test(
+            test_generate_does_not_overrun_on_oversized_groups_len),
+        cmocka_unit_test(test_size_get_accepts_groups_len_at_capacity),
+        cmocka_unit_test(test_generate_accepts_groups_len_at_capacity),
+    };
+    return cmocka_run_group_tests(tests, NULL, NULL);
+}

--- a/tests/unit/tests/sskr_generate_erase_on_split_failure.c
+++ b/tests/unit/tests/sskr_generate_erase_on_split_failure.c
@@ -1,0 +1,112 @@
+/*
+ * Coverage for the output-buffer erasure sskr_generate_shards() already
+ * performs when sss_split_secret() fails inside
+ * sskr_generate_shards_internal() (src/common/sskr/sskr.c):
+ *
+ *     int16_t split_error = sss_split_secret(...);
+ *     if (split_error < 0) {
+ *         memzero(member_shares/group_shares, ...);
+ *         return split_error;
+ *     }
+ *     ...
+ *     if (error) { memzero(output, buffer_size); return 0; }
+ *
+ * test_sskr_generate_split_error.c already covers this for a
+ * SSS_ERROR_TOO_MANY_SHARES failure (member-level split, an oversized
+ * group). This file adds two triggers that reach the same cleanup through
+ * a genuinely different failure inside sss_split_secret():
+ *
+ *   - member level: a real Shamir interpolation failure, forced the same
+ *     way as sss_recover_erase_length.c and the fix-2 combine test --
+ *     interpolate()'s own cx_bn_lock() fails immediately if a BN context
+ *     is already locked.
+ *   - group level: SSKR_MAX_GROUP_COUNT == 1 in this port, so the group
+ *     split's share_count is always 1, and sskr_count_shards() only
+ *     rejects group_threshold > groups_len -- group_threshold == 0 slips
+ *     through both that check and sskr_generate_shards_internal()'s own
+ *     `group_threshold > groups_len` guard (0 is not greater than
+ *     anything), reaching sss_split_secret(0, 1, ...), whose parameter
+ *     validation rejects threshold 0 outright (SSS_ERROR_INVALID_THRESHOLD).
+ *     This is the only way to make the *group*-level split fail in this
+ *     port: with groups_len fixed at 1, group_threshold <= groups_len
+ *     forces group_threshold to 1 for any threshold >= 1, which takes
+ *     sss_split_secret()'s threshold-1 shortcut (a plain copy) and never
+ *     reaches interpolate() at all, so cx_bn_lock() cannot force a failure
+ *     there. group_threshold == 0 is not reachable through the UI (the
+ *     only real caller, bolos_ux_bip39_to_sskr_convert(), hard-codes 1)
+ *     and sskr_count_shards() does not reject it either -- a minor,
+ *     already-benign validation gap (sss_split_secret() itself refuses it
+ *     safely), used here only as a trigger, not something this file fixes.
+ */
+
+#include <cmocka.h>
+#include <cx.h>
+#include <setjmp.h>
+#include <stdarg.h>
+#include <stddef.h>
+#include <stdint.h>
+#include <string.h>
+
+#include "sskr-constants.h"
+#include "sskr.h"
+#include "sss-constants.h"
+#include "testutils.h"
+
+#define SECRET_LEN (SSKR_MIN_STRENGTH_BYTES)
+#define BUFFER_LEN (64)
+
+static void test_generate_erases_output_on_member_level_interpolation_failure(
+    void** state) {
+    (void)state;
+
+    const uint8_t master_secret[SECRET_LEN] = {0};
+    const sskr_group_descriptor_t groups[] = {{.threshold = 2, .count = 2}};
+    uint8_t share_buffer[BUFFER_LEN];
+    uint8_t share_len;
+
+    memset(share_buffer, 0xFF, sizeof(share_buffer));
+
+    assert_int_equal(cx_bn_lock(1, 0), CX_OK);
+
+    int16_t result = sskr_generate_shards(1, groups, 1, master_secret,
+                                          SECRET_LEN, &share_len, share_buffer,
+                                          sizeof(share_buffer), cx_rng);
+
+    assert_int_equal(result, 0);
+
+    uint8_t expected[BUFFER_LEN];
+    memset(expected, 0x00, sizeof(expected));
+    assert_memory_equal(share_buffer, expected, sizeof(share_buffer));
+}
+
+static void test_generate_erases_output_on_group_level_split_failure(
+    void** state) {
+    (void)state;
+
+    const uint8_t master_secret[SECRET_LEN] = {0};
+    const sskr_group_descriptor_t groups[] = {{.threshold = 1, .count = 1}};
+    uint8_t share_buffer[BUFFER_LEN];
+    uint8_t share_len;
+
+    memset(share_buffer, 0xFF, sizeof(share_buffer));
+
+    int16_t result = sskr_generate_shards(0, groups, 1, master_secret,
+                                          SECRET_LEN, &share_len, share_buffer,
+                                          sizeof(share_buffer), cx_rng);
+
+    assert_int_equal(result, 0);
+
+    uint8_t expected[BUFFER_LEN];
+    memset(expected, 0x00, sizeof(expected));
+    assert_memory_equal(share_buffer, expected, sizeof(share_buffer));
+}
+
+int main(void) {
+    const struct CMUnitTest tests[] = {
+        cmocka_unit_test(
+            test_generate_erases_output_on_member_level_interpolation_failure),
+        cmocka_unit_test(
+            test_generate_erases_output_on_group_level_split_failure),
+    };
+    return cmocka_run_group_tests(tests, NULL, NULL);
+}


### PR DESCRIPTION
## Summary

Two defensive fixes in `src/common/sskr/`, each landed as a red/green test pair, plus a coverage-only commit on already-correct code.

- **`seed_sskr.c`** — `bolos_ux_sskr_generate()` and `bolos_ux_sskr_size_get()` both declare a local `groups[SSKR_MAX_GROUP_COUNT]` and fill it in a loop bounded only by the caller-supplied `groups_len`, never checked against `SSKR_MAX_GROUP_COUNT` before the loop runs — a `groups_len` above that (1 in this port) writes past the array. Not reachable today (the only existing caller hard-codes `groups_len = 1`), but fixed to match the equivalent guard the combine side already has (`sskr_combine_shards_internal()`'s `next_group >= SSKR_MAX_GROUP_COUNT` check).
- **`sskr.c`** — `sskr_combine_shards_internal()` cleans up its own working buffers on every failure but never touched the caller-supplied output `buffer`. Not a live leak with the current caller (it always passes a freshly-zeroed buffer), but a failed combine should leave its output buffer clean regardless, matching what the generation side already does on its own error path.

Both defects were only reachable through the library's public entry points, not through the UI as it exists today — same standing as prior defensive-bound fixes in this codebase.

## Tests

- `tests/sskr_generate_bound_groups.c` (new): reproduces the `groups_len` overflow under AddressSanitizer — confirmed a real `stack-buffer-overflow` abort before the fix — plus two at-capacity cases so the fix can't regress the one configuration this port supports.
- `tests/sskr_combine_erase_on_failure.c` (new): forces a genuine Shamir interpolation failure (locking the crypto BN context before the call, so `interpolate()`'s own lock attempt fails deterministically — same technique as the existing `sss_recover_erase_length.c`) and confirms a sentinel-filled output buffer is fully cleared despite the reported error. Failed on the buffer-content assertion before the fix.
- `tests/sskr_count_shards_invariants.c` and `tests/sskr_generate_erase_on_split_failure.c` (new, coverage-only, no production change): close a few previously-untested-but-already-correct invariants (invalid group/member thresholds, output erasure on a split failure reached through two different triggers). Commit message details two coverage items from the same pass that turned out to already be covered by existing tests, and why the equivalent internal checks on the combine side are unreachable dead code through their only call site.

## Verification

- Full unit suite: 28/28 passing.
- `clang-format --dry-run -Werror`: clean on all touched files.
- NBGL (`flex`) and BAGL (`nanox`) cross-compilation: both clean, zero warnings on `seed_sskr.c`/`sskr.c`.

## Limitations

Out of scope for this PR: a benign gap where `sskr_count_shards()` does not reject a `group_threshold` of 0 (used in one of the new coverage tests purely as a trigger — `sss_split_secret()`'s own parameter validation already refuses it safely, so nothing to fix). Also out of scope: two combine-side checks (`sskr_combine_shards_internal()`'s own zero-shard and oversized-member-set guards) that turned out to be dead code, unreachable through the function's only call site, which already rejects both conditions first.