### PR TITLE
tests/speculos: wait for the GDB stub instead of sleeping a fixed 2s

### DIFF
--- a/tests/speculos/README.md
+++ b/tests/speculos/README.md
@@ -27,6 +27,7 @@ touching secret-buffer lifecycle code in the NBGL UI layer.
   - [3. Async Ctrl-C interrupts are unreliable; breakpoints are not](#3-async-ctrl-c-interrupts-are-unreliable-breakpoints-are-not)
   - [4. Global variables are not at their linked address at runtime](#4-global-variables-are-not-at-their-linked-address-at-runtime)
   - [5. Stack-local secrets are SP-relative, and simpler than globals](#5-stack-local-secrets-are-sp-relative-and-simpler-than-globals)
+  - [6. The GDB stub is not ready when the container is](#6-the-gdb-stub-is-not-ready-when-the-container-is)
 - [Adapting to stax/apex, or another scenario](#adapting-to-staxapex-or-another-scenario)
 
 ## Files
@@ -54,23 +55,33 @@ touching secret-buffer lifecycle code in the NBGL UI layer.
 
 ## Running
 
+All six are executable and carry a `#!/usr/bin/env python3` shebang, so they
+can be run directly (prefixing `python3` also works):
+
 ```bash
-python3 tests/speculos/verify_bip39_cancel_clears_buffer.py
-python3 tests/speculos/verify_compare_recovery_phrase_cleanup.py
-python3 tests/speculos/verify_sskr_share_cancel_clears_buffer.py
-python3 tests/speculos/verify_sskr_generated_shares_dashboard_return.py
-python3 tests/speculos/verify_bip85_bip39_output_cleanup.py
-python3 tests/speculos/verify_app_reopen_clears_mnemonic.py
+./tests/speculos/verify_bip39_cancel_clears_buffer.py
+./tests/speculos/verify_compare_recovery_phrase_cleanup.py
+./tests/speculos/verify_sskr_share_cancel_clears_buffer.py
+./tests/speculos/verify_sskr_generated_shares_dashboard_return.py
+./tests/speculos/verify_bip85_bip39_output_cleanup.py
+./tests/speculos/verify_app_reopen_clears_mnemonic.py
 ```
 
-| Script | Typical duration | Why |
+Durations below are measured, from one sequential run of all six on a single
+host — treat them as an order of magnitude, not a guarantee; the dominant
+cost is the per-syscall GDB round-trip (gotcha 2), so they scale with host
+load.
+
+| Script | Measured | Why |
 |---|---|---|
-| Check 1 (BIP39 cancel) | A few minutes | Types one word only. |
-| Check 2 (`compare_recovery_phrase_finish`) | 15–30+ minutes | Types and confirms a full 12-word mnemonic. |
-| Check 3 (SSKR cancel) | A few minutes | Types one word plus a couple of letters. |
-| Check 4 (generated shares) | 15–30+ minutes | Types the full 12-word mnemonic, then generates and pages through 3 shares. |
-| Check 5 (BIP-85 BIP39 output) | A few minutes | Button taps and one numeric-keypad entry only, no mnemonic typing. |
-| Check 6 (app reopen) | 15–30+ minutes | Types and confirms a full 12-word mnemonic, then boots a second container. |
+| Check 1 (BIP39 cancel) | ~4.5 min | Types one word only. |
+| Check 2 (`compare_recovery_phrase_finish`) | ~33 min | Types and confirms a full 12-word mnemonic. |
+| Check 3 (SSKR cancel) | ~4 min | Types one word plus a couple of letters. |
+| Check 4 (generated shares) | ~35 min | Types the full 12-word mnemonic, then generates and pages through 3 shares. |
+| Check 5 (BIP-85 BIP39 output) | ~1 min | Button taps and one numeric-keypad entry only, no mnemonic typing. |
+| Check 6 (app reopen) | ~33 min | Types and confirms a full 12-word mnemonic, then boots a second container. |
+
+Running all six back to back therefore takes roughly two hours.
 
 The long runs are not hangs. Every guest syscall round-trips through this
 script while GDB is attached (see gotcha 2), and individual keystroke
@@ -555,6 +566,45 @@ image reads section/symbol tables fine (`nm`, `readelf` work unprefixed)
 but fails to disassemble ARM code at all
 (`can't disassemble for architecture UNKNOWN`) — use
 `arm-none-eabi-objdump -d` explicitly for that.
+
+### 6. The GDB stub is not ready when the container is
+
+`docker run` returning does not mean the gdbstub inside is listening. These
+scripts originally slept a flat 2 seconds before connecting, which is
+enough on some hosts and not on others; when it isn't, the failure lands on
+the *first RSP command* rather than at `connect()`:
+
+```
+  File "tests/speculos/rsp_client.py", line 78, in insert_bp
+    if self.send_command(f"Z0,{addr:x},{kind}") != "OK":
+ConnectionResetError: [Errno 104] Connection reset by peer
+```
+
+`wait_for_gdb()` (`rsp_client.py`) replaces that sleep in every script: it
+polls the port with a plain TCP connect until it is accepted, then allows a
+short settle before returning.
+
+**Do not "improve" it into an RSP-level probe.** The obvious objection to a
+TCP-only check is that it can succeed too early — and that is real, and
+Docker-configuration-dependent. With Docker's userland proxy (check with
+`ps aux | grep docker-proxy`) the host port is bound the instant the
+container starts, so `connect()` succeeds while the stub is still coming
+up; one host measured TCP accepted at +0.20s but the stub only answering at
++0.70s, with `ConnectionResetError` on every RSP attempt in between.
+Without the userland proxy (iptables DNAT), the connection is refused until
+the stub listens, so there the two coincide. Tightening the probe to send
+`?` and require a well-formed reply was tried, and it *broke the run*:
+QEMU's gdbstub serves a single GDB session, so a throwaway connection that
+actually speaks RSP and then closes reads as a client attaching and
+detaching, after which the real connection hangs on its first command. The
+trailing settle sleep is the deliberate, working alternative — the probe
+must stay silent.
+
+(A related framing trap, if anyone does revisit this: the stub's `+` ack
+and its `$T05...#xx` stop-reply may arrive coalesced in one TCP segment or
+split across two. Both were observed on the same host on consecutive runs,
+so any reply-parsing logic must read until it has a complete packet rather
+than trusting a single `recv()`.)
 
 ## Adapting to stax/apex, or another scenario
 

--- a/tests/speculos/rsp_client.py
+++ b/tests/speculos/rsp_client.py
@@ -3,12 +3,51 @@
 Talks directly to the gdbstub speculos/QEMU exposes on the debug port
 (``-d``, port 1234), without depending on a real ``gdb`` binary. Stdlib only.
 
-Only implements what verify_bip39_cancel_clears_buffer.py needs: resume
+Only implements what the verify_*.py checks in this directory need: resume
 execution, insert/remove a software breakpoint, single-step, read general
 registers, read memory, and redeliver a signal (used to pass SIGILL through
 -- see the README in this directory for why that's required).
+
+Also provides wait_for_gdb(), the startup-race guard every verify_*.py
+script needs before opening its RSP connection.
 """
 import socket
+import time
+
+
+def wait_for_gdb(port=1234, host="localhost", timeout=15):
+    """Wait for Speculos's GDB stub to come up before connecting to it.
+    Returns True once it looks ready, False if `timeout` elapses first
+    (callers report that as their own failure).
+
+    A fixed sleep after `docker run` is not enough: how long the stub takes
+    to start listening varies with the host and its load, and connecting too
+    early fails with `ConnectionResetError` on the first RSP command rather
+    than at connect() time.
+
+    Deliberately probes with a bare TCP connect and nothing else. It is
+    tempting to make this stricter by sending a real RSP packet ("?") and
+    requiring a well-formed reply, since a plain connect() can succeed
+    before the stub is truly ready -- with Docker's userland proxy the host
+    port is bound the instant the container starts, and one host measured
+    TCP accepted at +0.20s but the stub only answering at +0.70s, with
+    ConnectionResetError in between. Do not do that: QEMU's gdbstub serves a
+    single GDB session, so a throwaway connection that actually speaks RSP
+    and then disconnects reads as a client attaching and detaching, and the
+    real connection that follows then hangs on its first command. That was
+    tried here and broke the run; the trailing sleep below is the
+    deliberate, working alternative.
+    """
+    start = time.time()
+    while time.time() - start < timeout:
+        try:
+            s = socket.create_connection((host, port), timeout=1)
+            s.close()
+            time.sleep(1)  # brief buffer for GDB stub handshake readiness
+            return True
+        except (ConnectionRefusedError, OSError):
+            time.sleep(0.5)
+    return False
 
 
 class RSP:

--- a/tests/speculos/verify_app_reopen_clears_mnemonic.py
+++ b/tests/speculos/verify_app_reopen_clears_mnemonic.py
@@ -79,7 +79,7 @@ import time
 import urllib.request
 
 sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
-from rsp_client import RSP
+from rsp_client import RSP, wait_for_gdb
 
 REPO_ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", ".."))
 ELF_PATH = os.path.join(REPO_ROOT, "build", "flex", "bin", "app.elf")
@@ -418,13 +418,16 @@ def main():
         print(f"Starting first Speculos container ({CONTAINER_NAME_1}) ...")
         start_container(CONTAINER_NAME_1, patched_main)
         try:
-            time.sleep(2)
+            if not wait_for_gdb(GDB_PORT):
+                die(f"Speculos GDB stub on port {GDB_PORT} did not "
+                    "become ready in time")
             sampler1 = CheckReturnSampler(check_addr, mnemonic_offset, mnemonic_len)
             sampler1.start()
             print("Navigating: home -> BIP39 Check -> 12 words -> type+confirm "
                   "all 12 words of the test mnemonic ...")
             print("(this is slow -- every guest syscall round-trips through this "
-                  "script while GDB is attached; a full run takes a few minutes)")
+                  "script while GDB is attached; a full run of the 12-word entry "
+                  "alone can take 15-30+ minutes, see README.md)")
             navigate_and_confirm_mnemonic()
             for _ in range(150):
                 if sampler1.after_return is not None:
@@ -466,7 +469,9 @@ def main():
               "volumes/state with the first ...")
         start_container(CONTAINER_NAME_2, patched_main)
         try:
-            time.sleep(2)
+            if not wait_for_gdb(GDB_PORT):
+                die(f"Speculos GDB stub on port {GDB_PORT} did not "
+                    "become ready in time")
             sampler2 = FreshBootSampler(idle_addr, mnemonic_offset, mnemonic_len)
             sampler2.start()
             print("Waiting for the fresh process to reach ui_idle_init() "

--- a/tests/speculos/verify_bip39_cancel_clears_buffer.py
+++ b/tests/speculos/verify_bip39_cancel_clears_buffer.py
@@ -34,7 +34,7 @@ import time
 import urllib.request
 
 sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
-from rsp_client import RSP
+from rsp_client import RSP, wait_for_gdb
 
 REPO_ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", ".."))
 ELF_PATH = os.path.join(REPO_ROOT, "build", "flex", "bin", "app.elf")
@@ -304,7 +304,9 @@ def main():
         print("Starting Speculos ...")
         start_container(patched_main)
         try:
-            time.sleep(2)
+            if not wait_for_gdb(GDB_PORT):
+                die(f"Speculos GDB stub on port {GDB_PORT} did not "
+                    "become ready in time")
             sampler = MemorySampler(watch, mnemonic_offset, mnemonic_len)
             sampler.start()
             print("Navigating: home -> BIP39 Check -> 12 words -> type+confirm "

--- a/tests/speculos/verify_bip85_bip39_output_cleanup.py
+++ b/tests/speculos/verify_bip85_bip39_output_cleanup.py
@@ -51,7 +51,7 @@ import time
 import urllib.request
 
 sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
-from rsp_client import RSP
+from rsp_client import RSP, wait_for_gdb
 
 REPO_ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", ".."))
 ELF_PATH = os.path.join(REPO_ROOT, "build", "flex", "bin", "app.elf")
@@ -362,7 +362,9 @@ def main():
         print("Starting Speculos ...")
         start_container(patched_main)
         try:
-            time.sleep(2)
+            if not wait_for_gdb(GDB_PORT):
+                die(f"Speculos GDB stub on port {GDB_PORT} did not "
+                    "become ready in time")
             sampler = MemorySampler(watch, app_data_offset, app_data_len,
                                     mnemonic_offset, mnemonic_len)
             sampler.start()

--- a/tests/speculos/verify_compare_recovery_phrase_cleanup.py
+++ b/tests/speculos/verify_compare_recovery_phrase_cleanup.py
@@ -63,7 +63,7 @@ import time
 import urllib.request
 
 sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
-from rsp_client import RSP
+from rsp_client import RSP, wait_for_gdb
 
 REPO_ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", ".."))
 ELF_PATH = os.path.join(REPO_ROOT, "build", "flex", "bin", "app.elf")
@@ -443,14 +443,17 @@ def main():
         print(f"Starting Speculos (device seed: \"{MNEMONIC}\") ...")
         start_container(patched_main)
         try:
-            time.sleep(2)
+            if not wait_for_gdb(GDB_PORT):
+                die(f"Speculos GDB stub on port {GDB_PORT} did not "
+                    "become ready in time")
             sampler = MemorySampler(before_addr, after_addr,
                                     buffer_device_reg, buffer_reg)
             sampler.start()
             print("Navigating: home -> BIP39 Check -> 12 words -> type+confirm "
                   "all 12 words of the test mnemonic ...")
             print("(this is slow -- every guest syscall round-trips through this "
-                  "script while GDB is attached; a full run takes a few minutes)")
+                  "script while GDB is attached; a full run of the 12-word entry "
+                  "alone can take 15-30+ minutes, see README.md)")
             navigate_and_check()
             # give the two breakpoints time to fire once the 12th word
             # triggers bip39_mnemonic_check() -> compare_recovery_phrase();

--- a/tests/speculos/verify_sskr_generated_shares_dashboard_return.py
+++ b/tests/speculos/verify_sskr_generated_shares_dashboard_return.py
@@ -42,7 +42,7 @@ import time
 import urllib.request
 
 sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
-from rsp_client import RSP
+from rsp_client import RSP, wait_for_gdb
 
 REPO_ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", ".."))
 ELF_PATH = os.path.join(REPO_ROOT, "build", "flex", "bin", "app.elf")
@@ -401,7 +401,9 @@ def main():
         print(f"Starting Speculos (device seed: \"{MNEMONIC}\") ...")
         start_container(patched_main)
         try:
-            time.sleep(2)
+            if not wait_for_gdb(GDB_PORT):
+                die(f"Speculos GDB stub on port {GDB_PORT} did not "
+                    "become ready in time")
             sampler = MemorySampler(watch, shares_offset, read_len)
             sampler.start()
             print("Navigating: home -> BIP39 Check -> 12 words -> type+confirm "

--- a/tests/speculos/verify_sskr_share_cancel_clears_buffer.py
+++ b/tests/speculos/verify_sskr_share_cancel_clears_buffer.py
@@ -35,7 +35,7 @@ import time
 import urllib.request
 
 sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
-from rsp_client import RSP
+from rsp_client import RSP, wait_for_gdb
 
 REPO_ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", ".."))
 ELF_PATH = os.path.join(REPO_ROOT, "build", "flex", "bin", "app.elf")
@@ -346,7 +346,9 @@ def main():
         print("Starting Speculos ...")
         start_container(patched_main)
         try:
-            time.sleep(2)
+            if not wait_for_gdb(GDB_PORT):
+                die(f"Speculos GDB stub on port {GDB_PORT} did not "
+                    "become ready in time")
             sampler = MemorySampler(watch, shares_offset, read_len)
             sampler.start()
             print("Navigating: home -> SSKR Check -> type+confirm 'acid' -> "


### PR DESCRIPTION
Follow-up to the review comments on #91 and the crash reported on #83. Thanks for running these and digging into it — the failure was real and reproducible, not a problem on your end.

## The bug

Every check slept a flat 2 seconds after `docker run` before opening its RSP connection. That is enough on some hosts and not on others; when it isn't, the failure lands on the *first RSP command* rather than at `connect()` time — exactly the traceback you posted:

```
  File "tests/speculos/rsp_client.py", line 78, in insert_bp
    if self.send_command(f"Z0,{addr:x},{kind}") != "OK":
ConnectionResetError: [Errno 104] Connection reset by peer
```

Reproduced locally by polling a starting container: TCP accepted at **+0.20s**, but every RSP attempt returned `ConnectionResetError` until the stub actually answered at **+0.70s**.

## The fix

`wait_for_gdb()`, essentially as you wrote it, replacing the `time.sleep(2)` in all six scripts (7 call sites — check 6 starts two containers).

One deviation from your sketch, and happy to change it if you'd rather: it lives **once in `rsp_client.py`** rather than being copied into each script, since that module is already the shared home for GDB-connection concerns. It returns a bool so each caller still reports the failure through its own `die()`, keeping `sys.exit` out of the client module.

## Why the probe deliberately stays TCP-only

Worth recording, because the obvious "improvement" is a trap. The fair objection to a bare TCP connect is that it can succeed too early — and that is true, and Docker-configuration-dependent: with the userland proxy the host port is bound the instant the container starts (hence the +0.20s above), while without it the connection is refused until the stub listens.

So I tried tightening the probe to send `?` and require a well-formed reply. **It broke the run**: QEMU's gdbstub serves a single GDB session, so a throwaway connection that actually speaks RSP and then closes reads as a client attaching and detaching, after which the real connection hangs on its first command. Your simpler version is correct precisely *because* it stays silent. Both that trap, and the ack/stop-reply TCP-framing pitfall found along the way, are now written up as gotcha 6 in the README.

**One caveat worth flagging:** this remains timing-based. On a userland-proxy host the poll returns almost immediately and the trailing `sleep(1)` is the real margin (measured headroom ~0.5s); on a host that refuses connections until ready, the poll genuinely tracks readiness. It is a clear improvement in both cases and passes everywhere I can test, but if this ever bites again the fully robust fix is to retry the *real* connection instead of pre-probing — no throwaway connection, no timing assumption. Left out here as beyond the scope of the reported bug.

## Also included

- **`chmod +x` on all six** so they run as `./tests/speculos/verify_*.py` — the shebang was already present, only the exec bit was missing.
- **Two accuracy fixes noticed while verifying**: the README's duration table was estimated rather than measured, and two scripts printed "a full run takes a few minutes" while actually taking ~33 minutes — the "looks like a hang" confusion the README itself warns about. Both now carry measured numbers.

## Verification

All six checks run end to end on a real `flex` build, launched directly via their shebang so the exec bit is exercised too — all six PASS on their own substantive assertion, not merely exit code 0:

| Script | Measured | Result |
|---|---|---|
| `verify_bip39_cancel_clears_buffer.py` | ~4.5 min | PASS — `'abandon' is no longer present…` |
| `verify_sskr_share_cancel_clears_buffer.py` | ~4 min | PASS — `byte 0x01 ('acid') is no longer present…` |
| `verify_bip85_bip39_output_cleanup.py` | ~1 min | PASS — `bip85_app_reset() fired…` |
| `verify_compare_recovery_phrase_cleanup.py` | ~33 min | PASS — `both 'buffer' and 'buffer_device' read as all-zero…` |
| `verify_sskr_generated_shares_dashboard_return.py` | ~35 min | PASS — `sskr_shares_reset() fired…` |
| `verify_app_reopen_clears_mnemonic.py` | ~33 min | PASS — `no trace of the first session's typed mnemonic…` |

No production code changes.