### PR TITLE
tests/speculos: verify the mnemonic buffer is clear across an app close/reopen

### DIFF
--- a/tests/speculos/README.md
+++ b/tests/speculos/README.md
@@ -20,6 +20,7 @@ touching secret-buffer lifecycle code in the NBGL UI layer.
   - [Check 3 — SSKR share entry buffer, cancel mid-entry](#check-3--sskr-share-entry-buffer-cancel-mid-entry)
   - [Check 4 — Generated SSKR shares, dashboard return](#check-4--generated-sskr-shares-dashboard-return)
   - [Check 5 — Generated BIP-85 BIP39 output, dashboard return](#check-5--generated-bip-85-bip39-output-dashboard-return)
+  - [Check 6 — App reopen clears the mnemonic buffer](#check-6--app-reopen-clears-the-mnemonic-buffer)
 - [Gotchas](#gotchas)
   - [1. The published Speculos debug image is broken](#1-the-published-speculos-debug-image-is-broken)
   - [2. A live GDB connection freezes the app unless SIGILL is passed through](#2-a-live-gdb-connection-freezes-the-app-unless-sigill-is-passed-through)
@@ -38,6 +39,7 @@ touching secret-buffer lifecycle code in the NBGL UI layer.
 | `verify_sskr_share_cancel_clears_buffer.py` | Check 3 — SSKR share entry, cancel mid-word. |
 | `verify_sskr_generated_shares_dashboard_return.py` | Check 4 — generated SSKR shares, dashboard return. |
 | `verify_bip85_bip39_output_cleanup.py` | Check 5 — generated BIP-85 BIP39 output, dashboard return. |
+| `verify_app_reopen_clears_mnemonic.py` | Check 6 — app reopen, no residual mnemonic across a close/reopen. |
 
 ## Prerequisites
 
@@ -58,6 +60,7 @@ python3 tests/speculos/verify_compare_recovery_phrase_cleanup.py
 python3 tests/speculos/verify_sskr_share_cancel_clears_buffer.py
 python3 tests/speculos/verify_sskr_generated_shares_dashboard_return.py
 python3 tests/speculos/verify_bip85_bip39_output_cleanup.py
+python3 tests/speculos/verify_app_reopen_clears_mnemonic.py
 ```
 
 | Script | Typical duration | Why |
@@ -67,6 +70,7 @@ python3 tests/speculos/verify_bip85_bip39_output_cleanup.py
 | Check 3 (SSKR cancel) | A few minutes | Types one word plus a couple of letters. |
 | Check 4 (generated shares) | 15–30+ minutes | Types the full 12-word mnemonic, then generates and pages through 3 shares. |
 | Check 5 (BIP-85 BIP39 output) | A few minutes | Button taps and one numeric-keypad entry only, no mnemonic typing. |
+| Check 6 (app reopen) | 15–30+ minutes | Types and confirms a full 12-word mnemonic, then boots a second container. |
 
 The long runs are not hangs. Every guest syscall round-trips through this
 script while GDB is attached (see gotcha 2), and individual keystroke
@@ -82,21 +86,26 @@ curl -s 'http://localhost:5002/events?currentscreenonly=true' | python3 -m json.
 (the `"Enter word n. X/12..."` text shows exactly which word is in
 progress; the API port differs per script — see each script's `API_PORT`).
 
-All five scripts print a snapshot table and a `PASS`/`FAIL` line, exit 1 on
-failure, and always tear down their own Speculos container
+All six scripts print a snapshot table and a `PASS`/`FAIL` line, exit 1 on
+failure, and always tear down their own Speculos container(s)
 (`speculos-bip39-cancel-test` / `speculos-compare-recovery-phrase-cleanup-test`
 / `speculos-sskr-cancel-test` / `speculos-sskr-generated-shares-reset-test`
-/ `speculos-bip85-bip39-output-cleanup-test`). Safe to re-run, and safe to
-Ctrl-C — though a stray container may need `docker rm -f <name>` after a
-hard interrupt.
+/ `speculos-bip85-bip39-output-cleanup-test` /
+`speculos-app-reopen-test-1`+`speculos-app-reopen-test-2`, check 6 being the
+one script that runs two containers, one after the other). Safe to re-run,
+and safe to Ctrl-C — though a stray container may need `docker rm -f <name>`
+after a hard interrupt.
 
 ## Checks
 
 Each check follows the same shape: what screen/flow it drives, which
 function actually does the clearing (confirmed by reading the code, never
-assumed), and what a real failure looks like. All four read memory via
+assumed), and what a real failure looks like. All read memory via
 synchronous breakpoints, not a timing-based sample — a reported `FAIL` is a
-real regression, not flakiness.
+real regression, not flakiness. Check 6 is the one exception to "which
+function actually does the clearing": it verifies a platform guarantee (RAM
+reset across an app close/reopen), not this app's own cleanup code — see its
+section below for why that distinction matters.
 
 ### Check 1 — BIP39 mnemonic buffer, cancel mid-entry
 
@@ -347,6 +356,77 @@ assumed uniform because they get wiped from the same reset path.
 after `bip85_app_reset()` fires — the script prints the offending bytes
 and distinguishes `app_data` from `mnemonic.buffer` explicitly.
 
+### Check 6 — App reopen clears the mnemonic buffer
+
+`verify_app_reopen_clears_mnemonic.py` is different in kind from checks 1-5.
+`git grep -n "nvm_write\|nvm_erase" -- src/` finds nothing: this app never
+writes to NVM/flash, so every secret buffer — the `mnemonic` global watched
+here included — lives exclusively in RAM. The only way a secret could
+survive an app close-then-reopen is if BOLOS does not actually reset that
+RAM when (re)loading the app process — a platform guarantee, not something
+this app's own code controls. This script verifies that guarantee
+empirically rather than looking for an application bug.
+
+Flow: start a first Speculos container, type and confirm all 12 words of the
+same test mnemonic used by check 2 (`fly mule excess resource treat plunge
+nose soda reflect adult ramp planet`) on "Check BIP39", then read the real
+`mnemonic` buffer at the return of `bip39_mnemonic_check()`
+(`src/nbgl/bip39_mnemonic.c`) — the point furthest into the flow where the
+buffer is still guaranteed to hold the full typed phrase, since that
+function deliberately does not reset it on a valid-checksum path ("Don't
+clear the mnemonic just yet as we may need it to generate BIP39 mnemonic").
+Tear that container down entirely, start a second, completely independent
+container from the same `app.elf` (no shared volumes/state with the first),
+and read the same global — its `R9`-relative address re-resolved from
+scratch, never assumed identical to the first session, see gotcha 4 — before
+any simulated user interaction, at the entry of `ui_idle_init()` /
+`display_home_page()` (`src/nbgl/ui.c`), the very first UI code a fresh
+process runs at boot.
+
+**Why `docker stop`/`rm` rather than tapping the real "Quit app" action,
+decided deliberately, not a shortcut for lack of trying:** `on_quit()`
+(`src/nbgl/ui.c`, `os_sched_exit(-1)`) is trivially reachable — confirmed
+empirically, it is a "Quit app" footer link directly on the home screen
+(`nbgl_useCaseHomeAndSettings`) — but reaching it from the
+just-confirmed-12-words state requires first navigating back to the
+dashboard, and `display_home_page()` unconditionally calls
+`reset_globals()` (→ `bip39_mnemonic_reset()`) as its first statement,
+before it ever draws that screen. Doing that would wipe the buffer with this
+app's own defense-in-depth code (already verified by checks 1/4/5) before
+the platform-level guarantee under test is ever exercised — a `PASS` reached
+that way would be ambiguous (clean because of BOLOS, or clean because of
+application code that had nothing to do with the platform question this
+script asks?). Tearing the first container down directly, right after the
+sanity-check read, keeps the buffer populated with real content up to the
+moment the first process actually disappears — the more rigorous test.
+Symmetrically, the second container's read point is deliberately
+`ui_idle_init()`'s entry rather than "as soon as GDB can attach": reading
+after `display_home_page()`'s own `reset_globals()` call would let this
+fresh process's own init code launder away whatever the loader actually
+left behind, which is exactly what this script needs to observe untouched.
+
+**On a real run**, the first container's buffer at `bip39_mnemonic_check()`
+return held the full typed phrase (88/324 bytes nonzero — the 73-byte phrase
+text plus the same non-secret bookkeeping tail documented in check 5:
+`length`/`current_word_index`/`word_lengths[]`/`final_size`):
+
+```
+666c79206d756c6520657863657373207265736f7572636520747265617420706c756e6765...
+```
+(decodes as `"fly mule excess resource treat plunge nose soda reflect adult
+ramp planet"`, followed by zero padding and the expected bookkeeping tail).
+The second container's buffer, read at `ui_idle_init()` entry before any
+interaction (with a freshly re-resolved `R9`, confirmed different from the
+first container's), was entirely zero (0/324 bytes nonzero) — `PASS`.
+
+**On a real failure** (any of the first session's 12 typed words present in
+the second container's buffer): do not treat this as a routine one-line
+application fix. Possible causes range from a test-infrastructure artifact
+(unintended shared state between the two Docker containers, a wrong address
+resolution reading the wrong buffer) to something genuinely significant
+about BOLOS's RAM loading/initialization under Speculos — either way, this
+warrants understanding before proposing any fix.
+
 ## Gotchas
 
 None of the following was documented anywhere before these scripts
@@ -487,7 +567,11 @@ Ragger's navigator/backend layer, and mixing the two would add coupling
 for no benefit in single-scenario scripts like these.
 
 `rsp_client.py` and the `MemorySampler` breakpoint-snapshot pattern are
-generic and are reused as-is across checks 1, 3, and 4 (all R9-relative
+generic and are reused as-is across checks 1, 3, 4, and 6 (all R9-relative
 globals) and adapted for check 2 (SP-relative stack locals, gotcha 5).
 They remain applicable to other secret-buffer-lifecycle scenarios, such as
 BIP-85 passwords, without needing to re-solve any of the gotchas above.
+Check 6 additionally shows the pattern extends cleanly to a two-container
+scenario (a "before" process and an independent "after" process) with no new
+Speculos/GDB gotcha of its own — only the address re-resolution already
+required per-run by gotcha 4.

--- a/tests/speculos/verify_app_reopen_clears_mnemonic.py
+++ b/tests/speculos/verify_app_reopen_clears_mnemonic.py
@@ -1,0 +1,509 @@
+#!/usr/bin/env python3
+"""Speculos regression check: closing the app and starting a brand-new
+process must not leave a previous session's typed mnemonic content behind
+in RAM.
+
+Unlike the other five scripts in this directory, this one is not chasing an
+application bug. `git grep -n "nvm_write\\|nvm_erase" -- src/` finds nothing:
+this app never writes to NVM/flash, so every secret buffer -- the `mnemonic`
+global watched here included (src/nbgl/bip39_mnemonic.c) -- lives exclusively
+in RAM (globals/.bss or stack locals). The only way a secret could survive an
+app close-then-reopen is if BOLOS does not actually reset that RAM when
+(re)loading the app process -- a platform guarantee, not something this
+app's own code controls. A `PASS` here confirms that guarantee holds for this
+build; a `FAIL` would be a significant finding about the platform or the test
+infrastructure itself, not a one-line application fix.
+
+Scenario:
+  1. Start a first Speculos container. On "Check BIP39", type and confirm
+     all 12 words of a known-valid test mnemonic (reusing the vector and
+     per-word typing helper from verify_compare_recovery_phrase_cleanup.py),
+     filling the real `mnemonic` global.
+  2. Read that buffer at the return of bip39_mnemonic_check() -- the point
+     furthest into the flow where the buffer is still guaranteed to hold
+     the full typed phrase (see "Why docker stop/rm, not a real quit tap"
+     below) -- as a sanity check that the secret was genuinely present
+     before the app goes away.
+  3. Tear down that first container's process entirely.
+  4. Start a second, completely independent Speculos container from the
+     same app.elf (no shared volumes/state with the first).
+  5. Before any simulated user interaction, read the same global in this
+     fresh process (its R9-relative runtime address is re-resolved from
+     scratch -- never assumed identical to the first session) and confirm
+     none of the first session's typed words appear in it.
+
+Why docker stop/rm, not a real quit tap: on_quit() (src/nbgl/ui.c,
+os_sched_exit(-1)) is trivially reachable -- confirmed empirically, it is a
+"Quit app" footer link directly on the home screen (nbgl_useCaseHomeAndSettings)
+-- but reaching it from the post-confirmation state requires first navigating
+back to the dashboard, and display_home_page() unconditionally calls
+reset_globals() (-> bip39_mnemonic_reset()) before it ever draws that screen.
+Doing that would wipe the buffer with this app's own defense-in-depth code
+before the platform-level guarantee under test is ever exercised -- exactly
+the thing checks 1/4/5 already verify, and it would make a PASS here
+ambiguous (clean because of BOLOS, or clean because of application code that
+had nothing to do with it?). Tearing the container down directly, right after
+the sanity-check read, keeps the buffer populated with real content up to the
+moment the first process actually disappears.
+
+Symmetrically, the second container's read point is not "as soon as GDB can
+attach" but the entry of ui_idle_init() / display_home_page() -- the first
+UI code this fresh process ever runs, called once at boot. That is deliberately
+*before* its own reset_globals() call (the first statement in the function
+body): reading any later would let this process's own init code launder away
+whatever the loader actually left behind, which is exactly the thing this
+script needs to observe untouched.
+
+Usage:
+    docker run --rm -v "$(pwd)":/app \\
+      ghcr.io/ledgerhq/ledger-app-builder/ledger-app-builder-lite:latest \\
+      bash -c 'BOLOS_SDK=/opt/flex-secure-sdk make -j4'   # build first, once
+    python3 tests/speculos/verify_app_reopen_clears_mnemonic.py
+
+Exit code 0 and "PASS" if none of the first session's typed words appear in
+the second (fresh) process's buffer. Exit code 1 and "FAIL" otherwise -- see
+this script's header comment in the repo for what to do in that case (not a
+routine one-line fix).
+
+See README.md in this directory for the Speculos/GDB gotchas this script
+relies on (shared with the other five scripts).
+"""
+import json
+import os
+import socket
+import subprocess
+import sys
+import tempfile
+import threading
+import time
+import urllib.request
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+from rsp_client import RSP
+
+REPO_ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", ".."))
+ELF_PATH = os.path.join(REPO_ROOT, "build", "flex", "bin", "app.elf")
+BUILDER_IMAGE = "ghcr.io/ledgerhq/ledger-app-builder/ledger-app-builder-lite:latest"
+SPECULOS_IMAGE = "ghcr.io/ledgerhq/speculos:latest"
+CONTAINER_NAME_1 = "speculos-app-reopen-test-1"
+CONTAINER_NAME_2 = "speculos-app-reopen-test-2"
+API_PORT = 5006
+GDB_PORT = 1239
+BASE_URL = f"http://localhost:{API_PORT}"
+
+# Same 128-bit BlockchainCommons test vector already used by
+# verify_compare_recovery_phrase_cleanup.py / tests/functional/test_bip39_12word.py
+# -- a known-valid checksum matters here: bip39_mnemonic_check() calls
+# bip39_mnemonic_reset() itself on a *failed* checksum, before this script
+# would get a chance to read anything meaningful.
+MNEMONIC = ("fly mule excess resource treat plunge nose soda reflect adult "
+           "ramp planet")
+MNEMONIC_WORDS = MNEMONIC.split()
+
+# Link-time code base for the flex target vs. the address speculos's
+# launcher actually maps it at -- see README.md gotcha #4.
+CODE_LINK_BASE = 0xC0DE0000
+CODE_RUNTIME_BASE = 0x40000000
+
+SIGILL = 4
+SOCKET_TIMEOUT = 40
+
+# FLEX (480x600) touch-keyboard letter positions -- ragger/firmware/touch/positions.py,
+# POSITIONS["LetterOnlyKeyboard"][DeviceType.FLEX] -- same source as the other scripts.
+FLEX_KEYS = {
+    "q": (24, 415), "w": (72, 415), "e": (120, 415), "r": (168, 415),
+    "t": (216, 415), "y": (264, 415), "u": (312, 415), "i": (360, 415),
+    "o": (408, 415), "p": (456, 415),
+    "a": (48, 490), "s": (96, 490), "d": (144, 490), "f": (192, 490),
+    "g": (240, 490), "h": (288, 490), "j": (336, 490), "k": (384, 490),
+    "l": (432, 490),
+    "z": (24, 565), "x": (72, 565), "c": (120, 565), "v": (168, 565),
+    "b": (216, 565), "n": (264, 565), "m": (312, 565),
+}
+SUGGESTION_1 = (140, 300)
+
+
+def die(msg):
+    print(f"FAIL: {msg}", file=sys.stderr)
+    sys.exit(1)
+
+
+def check_build():
+    if not os.path.isfile(ELF_PATH):
+        die(
+            "build/flex/bin/app.elf not found. Build it first:\n\n"
+            '  docker run --rm -v "$(pwd)":/app \\\n'
+            f"    {BUILDER_IMAGE} \\\n"
+            "    bash -c 'BOLOS_SDK=/opt/flex-secure-sdk make -j4'\n"
+        )
+
+
+def docker_run_tool(*args):
+    return subprocess.run(
+        ["docker", "run", "--rm", "-v", f"{os.path.dirname(ELF_PATH)}:/app",
+         BUILDER_IMAGE, *args],
+        capture_output=True, text=True, check=True,
+    ).stdout
+
+
+def resolve_symbols():
+    """nm -S the built ELF -- never hardcode addresses, they shift on any
+    source change. `bip39_mnemonic_check` and `ui_idle_init` are both real
+    (non-inlined) symbols: the former is called via the keyboard dispatcher's
+    if-branch, the latter is registered as the app's UX idle callback --
+    confirmed present in this build via `nm`, not assumed."""
+    out = docker_run_tool("nm", "-S", "/app/app.elf")
+    wanted = {"mnemonic", "bip39_mnemonic_check", "ui_idle_init"}
+    syms = {}
+    for line in out.splitlines():
+        parts = line.split()
+        if len(parts) == 4 and parts[3] in wanted:
+            syms[parts[3]] = (int(parts[0], 16), int(parts[1], 16))
+        elif len(parts) == 3 and parts[2] in wanted:
+            syms[parts[2]] = (int(parts[0], 16), 0)
+    missing = wanted - syms.keys()
+    if missing:
+        die(f"could not resolve symbols in app.elf: {missing} "
+            "(did bip39_mnemonic.c/ui.c rename these?)")
+    return syms
+
+
+def resolve_bss_base():
+    out = docker_run_tool("readelf", "-S", "/app/app.elf")
+    for line in out.splitlines():
+        parts = line.split()
+        if ".bss" in parts:
+            return int(parts[parts.index(".bss") + 2], 16)
+    die("could not find .bss section in app.elf")
+
+
+def code_runtime_addr(link_addr):
+    """Translate a linked code address to where speculos's launcher actually
+    maps it -- see README.md gotcha #4. `link_addr` may carry the Thumb bit
+    (bit 0), stripped here since it's not part of the real address."""
+    even = link_addr & ~1
+    return CODE_RUNTIME_BASE + (even - CODE_LINK_BASE)
+
+
+def prepare_patched_speculos_main(scratch_dir):
+    """See README.md gotcha #1: the published debug image's `-singlestep`
+    flag no longer exists in the bundled QEMU; patch it to
+    `-one-insn-per-tb`."""
+    patched = os.path.join(scratch_dir, "main.py")
+    cid = subprocess.run(["docker", "create", SPECULOS_IMAGE],
+                          capture_output=True, text=True, check=True).stdout.strip()
+    try:
+        subprocess.run(["docker", "cp", f"{cid}:/speculos/speculos/main.py", patched], check=True)
+    finally:
+        subprocess.run(["docker", "rm", cid], capture_output=True)
+    with open(patched) as f:
+        content = f.read()
+    if "'-singlestep'" not in content:
+        die("speculos main.py no longer contains '-singlestep' -- "
+            "the image changed, this patch needs re-checking by hand")
+    content = content.replace("'-singlestep'", "'-one-insn-per-tb'")
+    with open(patched, "w") as f:
+        f.write(content)
+    return patched
+
+
+def start_container(name, patched_main_py):
+    subprocess.run(["docker", "rm", "-f", name], capture_output=True)
+    subprocess.run([
+        "docker", "run", "-d", "--name", name,
+        "-p", f"{GDB_PORT}:1234", "-p", f"{API_PORT}:5001",
+        "-v", f"{os.path.dirname(ELF_PATH)}:/app",
+        "-v", f"{patched_main_py}:/speculos/speculos/main.py",
+        SPECULOS_IMAGE, "-m", "flex", "--display", "headless",
+        "--api-port", "5001", "-d", "/app/app.elf",
+    ], check=True, capture_output=True)
+
+
+def stop_container(name):
+    subprocess.run(["docker", "rm", "-f", name], capture_output=True)
+
+
+def tap(x, y, delay=0.1):
+    body = json.dumps({"action": "press-and-release", "x": x, "y": y, "delay": delay}).encode()
+    req = urllib.request.Request(f"{BASE_URL}/finger", data=body,
+                                  headers={"Content-Type": "application/json"}, method="POST")
+    urllib.request.urlopen(req).read()
+    time.sleep(0.4)
+
+
+def screen_texts():
+    data = json.loads(urllib.request.urlopen(f"{BASE_URL}/events?currentscreenonly=true").read())
+    return [e["text"] for e in data["events"]]
+
+
+class CheckReturnSampler:
+    """First container: runs the app under GDB (SIGILL passthrough, see
+    README.md gotcha #2), and takes a synchronous snapshot of the `mnemonic`
+    buffer at the entry and return of bip39_mnemonic_check() -- same
+    entry+LR-return pattern as verify_bip39_cancel_clears_buffer.py's
+    MemorySampler, narrowed to a single watched function.
+
+    The return point is the sanity-check read this script needs: by then
+    compare_recovery_phrase() has already run, but bip39_mnemonic_check()
+    deliberately does *not* reset the buffer on a valid-checksum path ("Don't
+    clear the mnemonic just yet as we may need it to generate BIP39
+    mnemonic" -- bip39_mnemonic.c), so the full typed phrase is still there.
+    """
+
+    def __init__(self, watch_addr, mnemonic_offset, mnemonic_len):
+        self.rsp = RSP(port=GDB_PORT, timeout=SOCKET_TIMEOUT)
+        self.watch_addr = watch_addr
+        self.mnemonic_offset = mnemonic_offset
+        self.mnemonic_len = mnemonic_len
+        self.entry = None
+        self.after_return = None
+        self._pending_return = None  # (ret_addr, before_bytes)
+        self._thread = threading.Thread(target=self._pump, daemon=True)
+
+    def start(self):
+        self.rsp.insert_bp(self.watch_addr, kind=2)
+        self.rsp.cont()
+        self._thread.start()
+
+    def _pump(self):
+        while True:
+            try:
+                reply = self.rsp.wait_stop()
+            except socket.timeout:
+                continue
+            except (ConnectionError, OSError):
+                return
+            try:
+                if self.rsp.stop_signal(reply) == SIGILL:
+                    self.rsp.cont_with_signal(SIGILL)
+                    continue
+
+                regs = self.rsp.read_regs()
+                pc = regs[15] & ~1
+                mnemonic_addr = regs[9] + self.mnemonic_offset
+
+                if self._pending_return and pc == self._pending_return[0]:
+                    ret_addr, before = self._pending_return
+                    after = self.rsp.read_mem(mnemonic_addr, self.mnemonic_len)
+                    self.after_return = after
+                    self.rsp.remove_bp(ret_addr, kind=2)
+                    self._pending_return = None
+                    self.rsp.cont()
+                    continue
+
+                if pc == self.watch_addr and self.entry is None:
+                    self.entry = self.rsp.read_mem(mnemonic_addr, self.mnemonic_len)
+                    ret_addr = regs[14] & ~1
+                    self.rsp.insert_bp(ret_addr, kind=2)
+                    self._pending_return = (ret_addr, self.entry)
+                    # step over the breakpoint we're sitting on before
+                    # resuming, or we'd hit it again immediately
+                    self.rsp.remove_bp(pc, kind=2)
+                    self.rsp.step()
+                    self.rsp.insert_bp(pc, kind=2)
+                    self.rsp.cont()
+                    continue
+
+                self.rsp.cont()
+            except (ConnectionError, OSError):
+                return
+
+
+class FreshBootSampler:
+    """Second container: a single breakpoint at ui_idle_init()'s entry, the
+    very first UI code a fresh process runs at boot -- deliberately *before*
+    display_home_page()'s own reset_globals() call, so this captures whatever
+    the loader actually left in .bss, untouched by this app's own init code.
+    No taps, no other interaction: this fires purely from the normal boot
+    sequence."""
+
+    def __init__(self, watch_addr, mnemonic_offset, mnemonic_len):
+        self.rsp = RSP(port=GDB_PORT, timeout=SOCKET_TIMEOUT)
+        self.watch_addr = watch_addr
+        self.mnemonic_offset = mnemonic_offset
+        self.mnemonic_len = mnemonic_len
+        self.r9 = None
+        self.snapshot = None
+        self._thread = threading.Thread(target=self._pump, daemon=True)
+
+    def start(self):
+        self.rsp.insert_bp(self.watch_addr, kind=2)
+        self.rsp.cont()
+        self._thread.start()
+
+    def _pump(self):
+        while True:
+            try:
+                reply = self.rsp.wait_stop()
+            except socket.timeout:
+                continue
+            except (ConnectionError, OSError):
+                return
+            try:
+                if self.rsp.stop_signal(reply) == SIGILL:
+                    self.rsp.cont_with_signal(SIGILL)
+                    continue
+
+                regs = self.rsp.read_regs()
+                pc = regs[15] & ~1
+
+                if pc == self.watch_addr and self.snapshot is None:
+                    self.r9 = regs[9]
+                    mnemonic_addr = self.r9 + self.mnemonic_offset
+                    self.snapshot = self.rsp.read_mem(mnemonic_addr, self.mnemonic_len)
+                    return  # got what we need, nothing left to pump
+
+                self.rsp.cont()
+            except (ConnectionError, OSError):
+                return
+
+
+def type_and_confirm_word(word):
+    """Type a BIP39 word in full and tap the first suggestion -- see
+    verify_compare_recovery_phrase_cleanup.py for why the poll is patient
+    (screen redraws under GDB + SIGILL-passthrough overhead can lag many
+    tens of seconds behind the actual taps)."""
+    for letter in word:
+        tap(*FLEX_KEYS[letter])
+    texts = []
+    for _ in range(200):
+        texts = screen_texts()
+        if word in texts:
+            break
+        time.sleep(0.5)
+    else:
+        die(f"expected '{word}' suggestion on screen after typing it, got: "
+            f"{texts} -- navigation/keyboard-mapping assumption is wrong")
+    tap(*SUGGESTION_1)
+
+
+def navigate_and_confirm_mnemonic():
+    """Coordinates are for the flex layout only (480x600); see README.md
+    for how these were found and how to adapt to stax/apex."""
+    time.sleep(3)  # let the app finish booting before the first tap
+    tap(371, 436)  # home screen: "Select Tool"
+    time.sleep(1)
+    tap(358, 524)  # "BIP39 Check"
+    time.sleep(1)
+    tap(387, 524)  # "12 words"
+    time.sleep(1)
+
+    for word in MNEMONIC_WORDS:
+        type_and_confirm_word(word)
+
+
+def nz(b):
+    return sum(1 for x in b if x)
+
+
+def main():
+    check_build()
+    print("Resolving symbols from build/flex/bin/app.elf ...")
+    syms = resolve_symbols()
+    bss_base = resolve_bss_base()
+    mnemonic_addr, mnemonic_len = syms["mnemonic"]
+    mnemonic_offset = mnemonic_addr - bss_base
+    check_addr = code_runtime_addr(syms["bip39_mnemonic_check"][0])
+    idle_addr = code_runtime_addr(syms["ui_idle_init"][0])
+    print(f"  mnemonic buffer: offset R9+0x{mnemonic_offset:x}, {mnemonic_len} bytes")
+    print(f"  breakpoint (container 1): 0x{check_addr:x} (bip39_mnemonic_check)")
+    print(f"  breakpoint (container 2): 0x{idle_addr:x} (ui_idle_init)")
+
+    # --- Container 1: fill the buffer, read it, then tear the process down ---
+    sampler1 = None
+    with tempfile.TemporaryDirectory() as scratch:
+        print("\nPatching Speculos debug image (singlestep -> one-insn-per-tb) ...")
+        patched_main = prepare_patched_speculos_main(scratch)
+
+        print(f"Starting first Speculos container ({CONTAINER_NAME_1}) ...")
+        start_container(CONTAINER_NAME_1, patched_main)
+        try:
+            time.sleep(2)
+            sampler1 = CheckReturnSampler(check_addr, mnemonic_offset, mnemonic_len)
+            sampler1.start()
+            print("Navigating: home -> BIP39 Check -> 12 words -> type+confirm "
+                  "all 12 words of the test mnemonic ...")
+            print("(this is slow -- every guest syscall round-trips through this "
+                  "script while GDB is attached; a full run takes a few minutes)")
+            navigate_and_confirm_mnemonic()
+            for _ in range(150):
+                if sampler1.after_return is not None:
+                    break
+                time.sleep(0.5)
+        finally:
+            print("Tearing down the first container (simulates the app closing) ...")
+            stop_container(CONTAINER_NAME_1)
+
+    if sampler1.entry is None:
+        die("bip39_mnemonic_check was never hit -- navigation didn't reach "
+            "the expected code path (did the UI flow change?)")
+    if MNEMONIC.encode() not in sampler1.entry:
+        die("bip39_mnemonic_check fired without the full typed phrase present "
+            "in the mnemonic buffer -- test setup is broken, this isn't the "
+            f"scenario under test:\n  {sampler1.entry.hex()}")
+    if sampler1.after_return is None:
+        die("bip39_mnemonic_check's entry breakpoint fired but its return "
+            "never did -- it didn't return normally (LEDGER_ASSERT somewhere "
+            "downstream?)")
+
+    print(f"\nContainer 1 -- mnemonic buffer at bip39_mnemonic_check() return "
+          f"(nonzero={nz(sampler1.after_return)}/{mnemonic_len}):")
+    print(f"  {sampler1.after_return.hex()}")
+    if MNEMONIC.encode() not in sampler1.after_return:
+        die("the typed phrase is not present at bip39_mnemonic_check's return "
+            "-- test setup is broken (unexpected early clear?), this isn't "
+            "the scenario under test")
+    print("\n  confirmed: the full typed phrase is present in RAM right "
+          "before the first process is torn down (as expected -- this is "
+          "what makes the next check meaningful)")
+
+    # --- Container 2: brand-new process, read before any interaction ---
+    sampler2 = None
+    with tempfile.TemporaryDirectory() as scratch:
+        patched_main = prepare_patched_speculos_main(scratch)
+        print(f"\nStarting second, independent Speculos container "
+              f"({CONTAINER_NAME_2}) from the same app.elf, no shared "
+              "volumes/state with the first ...")
+        start_container(CONTAINER_NAME_2, patched_main)
+        try:
+            time.sleep(2)
+            sampler2 = FreshBootSampler(idle_addr, mnemonic_offset, mnemonic_len)
+            sampler2.start()
+            print("Waiting for the fresh process to reach ui_idle_init() "
+                  "(no taps sent -- this fires from the normal boot sequence "
+                  "alone) ...")
+            for _ in range(150):
+                if sampler2.snapshot is not None:
+                    break
+                time.sleep(0.5)
+        finally:
+            stop_container(CONTAINER_NAME_2)
+
+    if sampler2.snapshot is None:
+        die("ui_idle_init was never hit in the second container -- it never "
+            "reached its normal boot sequence (Speculos/container problem, "
+            "not the scenario under test)")
+
+    print(f"\nContainer 2 -- mnemonic buffer at ui_idle_init() entry, before "
+          f"any interaction (R9=0x{sampler2.r9:x}, nonzero="
+          f"{nz(sampler2.snapshot)}/{mnemonic_len}):")
+    print(f"  {sampler2.snapshot.hex()}")
+
+    for word in MNEMONIC_WORDS:
+        if word.encode() in sampler2.snapshot:
+            print(f"\nFAIL: '{word}' from the first session's mnemonic is "
+                  "still present in the second (fresh) process's mnemonic "
+                  "buffer -- BOLOS did not reset this RAM across the "
+                  "close/reopen. Do not treat this as a routine application "
+                  "bug -- see this script's module docstring for what to do.")
+            sys.exit(1)
+
+    print("\nPASS: no trace of the first session's typed mnemonic is present "
+          "in the second, freshly-booted process's buffer -- BOLOS resets "
+          "this RAM on app reload, as expected for a platform guarantee "
+          "this app relies on rather than implements itself.")
+    sys.exit(0)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## What this checks

This app never writes to NVM/flash (`git grep -n "nvm_write\|nvm_erase" -- src/` finds nothing), so every secret buffer -- including the `mnemonic` global watched here -- lives exclusively in RAM. The only way a secret could survive closing and reopening the app is if BOLOS does not actually reset that RAM when (re)loading the process -- **a platform guarantee, not something this app's own code controls.**

This adds a sixth Speculos check (`tests/speculos/verify_app_reopen_clears_mnemonic.py`) that verifies that guarantee empirically. Unlike the existing five checks in this directory (which all verify this app's own `memzero()`/`explicit_bzero()` cleanup code), this one is explicitly *not* hunting for an application bug -- there is no application-level fix expected here if it passes.

## Scenario

1. A first Speculos container types and confirms a full 12-word test mnemonic on "Check BIP39".
2. The real `mnemonic` buffer (`src/nbgl/bip39_mnemonic.c`) is read at the return of `bip39_mnemonic_check()` -- the point furthest into the flow where it's still guaranteed to hold the full typed phrase (that function deliberately does not clear it on a valid-checksum path, since it may still be needed for SSKR generation) -- confirming the secret was genuinely present.
3. That container is torn down entirely (`docker stop`/`rm`).
4. A second, completely independent container boots from the same `app.elf` (no shared Docker volumes/state with the first).
5. Before any simulated user interaction, the same global is read again in this fresh process -- its `R9`-relative runtime address re-resolved from scratch, never assumed identical to the first session -- at the entry of `ui_idle_init()`/`display_home_page()`, the very first UI code a fresh process runs at boot.

**Why `docker stop`/`rm` instead of tapping the app's own "Quit app" action** (confirmed reachable, it's a footer link on the home screen): reaching it from the just-confirmed state requires navigating back to the dashboard first, and `display_home_page()` unconditionally clears the buffer via this app's own defense-in-depth code (`reset_globals()`) before it ever draws that screen -- before the platform guarantee under test would ever get exercised. That would make a `PASS` ambiguous (clean because of BOLOS, or clean because of unrelated application code?). Tearing the container down directly keeps the buffer populated with real content up to the moment the process actually disappears.

## Result -- PASS

Run against a real `flex` build:

```
Container 1 -- mnemonic buffer at bip39_mnemonic_check() return (nonzero=88/324):
  666c79206d756c6520657863657373207265736f7572636520747265617420706c756e6765...
  (decodes as "fly mule excess resource treat plunge nose soda reflect adult ramp planet")

Container 2 -- mnemonic buffer at ui_idle_init() entry, before any interaction (R9=0x50000000, nonzero=0/324):
  0000000000000000...0000  (entirely zero)

PASS: no trace of the first session's typed mnemonic is present in the second,
freshly-booted process's buffer -- BOLOS resets this RAM on app reload.
```

## Scope

No production code changes -- see the reasoning above for why none are expected on a `PASS`. `tests/speculos/README.md` updated with a new Check 6 entry (table of contents, files table, duration table, and a dedicated section) following the same structure as the existing five checks.

If this had come back `FAIL`, the plan was to stop and discuss rather than treat it as a routine one-line fix -- documented as such in the script and the README, since a real failure here would point at either a test-infrastructure artifact or something significant about BOLOS's RAM handling under Speculos, not an application bug.