### PR TITLE
tests: cover bip85_dice_roll() error paths

### DIFF
--- a/tests/unit/tests/bip85_dice_roll.c
+++ b/tests/unit/tests/bip85_dice_roll.c
@@ -84,11 +84,44 @@ static void test_dice_roll_extension_preserves_prior_rolls(void** state) {
                         sizeof(out_no_extension));
 }
 
+// out_capacity < rolls is checked before anything else -- the content of
+// seed/sides is irrelevant, and the function must return before writing
+// anything to out.
+static void test_dice_roll_rejects_insufficient_capacity(void** state) {
+    (void)state;
+
+    uint32_t out[5];
+    int32_t produced = bip85_dice_roll(out, 5, 2, 10, seed);
+
+    assert_int_equal(produced, -1);
+}
+
+// Each attempt re-derives the digest from scratch rather than accumulating
+// across attempts, so the most rolls any single attempt can ever produce is
+// bounded by its own digest length, not by the sum of all attempts. The
+// largest digest ever tried is BIP85_DRNG_MAX_DIGEST_SIZE (256) doubled
+// BIP85_DICE_MAX_DRNG_DOUBLINGS (3) times, i.e. 2048 bytes -- and at d2's
+// 100% acceptance rate (see the seed comment above), that is also the most
+// rolls that final attempt can produce. Asking for one more than that
+// (2049) therefore deterministically exhausts every attempt without ever
+// depending on chance.
+static void test_dice_roll_reports_drng_exhaustion(void** state) {
+    (void)state;
+
+    uint32_t out[2049];
+    int32_t produced =
+        bip85_dice_roll(out, sizeof(out) / sizeof(out[0]), 2, 2049, seed);
+
+    assert_int_equal(produced, -3);
+}
+
 int main(void) {
     const struct CMUnitTest tests[] = {
         cmocka_unit_test(test_dice_roll_extends_past_256_bytes),
         cmocka_unit_test(test_dice_roll_exact_when_well_under_capacity),
         cmocka_unit_test(test_dice_roll_extension_preserves_prior_rolls),
+        cmocka_unit_test(test_dice_roll_rejects_insufficient_capacity),
+        cmocka_unit_test(test_dice_roll_reports_drng_exhaustion),
     };
     return cmocka_run_group_tests(tests, NULL, NULL);
 }


### PR DESCRIPTION
## Summary

`bip85_dice_roll()` documents three possible error returns, but only its
success paths were exercised by the existing test file. This adds the two
that are testable without faking the crypto call:

- `out_capacity < rolls` -> `-1` (checked before anything else, trivial).
- DRNG stream exhaustion -> `-3`, made deterministic (not probabilistic) by
  reusing the file's existing `d2` trick (`sides = 2` has a 100% acceptance
  rate for any digest content): the largest digest this function will ever
  try is 2048 bytes, so `rolls = 2049` always exhausts every retry attempt
  regardless of seed content.

The third documented error (`-2`, SHAKE256 failure) is **not** covered: I
traced the call chain through the SDK
(`cx_shake256_hash` -> `cx_shake256_hash_iovec` -> `cx_shake256_init_no_throw`
/ `cx_sha3_update` / `cx_sha3_final`) and confirmed it cannot fail with the
fixed, always-valid parameters this function passes it -- constant seed
length, `digest_length` always a clean multiple of 8 bits, and an input far
too small to ever hit the hash's internal 65535-block counter limit. There
is no way to trigger this path without faking the crypto call, so it is
left undocumented-by-test rather than worked around.

This is pure coverage on code that is already correct -- no behavior
changes.

## Test plan

- [x] Full unit test suite rebuilt from scratch in the `ledger-app-dev-tools`
  container: 24/24 tests pass, including the 2 new cases.
- [x] `clang-format --dry-run -Werror` clean on the touched file.
- [x] No `src/` file touched, so no NBGL/BAGL cross-compilation needed.