### PR TITLE
tests: cover BIP85 password truncation bounds and DRNG-with-seed

### DIFF
--- a/src/common/bip85/seed_bip85.c
+++ b/src/common/bip85/seed_bip85.c
@@ -23,6 +23,7 @@
 
 #ifdef HAVE_SHA3
 #include <lcx_sha3.h>
+#include <os.h>
 #endif
 
 /**
@@ -148,6 +149,41 @@ int32_t bip85_dice_roll(uint32_t* out, size_t out_capacity, uint32_t sides,
     return result;
 }
 
+/**
+ * @brief Generates a random digest using SHAKE-256.
+ *
+ * @details This function generates a random digest of the specified length
+ * using the SHAKE-256 hash function, seeded with the provided seed data.
+ *
+ * Kept outside the `HAVE_NBGL` guard below, and with external linkage,
+ * purely so it can be linked into a unit test against the real
+ * `cx_shake256_hash()` -- pure software, no BOLOS syscall, taking `seed` as a
+ * raw byte buffer rather than deriving it from the device via
+ * `bolos_ux_bip85_entropy()` (which `bolos_ux_bip85_drng_test()` below does,
+ * and which cannot be tested on host). Same pattern as `bip85_dice_roll()`
+ * above, which calls the same `cx_shake256_hash()`.
+ *
+ * @param[out] digest         Pointer to the buffer to store the generated
+ * digest.
+ * @param[in]  digest_length  Length of the digest in bytes.
+ * @param[in]  seed           Pointer to the seed data.
+ * @param[in]  seed_length    Length of the seed data in bytes.
+ *
+ * @return 1 on success, 0 on failure.
+ */
+bool bolos_ux_bip85_drng_with_seed(uint8_t* seed, size_t seed_length,
+                                   uint8_t* digest, size_t digest_length) {
+    LEDGER_ASSERT(digest_length <= BIP85_DRNG_MAX_DIGEST_SIZE,
+                  "BIP85 DRNG digest length exceeds maximum");
+    if (cx_shake256_hash(seed, seed_length, digest, digest_length) != CX_OK) {
+        PRINTF("SHAKE256 hash error\n");
+        return 0;
+    }
+    PRINTF("BIP85 DRNG output: %u bytes\n", digest_length);
+
+    return 1;
+}
+
 #endif  // HAVE_SHA3
 
 #ifdef HAVE_HMAC
@@ -263,33 +299,6 @@ bool bolos_ux_bip85_entropy(uint8_t* entropy, const unsigned int* path,
         LEDGER_ASSERT(false, "HMAC failed");
     }
     PRINTF("BIP85 entropy from root key: %u bytes\n", BIP85_ENTROPY_LENGTH);
-
-    return 1;
-}
-
-/**
- * @brief Generates a random digest using SHAKE-256.
- *
- * @details This function generates a random digest of the specified length
- * using the SHAKE-256 hash function, seeded with the provided seed data.
- *
- * @param[out] digest         Pointer to the buffer to store the generated
- * digest.
- * @param[in]  digest_length  Length of the digest in bytes.
- * @param[in]  seed           Pointer to the seed data.
- * @param[in]  seed_length    Length of the seed data in bytes.
- *
- * @return 1 on success, 0 on failure.
- */
-bool bolos_ux_bip85_drng_with_seed(uint8_t* seed, size_t seed_length,
-                                   uint8_t* digest, size_t digest_length) {
-    LEDGER_ASSERT(digest_length <= BIP85_DRNG_MAX_DIGEST_SIZE,
-                  "BIP85 DRNG digest length exceeds maximum");
-    if (cx_shake256_hash(seed, seed_length, digest, digest_length) != CX_OK) {
-        PRINTF("SHAKE256 hash error\n");
-        return 0;
-    }
-    PRINTF("BIP85 DRNG output: %u bytes\n", digest_length);
 
     return 1;
 }

--- a/src/common/bip85/seed_bip85.c
+++ b/src/common/bip85/seed_bip85.c
@@ -193,6 +193,31 @@ bool bip85_entropy_from_key(const uint8_t key[32], uint8_t* out,
 }
 #endif  // HAVE_HMAC
 
+/**
+ * @brief Copies the first `pwd_len` bytes of an encoded password buffer into
+ * the caller's output buffer and NUL-terminates it.
+ *
+ * @details Kept outside the `HAVE_NBGL` guard below, and with external
+ * linkage, purely so it can be linked into a unit test: `buffer_pwd` comes
+ * from `base64_encode_64bytes()`/`base85_encode_64bytes()`, already tested
+ * directly, but this final truncation-and-terminate step -- the one that
+ * previously had a missing `pwd[pwd_len] = '\0';` on the Base64 side -- had
+ * no test of its own. Same pattern as `bip85_dice_roll()`/
+ * `bip85_entropy_from_key()` above.
+ *
+ * @param[in]  buffer_pwd  Fully encoded password, at least `pwd_len` bytes.
+ * @param[out] pwd         Buffer to receive the truncated, NUL-terminated
+ * password; must have room for `pwd_len + 1` bytes.
+ * @param[in]  pwd_len     Number of bytes to copy from `buffer_pwd`.
+ *
+ * @return `pwd_len`.
+ */
+uint8_t bip85_finalize_pwd(const char* buffer_pwd, char* pwd, uint8_t pwd_len) {
+    memcpy(pwd, buffer_pwd, pwd_len);
+    pwd[pwd_len] = '\0';  // Add string termination character
+    return pwd_len;
+}
+
 #if defined(HAVE_NBGL)
 #include <lcx_hmac.h>
 #include <lcx_sha3.h>
@@ -377,8 +402,7 @@ uint8_t bolos_ux_bip85_pwd_base64(char* pwd, uint8_t pwd_len,
         LEDGER_ASSERT(false, "Base64 encoding failed");
     }
 
-    memcpy(pwd, buffer_pwd, pwd_len);
-    pwd[pwd_len] = '\0';  // Add string termination character
+    bip85_finalize_pwd(buffer_pwd, pwd, pwd_len);
 
     memzero(buffer_ent, BIP85_ENTROPY_LENGTH);
     memzero(buffer_pwd, BASE64_ENCODE_LENGTH);
@@ -411,8 +435,7 @@ uint8_t bolos_ux_bip85_pwd_base85(char* pwd, uint8_t pwd_len,
         LEDGER_ASSERT(false, "Base85 encoding failed");
     }
 
-    memcpy(pwd, buffer_pwd, pwd_len);
-    pwd[pwd_len] = '\0';  // Add string termination character
+    bip85_finalize_pwd(buffer_pwd, pwd, pwd_len);
 
     memzero(buffer_ent, BIP85_ENTROPY_LENGTH);
     memzero(buffer_pwd, BASE85_ENCODE_LENGTH);

--- a/tests/unit/CMakeLists.txt
+++ b/tests/unit/CMakeLists.txt
@@ -319,6 +319,16 @@ target_compile_definitions(test_bip85_dice_roll PRIVATE HAVE_SHA3)
 target_include_directories(test_bip85_dice_roll PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/../../src $ENV{LEDGER_SECURE_SDK})
 target_link_libraries(test_bip85_dice_roll PUBLIC cmocka gcov testutils)
 
+# bolos_ux_bip85_drng_with_seed() (also outside the HAVE_NBGL guard, moved
+# there alongside bip85_dice_roll() since it needs the same HAVE_SHA3
+# cx_shake256_hash()) takes its seed as a raw byte buffer rather than
+# deriving it via bolos_ux_bip85_entropy() -- no BOLOS syscall, same
+# reasoning and same compilation pattern as test_bip85_dice_roll above.
+add_executable(test_bip85_drng_with_seed tests/bip85_drng_with_seed.c ../../src/common/bip85/seed_bip85.c $ENV{LEDGER_SECURE_SDK}/src/cx_hash_iovec.c)
+target_compile_definitions(test_bip85_drng_with_seed PRIVATE HAVE_SHA3)
+target_include_directories(test_bip85_drng_with_seed PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/../../src $ENV{LEDGER_SECURE_SDK})
+target_link_libraries(test_bip85_drng_with_seed PUBLIC cmocka gcov testutils)
+
 # bip85_entropy_from_key() (also outside the HAVE_NBGL guard) is the
 # HMAC-SHA512("bip-entropy-from-k", key) half of bolos_ux_bip85_entropy();
 # the BIP32 derivation that produces `key` is a BOLOS syscall
@@ -350,6 +360,6 @@ add_executable(test_bip85_finalize_pwd tests/bip85_finalize_pwd.c ../../src/comm
 target_include_directories(test_bip85_finalize_pwd PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/../../src)
 target_link_libraries(test_bip85_finalize_pwd PUBLIC cmocka gcov testutils)
 
-foreach(target test_sss test_sss_recover_erase_length test_sskr test_sskr_share_len test_sskr_memzero test_sskr_shard_count test_sskr_generate_split_error test_sskr_generate_bound_groups test_sskr_combine_erase_on_failure test_sskr_count_shards_invariants test_sskr_generate_erase_on_split_failure test_sskr_combine_bounds test_sskr_combine_error test_sskr_combine_invariants test_sskr_interop_bc128 test_sskr_interop_bc128_bytewords test_sskr_entry_bounds test_sskr_byteword_sentinel test_sskr_cbor_additional_info test_bip39 test_roundtrip test_words test_base64 test_base85 test_bip85_dice_bits_per_roll test_bip85_dice_roll test_bip85_bip39_entropy test_bip85_hex_vector test_bip85_finalize_pwd)
+foreach(target test_sss test_sss_recover_erase_length test_sskr test_sskr_share_len test_sskr_memzero test_sskr_shard_count test_sskr_generate_split_error test_sskr_generate_bound_groups test_sskr_combine_erase_on_failure test_sskr_count_shards_invariants test_sskr_generate_erase_on_split_failure test_sskr_combine_bounds test_sskr_combine_error test_sskr_combine_invariants test_sskr_interop_bc128 test_sskr_interop_bc128_bytewords test_sskr_entry_bounds test_sskr_byteword_sentinel test_sskr_cbor_additional_info test_bip39 test_roundtrip test_words test_base64 test_base85 test_bip85_dice_bits_per_roll test_bip85_dice_roll test_bip85_bip39_entropy test_bip85_hex_vector test_bip85_finalize_pwd test_bip85_drng_with_seed)
     add_test(NAME ${target} COMMAND ${target})
 endforeach()

--- a/tests/unit/CMakeLists.txt
+++ b/tests/unit/CMakeLists.txt
@@ -340,6 +340,16 @@ add_executable(test_bip85_hex_vector tests/bip85_hex_vector.c ../../src/common/b
 target_include_directories(test_bip85_hex_vector PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/../../src)
 target_link_libraries(test_bip85_hex_vector PUBLIC cmocka gcov testutils)
 
-foreach(target test_sss test_sss_recover_erase_length test_sskr test_sskr_share_len test_sskr_memzero test_sskr_shard_count test_sskr_generate_split_error test_sskr_generate_bound_groups test_sskr_combine_erase_on_failure test_sskr_count_shards_invariants test_sskr_generate_erase_on_split_failure test_sskr_combine_bounds test_sskr_combine_error test_sskr_combine_invariants test_sskr_interop_bc128 test_sskr_interop_bc128_bytewords test_sskr_entry_bounds test_sskr_byteword_sentinel test_sskr_cbor_additional_info test_bip39 test_roundtrip test_words test_base64 test_base85 test_bip85_dice_bits_per_roll test_bip85_dice_roll test_bip85_bip39_entropy test_bip85_hex_vector)
+# bip85_finalize_pwd() (also outside the HAVE_NBGL guard) is the
+# memcpy-and-terminate tail shared by bolos_ux_bip85_pwd_base64()/
+# bolos_ux_bip85_pwd_base85(); no crypto dependency, so no extra compile
+# definitions are needed beyond the globally-defined HAVE_HMAC (already
+# required to link bip85_entropy_from_key(), also in this file, same as
+# test_bip85_dice_bits_per_roll above).
+add_executable(test_bip85_finalize_pwd tests/bip85_finalize_pwd.c ../../src/common/bip85/seed_bip85.c)
+target_include_directories(test_bip85_finalize_pwd PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/../../src)
+target_link_libraries(test_bip85_finalize_pwd PUBLIC cmocka gcov testutils)
+
+foreach(target test_sss test_sss_recover_erase_length test_sskr test_sskr_share_len test_sskr_memzero test_sskr_shard_count test_sskr_generate_split_error test_sskr_generate_bound_groups test_sskr_combine_erase_on_failure test_sskr_count_shards_invariants test_sskr_generate_erase_on_split_failure test_sskr_combine_bounds test_sskr_combine_error test_sskr_combine_invariants test_sskr_interop_bc128 test_sskr_interop_bc128_bytewords test_sskr_entry_bounds test_sskr_byteword_sentinel test_sskr_cbor_additional_info test_bip39 test_roundtrip test_words test_base64 test_base85 test_bip85_dice_bits_per_roll test_bip85_dice_roll test_bip85_bip39_entropy test_bip85_hex_vector test_bip85_finalize_pwd)
     add_test(NAME ${target} COMMAND ${target})
 endforeach()

--- a/tests/unit/lib/testutils.c
+++ b/tests/unit/lib/testutils.c
@@ -1,7 +1,20 @@
-#include <stdint.h>
+#include <stdbool.h>
 #include <stddef.h>
+#include <stdint.h>
+#include <stdlib.h>
 
 #include "bolos/cxlib.h"
+
+// LEDGER_ASSERT() calls this on a failing condition (see the SDK's
+// ledger_assert_internals.h). The SDK's own unit tests stub this the same
+// way (unit-tests/lib_tlv/mock_os.c) but with exit(0); this uses exit(1)
+// instead so that a LEDGER_ASSERT unexpectedly firing inside any function
+// linked into a test target makes ctest report a failure, rather than the
+// process silently exiting 0 with no cmocka summary printed.
+void assert_exit(bool confirm) {
+    (void)confirm;
+    exit(1);
+}
 
 // Fake random generator used only for testing
 void cx_rng_no_throw(uint8_t *buffer, size_t len)

--- a/tests/unit/tests/bip85_drng_with_seed.c
+++ b/tests/unit/tests/bip85_drng_with_seed.c
@@ -1,0 +1,76 @@
+#include <cmocka.h>
+#include <lcx_sha3.h>
+#include <setjmp.h>
+#include <stdarg.h>
+#include <stddef.h>
+#include <stdint.h>
+#include <string.h>
+
+#define BIP85_DRNG_MAX_DIGEST_SIZE 256
+
+extern bool bolos_ux_bip85_drng_with_seed(uint8_t* seed, size_t seed_length,
+                                          uint8_t* digest,
+                                          size_t digest_length);
+
+static uint8_t seed[] = {0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08,
+                         0x09, 0x0a, 0x0b, 0x0c, 0x0d, 0x0e, 0x0f, 0x10,
+                         0x11, 0x12, 0x13, 0x14, 0x15, 0x16, 0x17, 0x18,
+                         0x19, 0x1a, 0x1b, 0x1c, 0x1d, 0x1e, 0x1f, 0x20};
+
+// bolos_ux_bip85_drng_with_seed() is a thin wrapper around cx_shake256_hash()
+// -- no derivation, no BOLOS syscall -- so its output for a given
+// seed/digest_length is checked directly against an independent call to the
+// same real cx_shake256_hash(), rather than against a second BIP85 helper:
+// there is no simpler oracle than the function it wraps.
+static void test_drng_with_seed_matches_cx_shake256_hash(void** state) {
+    (void)state;
+
+    uint8_t digest[64];
+    uint8_t expected[sizeof(digest)];
+
+    bool ok = bolos_ux_bip85_drng_with_seed(seed, sizeof(seed), digest,
+                                            sizeof(digest));
+    assert_true(ok);
+
+    assert_int_equal(
+        cx_shake256_hash(seed, sizeof(seed), expected, sizeof(expected)),
+        CX_OK);
+    assert_memory_equal(digest, expected, sizeof(digest));
+}
+
+// digest_length == BIP85_DRNG_MAX_DIGEST_SIZE is the upper bound the
+// LEDGER_ASSERT allows (`digest_length <= BIP85_DRNG_MAX_DIGEST_SIZE`) --
+// exercised here rather than only an arbitrary smaller length, since it is
+// the one value where the assert's condition is exactly true rather than
+// slack.
+static void test_drng_with_seed_accepts_max_digest_size(void** state) {
+    (void)state;
+
+    uint8_t digest[BIP85_DRNG_MAX_DIGEST_SIZE];
+    uint8_t expected[sizeof(digest)];
+
+    bool ok = bolos_ux_bip85_drng_with_seed(seed, sizeof(seed), digest,
+                                            sizeof(digest));
+    assert_true(ok);
+
+    assert_int_equal(
+        cx_shake256_hash(seed, sizeof(seed), expected, sizeof(expected)),
+        CX_OK);
+    assert_memory_equal(digest, expected, sizeof(digest));
+}
+
+// digest_length > BIP85_DRNG_MAX_DIGEST_SIZE is deliberately not exercised:
+// that path is a LEDGER_ASSERT, not a returned error, and LEDGER_ASSERT
+// terminates the process on this host build -- same as every other
+// LEDGER_ASSERT-guarded path in this file (e.g. the entropy-derivation
+// asserts). There is no return value or output buffer left to assert on
+// afterwards, only a crashed test binary. Documented here rather than
+// worked around.
+
+int main(void) {
+    const struct CMUnitTest tests[] = {
+        cmocka_unit_test(test_drng_with_seed_matches_cx_shake256_hash),
+        cmocka_unit_test(test_drng_with_seed_accepts_max_digest_size),
+    };
+    return cmocka_run_group_tests(tests, NULL, NULL);
+}

--- a/tests/unit/tests/bip85_finalize_pwd.c
+++ b/tests/unit/tests/bip85_finalize_pwd.c
@@ -1,0 +1,93 @@
+#include <cmocka.h>
+#include <setjmp.h>
+#include <stdarg.h>
+#include <stddef.h>
+#include <stdint.h>
+#include <string.h>
+
+#define BASE64_ENCODE_LENGTH 88
+#define BASE85_ENCODE_LENGTH 80
+
+extern uint8_t bip85_finalize_pwd(const char* buffer_pwd, char* pwd,
+                                  uint8_t pwd_len);
+
+// Same fully-encoded vectors as tests/base64.c/base85.c -- already verified
+// there against base64_encode_64bytes()/base85_encode_64bytes() directly.
+// bip85_finalize_pwd() only ever sees this kind of fully-encoded buffer as
+// input, so reusing it here (rather than an arbitrary string) keeps this
+// test representative of the real call site.
+static const char base64_encoded[] =
+    "dKLoepugzdVJvdL56ogNVUxsNVsI7SUIjPqI8/"
+    "HE90YytlL9So9f2kMHTG9pZKN1Owi7UhDI9edcB6TCogv26Q==";
+static const char base85_encoded[] =
+    "_s`{TW89)i4`uwnp5{Hxh0%|78*5%18;3KmWLe1sr(S}zqAvgWx#peX6iX>OsBuFXpj5WYRf1}"
+    "cQ9@D)";
+
+#define SENTINEL 0xaa
+
+// pwd_len 20 and 86 (== BASE64_ENCODE_LENGTH - 2) are the user-facing length
+// bounds of bolos_ux_bip85_pwd_base64() (seed_bip85.c). The destination is
+// prefilled with a sentinel byte across its whole capacity so that both "did
+// it copy the right prefix" and "did it touch anything past pwd_len + 1" are
+// checked in the same test.
+static void test_finalize_pwd_base64_length(uint8_t pwd_len) {
+    char pwd[BASE64_ENCODE_LENGTH];
+    memset(pwd, SENTINEL, sizeof(pwd));
+
+    uint8_t returned = bip85_finalize_pwd(base64_encoded, pwd, pwd_len);
+
+    assert_int_equal(returned, pwd_len);
+    assert_memory_equal(pwd, base64_encoded, pwd_len);
+    assert_int_equal((uint8_t)pwd[pwd_len], 0);
+    for (size_t i = (size_t)pwd_len + 1; i < sizeof(pwd); i++) {
+        assert_int_equal((uint8_t)pwd[i], SENTINEL);
+    }
+}
+
+static void test_finalize_pwd_base64_min_length(void** state) {
+    (void)state;
+    test_finalize_pwd_base64_length(20);
+}
+
+static void test_finalize_pwd_base64_max_length(void** state) {
+    (void)state;
+    test_finalize_pwd_base64_length(BASE64_ENCODE_LENGTH - 2);
+}
+
+// pwd_len 10 and 80 (== BASE85_ENCODE_LENGTH) are the user-facing length
+// bounds of bolos_ux_bip85_pwd_base85() (seed_bip85.c). At pwd_len ==
+// BASE85_ENCODE_LENGTH there is no room left in `pwd` for a sentinel past
+// `pwd_len + 1`, so this case only checks the copy and the terminator.
+static void test_finalize_pwd_base85_length(uint8_t pwd_len) {
+    char pwd[BASE85_ENCODE_LENGTH + 1];
+    memset(pwd, SENTINEL, sizeof(pwd));
+
+    uint8_t returned = bip85_finalize_pwd(base85_encoded, pwd, pwd_len);
+
+    assert_int_equal(returned, pwd_len);
+    assert_memory_equal(pwd, base85_encoded, pwd_len);
+    assert_int_equal((uint8_t)pwd[pwd_len], 0);
+    for (size_t i = (size_t)pwd_len + 1; i < sizeof(pwd); i++) {
+        assert_int_equal((uint8_t)pwd[i], SENTINEL);
+    }
+}
+
+static void test_finalize_pwd_base85_min_length(void** state) {
+    (void)state;
+    test_finalize_pwd_base85_length(10);
+}
+
+static void test_finalize_pwd_base85_max_length(void** state) {
+    (void)state;
+    test_finalize_pwd_base85_length(BASE85_ENCODE_LENGTH);
+}
+
+int main(void) {
+    const struct CMUnitTest tests[] = {
+        cmocka_unit_test(test_finalize_pwd_base64_min_length),
+        cmocka_unit_test(test_finalize_pwd_base64_max_length),
+        cmocka_unit_test(test_finalize_pwd_base85_min_length),
+        cmocka_unit_test(test_finalize_pwd_base85_max_length),
+    };
+    return cmocka_run_group_tests(tests, NULL, NULL);
+}


### PR DESCRIPTION
## What this changes

Two independent pieces of BIP-85 unit coverage that had each been wrongly
filed as untestable in their entirety, when only part of each actually is.

**Part 1 — password truncation at the user-facing length bounds.**
`bolos_ux_bip85_pwd_base64()`/`bolos_ux_bip85_pwd_base85()` derive entropy
via the on-device syscall, so they've always been treated as untestable as
a whole. But their very last step — copying the encoded password into the
caller's buffer and NUL-terminating it — has no syscall dependency at all:
the buffer it copies from is already covered directly by the existing
`base64.c`/`base85.c` tests. This step is extracted into
`bip85_finalize_pwd()` (mechanical move, no behavior change) and tested at
the user-facing length bounds (20 and 86 for Base64, 10 and 80 for
Base85), which is exactly the length matrix that had been deferred to the
hardware campaign under the assumption that the whole function needed a
device.

**Part 2 — `bolos_ux_bip85_drng_with_seed()`.** Never tested before,
despite taking its seed as a plain byte buffer with no syscall involved —
unlike its only caller, which does derive that seed from the device. Moved
outside the `HAVE_NBGL` guard (same pattern already used for
`bip85_dice_roll()`) so it can be linked into a host unit test, and
checked against an independent call to the same `cx_shake256_hash()` it
wraps.

## Why

Both functions had a testable software core hiding behind a syscall-only
label. Part 1 in particular closes a real blind spot: this exact
truncate-and-terminate step is where a missing NUL terminator once shipped
on the Base64 side (fixed in a previous PR, without a regression test at
the time, since the step wasn't separated out yet).

## Branch and scope

- Base SHA: `fac28f3`
- Target branch: `bip85`
- Devices: host unit tests only; Flex (NBGL) cross-compiled to confirm no
  production regression, no BAGL variant to check (this file is
  NBGL-only)
- UI stack: common (`src/common/bip85/seed_bip85.c`)

## Security properties

- Remote channel: none
- Host-controlled input: none (test-only changes; the one production
  change is a mechanical extraction with no altered control flow)
- Secret output: unchanged — both extracted functions preserve the exact
  same reads/writes as before the move
- NVM writes: none
- Memory-safety impact: none

## Commits

1. `bip85: extract password truncation into bip85_finalize_pwd()` —
   mechanical, no behavior change
2. `tests: cover BIP85 password truncation at the user-facing length
   bounds`
3. `bip85: move bolos_ux_bip85_drng_with_seed() outside the HAVE_NBGL
   guard` — mechanical, no behavior change; also adds the `assert_exit()`
   stub the test harness needs the first time a `LEDGER_ASSERT`-calling
   function gets linked into a host test
4. `tests: cover bolos_ux_bip85_drng_with_seed()`

## Verification

| Check | Command | Result |
|---|---|---|
| Unit | `cmake -B build -H. && make -C build && ctest` (ledger-app-dev-tools) | 30/30 pass (26 pre-existing + 4 new) |
| Lint | `clang-format --dry-run -Werror` on all touched files | clean |
| Builds | Flex (NBGL), `ledger-app-builder-lite`, full clean rebuild | pass, 0 warnings |
| Speculos | not applicable | not run |
| Hardware | not applicable | not run |

## Before and after

For the password-truncation tests: temporarily removing the
`pwd[pwd_len] = '\0';` line (the historical bug) makes all four new tests
fail with the destination's prefilled sentinel byte instead of a NUL
terminator; restoring the line makes them pass again.

## Limitations

- The actual BIP32 derivation (`os_derive_bip32_no_throw()`, the syscall
  both `bolos_ux_bip85_pwd_base64/85()` and `bolos_ux_bip85_drng_test()`
  depend on for their seed) remains untested here — no host
  implementation exists, tracked separately for the hardware campaign.
- `digest_length > BIP85_DRNG_MAX_DIGEST_SIZE` in
  `bolos_ux_bip85_drng_with_seed()` is a `LEDGER_ASSERT`, not a returned
  error; it terminates the process rather than leaving anything to assert
  on, so it isn't exercised — documented in the test file rather than
  worked around.

## Follow-up

None expected on this branch; the remaining BIP-85 password/DRNG surface
that depends on the on-device derivation stays in the hardware campaign.
