### PR TITLE
sskr: reject an invalid group descriptor before it becomes a buffer length

### DIFF
--- a/src/common/sskr/seed_sskr.c
+++ b/src/common/sskr/seed_sskr.c
@@ -34,6 +34,14 @@
 #error "What kind of system is this?"
 #endif
 
+// Largest a full set of serialized shards can be, in bytes, and hence the
+// capacity of every share buffer handed to bolos_ux_sskr_generate(): every
+// group at its maximum member count, each shard holding a maximum-strength
+// value plus its metadata.
+#define SSKR_MAX_SHARE_BUFFER_LENGTH              \
+    (SSKR_MAX_GROUP_COUNT * SSS_MAX_SHARE_COUNT * \
+     (SSKR_MAX_STRENGTH_BYTES + SSKR_METADATA_LENGTH_BYTES))
+
 int16_t bolos_ux_sskr_size_get(uint8_t bip39_type, uint8_t groups_threshold,
                                unsigned int* group_descriptor,
                                uint8_t groups_len, uint8_t* share_len) {
@@ -134,6 +142,13 @@ unsigned int bolos_ux_sskr_generate(uint8_t groups_threshold,
     if (groups_len > SSKR_MAX_GROUP_COUNT) {
         return 0;
     }
+    // share_buffer_len is a write length, not just a capacity hint: the
+    // failure path below memzero()s the whole of it. No real share buffer is
+    // longer than a full set of maximum-size shards, so refuse anything
+    // longer rather than write past the end of one.
+    if (share_buffer_len > SSKR_MAX_SHARE_BUFFER_LENGTH) {
+        return 0;
+    }
     sskr_group_descriptor_t groups[SSKR_MAX_GROUP_COUNT];
 
     for (uint8_t i = 0; i < (uint8_t)groups_len; i++) {
@@ -228,11 +243,22 @@ unsigned int bolos_ux_bip39_to_sskr_convert(
             bip39_type, groups_threshold, group_descriptor, groups_len,
             &share_len_expected);
 
+        // bolos_ux_sskr_size_get() propagates sskr_count_shards()'s negative
+        // error codes as-is for an invalid group descriptor. The product
+        // below is a uint16_t, so a negative count would wrap into a length
+        // far larger than share_hex_buffer, which bolos_ux_sskr_generate()
+        // then memzero()s. Reject the descriptor before that product is
+        // formed.
+        if (share_count_expected < 0 || share_len_expected == 0) {
+            *share_count = 0;
+            memzero(seed_buffer, sizeof(seed_buffer));
+            memzero(bip39_words_buffer, bip39_words_buffer_length);
+            return 0;
+        }
+
         uint16_t share_hex_buffer_len =
             share_count_expected * share_len_expected;
-        uint8_t share_hex_buffer[SSKR_MAX_GROUP_COUNT * SSS_MAX_SHARE_COUNT *
-                                 (SSKR_MAX_STRENGTH_BYTES +
-                                  SSKR_METADATA_LENGTH_BYTES)];
+        uint8_t share_hex_buffer[SSKR_MAX_SHARE_BUFFER_LENGTH];
         uint8_t share_len = 0;
         *share_count = bolos_ux_sskr_generate(
             groups_threshold, group_descriptor, groups_len, seed_buffer,

--- a/tests/unit/CMakeLists.txt
+++ b/tests/unit/CMakeLists.txt
@@ -228,6 +228,19 @@ target_compile_options(test_sskr_combine_bounds PRIVATE -fsanitize=address -fno-
 target_link_options(test_sskr_combine_bounds PRIVATE -fsanitize=address)
 target_link_libraries(test_sskr_combine_bounds PUBLIC cmocka gcov testutils sskr sss)
 
+# Built with AddressSanitizer for the same reason as
+# test_sskr_generate_bound_groups below, with the same caveat spelled out
+# in the test file's header: the overrun this one covers is a memzero()
+# (explicit_bzero()), which ASan does not intercept, so the sanitizer is
+# not the assertion here -- surviving the call is. ASan is on to catch any
+# neighbouring overrun, and seed_sskr.c is compiled directly into the
+# target so its frames are instrumented either way.
+add_executable(test_sskr_invalid_group_descriptor ./tests/sskr_invalid_group_descriptor.c ../../src/common/bip39/seed_rom_variables.c ../../src/common/bip39/seed_bip39.c ../../src/common/sskr/seed_rom_variables.c ../../src/common/sskr/seed_sskr.c)
+target_include_directories(test_sskr_invalid_group_descriptor PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/../../src ${CMAKE_CURRENT_SOURCE_DIR}/../../src/common ${CMAKE_CURRENT_SOURCE_DIR}/../../src/common/sskr/sss)
+target_compile_options(test_sskr_invalid_group_descriptor PRIVATE -fsanitize=address -fno-omit-frame-pointer)
+target_link_options(test_sskr_invalid_group_descriptor PRIVATE -fsanitize=address)
+target_link_libraries(test_sskr_invalid_group_descriptor PUBLIC cmocka gcov testutils sskr sss)
+
 add_executable(test_sskr_combine_error ./tests/sskr_combine_error.c ../../src/common/bip39/seed_rom_variables.c ../../src/common/bip39/seed_bip39.c ../../src/common/sskr/seed_rom_variables.c ../../src/common/sskr/seed_sskr.c)
 target_include_directories(test_sskr_combine_error PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/../../src/common)
 target_link_libraries(test_sskr_combine_error PUBLIC cmocka gcov sskr sss testutils)
@@ -443,6 +456,6 @@ add_executable(test_bip85_finalize_pwd tests/bip85_finalize_pwd.c ../../src/comm
 target_include_directories(test_bip85_finalize_pwd PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/../../src)
 target_link_libraries(test_bip85_finalize_pwd PUBLIC cmocka gcov testutils)
 
-foreach(target test_sss test_sss_recover_erase_length test_sss_validate_parameters test_sskr test_sskr_to_seed_convert test_sskr_generate_combine_guards test_sskr_threshold_three_roundtrip test_sskr_share_len test_sskr_memzero test_sskr_shard_count test_sskr_generate_split_error test_sskr_generate_bound_groups test_sskr_combine_erase_on_failure test_sskr_count_shards_invariants test_sskr_generate_erase_on_split_failure test_sskr_combine_bounds test_sskr_combine_error test_sskr_combine_invariants test_sskr_interop_bc128 test_sskr_interop_bc128_bytewords test_sskr_entry_bounds test_sskr_byteword_sentinel test_sskr_cbor_additional_info test_bip39 test_bip39_entry_bounds test_roundtrip test_words test_base64 test_base85 test_bip85_dice_bits_per_roll test_bip85_dice_roll test_bip85_bip39_entropy test_bip85_hex_vector test_bip85_finalize_pwd test_bip85_drng_with_seed test_compare_recovery_phrase_finish)
+foreach(target test_sss test_sss_recover_erase_length test_sss_validate_parameters test_sskr test_sskr_to_seed_convert test_sskr_generate_combine_guards test_sskr_threshold_three_roundtrip test_sskr_share_len test_sskr_memzero test_sskr_shard_count test_sskr_generate_split_error test_sskr_generate_bound_groups test_sskr_combine_erase_on_failure test_sskr_count_shards_invariants test_sskr_generate_erase_on_split_failure test_sskr_combine_bounds test_sskr_invalid_group_descriptor test_sskr_combine_error test_sskr_combine_invariants test_sskr_interop_bc128 test_sskr_interop_bc128_bytewords test_sskr_entry_bounds test_sskr_byteword_sentinel test_sskr_cbor_additional_info test_bip39 test_bip39_entry_bounds test_roundtrip test_words test_base64 test_base85 test_bip85_dice_bits_per_roll test_bip85_dice_roll test_bip85_bip39_entropy test_bip85_hex_vector test_bip85_finalize_pwd test_bip85_drng_with_seed test_compare_recovery_phrase_finish)
     add_test(NAME ${target} COMMAND ${target})
 endforeach()

--- a/tests/unit/tests/sskr_invalid_group_descriptor.c
+++ b/tests/unit/tests/sskr_invalid_group_descriptor.c
@@ -1,0 +1,300 @@
+/*
+ * Regression test for the unchecked sign of bolos_ux_sskr_size_get()'s
+ * return value in bolos_ux_bip39_to_sskr_convert() (seed_sskr.c).
+ *
+ * bolos_ux_sskr_size_get() propagates sskr_count_shards()'s return value
+ * as-is, so an invalid group descriptor comes back as a negative error
+ * code. The caller multiplied that count by the share length into a
+ * uint16_t and passed the product to bolos_ux_sskr_generate() as
+ * share_buffer_len -- the same value its failure path hands to
+ * memzero(share_buffer, share_buffer_len). Measured on the three invalid
+ * descriptors below, against a share_hex_buffer that is 592 bytes
+ * (SSKR_MAX_GROUP_COUNT * SSS_MAX_SHARE_COUNT * (SSKR_MAX_STRENGTH_BYTES +
+ * SSKR_METADATA_LENGTH_BYTES)):
+ *
+ *     {2,3} (valid)  count=  3  share_len=21  product=   63
+ *     {3,2}          count=-12  share_len=21  product=65284
+ *     {1,0}          count=-18  share_len=21  product=65158
+ *     {1,5}          count= -4  share_len=21  product=65452
+ *
+ * i.e. up to 65452 bytes of zeros written over a 592-byte stack array,
+ * through the caller's frame.
+ *
+ * Not reachable from the application today: both callers of
+ * bolos_ux_bip39_to_sskr_convert() constrain the descriptor first --
+ * src/nbgl/ui.c rejects a share count outside 1..16, a threshold of 0, a
+ * threshold above the share count and 1-of-m with m > 1; src/bagl/ux_sskr.c
+ * derives the share count from a bounded menu index, bounds the threshold
+ * selector by the share count already chosen, and diverts 1-of-m with
+ * m > 1 to a warning screen. bolos_ux_bip39_to_sskr_convert() is declared
+ * in common_sskr.h all the same, and neither UI guard is compiled into any
+ * test target, so nothing here checks that they stay.
+ *
+ * Verification technique: memzero() is explicit_bzero(), which this
+ * toolchain's AddressSanitizer does not intercept -- unlike the plain
+ * indexed writes in sskr_generate_bound_groups.c, the overrun is not
+ * reported at the point of the write. What ASan sees is the process dying
+ * later on a pointer the smashed frame no longer holds:
+ *
+ *     AddressSanitizer: SEGV on unknown address 0x000000000000
+ *     The signal is caused by a WRITE memory access.
+ *         #0 bolos_ux_bip39_to_sskr_convert .../seed_sskr.c
+ *
+ * so the first assertion here is survival: with neither half of the fix in
+ * place these calls crash, and cmocka reports the failure. On top of that,
+ * the return value pins each half separately -- the descriptor rejection
+ * makes bolos_ux_bip39_to_sskr_convert() return 0 like its other failure
+ * exit, which the bound inside bolos_ux_sskr_generate() alone would not do
+ * (it would leave the caller returning 1 with a zero share count), and
+ * test_generate_rejects_share_buffer_len_beyond_capacity exercises that
+ * bound on its own. ASan is still enabled on the target to catch any
+ * neighbouring overrun these cases might provoke, and seed_sskr.c is
+ * compiled directly into it (rather than linked) so its stack frames are
+ * instrumented, matching test_sskr_generate_bound_groups.
+ */
+
+#include <cmocka.h>
+#include <setjmp.h>
+#include <stdarg.h>
+#include <stddef.h>
+#include <stdint.h>
+#include <string.h>
+
+#include "bip39/common_bip39.h"
+#include "constants.h"
+#include "sskr/common_sskr.h"
+#include "sskr/sskr-constants.h"
+#include "testutils.h"
+
+/* Same 24-word vector as roundtrip.c, itself taken from the Blockchain
+ * Commons SSKR test vectors. A valid mnemonic is required: an invalid one
+ * would fail bolos_ux_bip39_mnemonic_decode() and return before reaching
+ * the descriptor handling under test. */
+static const unsigned char bip39_mnemonic[] =
+    "toe priority custom gauge jacket theme arrest bargain gloom wide ill "
+    "fit eagle prepare capable fish limb cigar reform other priority speak "
+    "rough imitate";
+
+/* Real capacity of bolos_ux_bip39_to_sskr_convert()'s share_hex_buffer. */
+#define SHARE_HEX_BUFFER_LENGTH                   \
+    (SSKR_MAX_GROUP_COUNT * SSS_MAX_SHARE_COUNT * \
+     (SSKR_MAX_STRENGTH_BYTES + SSKR_METADATA_LENGTH_BYTES))
+
+/* What one share of a 24-word seed occupies once serialized: a 5-byte
+ * long-form CBOR byte-string header, the 37-byte shard
+ * (SSKR_METADATA_LENGTH_BYTES + a 32-byte value) and the 4-byte CRC. */
+#define SERIALIZED_SHARE_24_LENGTH \
+    (5 + SSKR_METADATA_LENGTH_BYTES + SSKR_MAX_STRENGTH_BYTES + 4)
+
+/* ...and as space-separated ByteWords: 4 letters per byte plus a
+ * separator, minus the trailing separator of the last word. */
+#define BYTEWORDS_SHARE_24_LENGTH (SERIALIZED_SHARE_24_LENGTH * 5 - 1)
+
+/* bolos_ux_sskr_size_get() and bolos_ux_sskr_generate() are public entry
+ * points (external linkage) but only ever called from within seed_sskr.c
+ * itself, so neither is declared in common_sskr.h. */
+extern int16_t bolos_ux_sskr_size_get(uint8_t bip39_type,
+                                      uint8_t groups_threshold,
+                                      unsigned int* group_descriptor,
+                                      uint8_t groups_len, uint8_t* share_len);
+
+extern unsigned int bolos_ux_sskr_generate(
+    uint8_t groups_threshold, unsigned int* group_descriptor,
+    uint8_t groups_len, unsigned char* seed, unsigned int seed_len,
+    uint8_t* share_len, unsigned char* share_buffer,
+    unsigned int share_buffer_len, uint8_t share_len_expected,
+    int16_t share_count_expected);
+
+/*
+ * Drive bolos_ux_bip39_to_sskr_convert() end to end with the given
+ * descriptor. The output buffer is sized for the largest share set any
+ * descriptor could ask for, so that nothing here depends on the function
+ * stopping short.
+ */
+static unsigned int convert_with_descriptor(unsigned int threshold,
+                                            unsigned int count,
+                                            uint8_t* share_count_out,
+                                            unsigned int* share_words_len_out) {
+    unsigned int group_descriptor[2] = {threshold, count};
+    unsigned char bip39_words_buffer[sizeof(bip39_mnemonic)];
+    unsigned char share_words_buffer[SSS_MAX_SHARE_COUNT *
+                                     (BYTEWORDS_SHARE_24_LENGTH + 1)];
+
+    memcpy(bip39_words_buffer, bip39_mnemonic, sizeof(bip39_words_buffer));
+    memset(share_words_buffer, 0, sizeof(share_words_buffer));
+
+    *share_count_out = 0xff;
+    *share_words_len_out = 0;
+
+    return bolos_ux_bip39_to_sskr_convert(
+        bip39_words_buffer, sizeof(bip39_words_buffer) - 1,
+        BIP39_MNEMONIC_SIZE_24, group_descriptor, share_count_out,
+        share_words_buffer, share_words_len_out);
+}
+
+/*
+ * Threshold above the member count: sskr_count_shards() returns
+ * SSKR_ERROR_INVALID_MEMBER_THRESHOLD.
+ */
+static void test_convert_rejects_threshold_above_count(void** state) {
+    (void)state;
+
+    uint8_t share_count = 0;
+    unsigned int share_words_len = 0;
+
+    unsigned int result =
+        convert_with_descriptor(3, 2, &share_count, &share_words_len);
+
+    assert_int_equal(result, 0);
+    assert_int_equal(share_count, 0);
+}
+
+/*
+ * Zero members: SSKR_ERROR_INVALID_GROUP_COUNT.
+ */
+static void test_convert_rejects_zero_count(void** state) {
+    (void)state;
+
+    uint8_t share_count = 0;
+    unsigned int share_words_len = 0;
+
+    unsigned int result =
+        convert_with_descriptor(1, 0, &share_count, &share_words_len);
+
+    assert_int_equal(result, 0);
+    assert_int_equal(share_count, 0);
+}
+
+/*
+ * 1-of-m with m > 1: SSKR_ERROR_INVALID_SINGLETON_MEMBER.
+ */
+static void test_convert_rejects_singleton_member(void** state) {
+    (void)state;
+
+    uint8_t share_count = 0;
+    unsigned int share_words_len = 0;
+
+    unsigned int result =
+        convert_with_descriptor(1, 5, &share_count, &share_words_len);
+
+    assert_int_equal(result, 0);
+    assert_int_equal(share_count, 0);
+}
+
+/*
+ * The one case the UI can actually produce must be untouched: a 2-of-3
+ * descriptor still yields three shares of the expected length. The share
+ * contents themselves are covered by roundtrip.c; what matters here is
+ * that the new rejection does not turn away a valid descriptor.
+ */
+static void test_convert_accepts_valid_descriptor(void** state) {
+    (void)state;
+
+    uint8_t share_count = 0;
+    unsigned int share_words_len = 0;
+
+    unsigned int result =
+        convert_with_descriptor(2, 3, &share_count, &share_words_len);
+
+    assert_int_equal(result, 1);
+    assert_int_equal(share_count, 3);
+    assert_int_equal(share_words_len, BYTEWORDS_SHARE_24_LENGTH * 3);
+}
+
+/*
+ * The contract the rejection above consumes: bolos_ux_sskr_size_get()
+ * really does return a negative code, not a count, for each of these
+ * descriptors. If it ever started returning 0 or a positive value instead,
+ * the guard in bolos_ux_bip39_to_sskr_convert() would silently stop
+ * matching.
+ */
+static void test_size_get_returns_negative_error_codes(void** state) {
+    (void)state;
+
+    unsigned int threshold_above_count[2] = {3, 2};
+    unsigned int zero_count[2] = {1, 0};
+    unsigned int singleton_member[2] = {1, 5};
+    unsigned int valid[2] = {2, 3};
+    uint8_t share_len = 0;
+
+    assert_int_equal(
+        bolos_ux_sskr_size_get(BIP39_MNEMONIC_SIZE_24, 1, threshold_above_count,
+                               1, &share_len),
+        SSKR_ERROR_INVALID_MEMBER_THRESHOLD);
+    assert_int_equal(bolos_ux_sskr_size_get(BIP39_MNEMONIC_SIZE_24, 1,
+                                            zero_count, 1, &share_len),
+                     SSKR_ERROR_INVALID_GROUP_COUNT);
+    assert_int_equal(bolos_ux_sskr_size_get(BIP39_MNEMONIC_SIZE_24, 1,
+                                            singleton_member, 1, &share_len),
+                     SSKR_ERROR_INVALID_SINGLETON_MEMBER);
+
+    assert_int_equal(
+        bolos_ux_sskr_size_get(BIP39_MNEMONIC_SIZE_24, 1, valid, 1, &share_len),
+        3);
+    assert_int_equal(
+        share_len, BIP39_MNEMONIC_SIZE_24 * 4 / 3 + SSKR_METADATA_LENGTH_BYTES);
+}
+
+/*
+ * Second half of the fix, exercised directly rather than through the
+ * descriptor: a share_buffer_len beyond any real buffer must never be used
+ * as a write length. share_count_expected is deliberately mismatched so
+ * that bolos_ux_sskr_generate() takes its memzero(share_buffer,
+ * share_buffer_len) failure path -- which, unbounded, writes 65284 bytes
+ * over the 592-byte buffer below.
+ */
+static void test_generate_rejects_share_buffer_len_beyond_capacity(
+    void** state) {
+    (void)state;
+
+    unsigned int group_descriptor[2] = {1, 1};
+    uint8_t seed[SSKR_MIN_STRENGTH_BYTES] = {0};
+    uint8_t share_buffer[SHARE_HEX_BUFFER_LENGTH] = {0};
+    uint8_t share_len = 0;
+
+    unsigned int share_count =
+        bolos_ux_sskr_generate(1, group_descriptor, 1, seed, sizeof(seed),
+                               &share_len, share_buffer, 65284, 21, 0);
+
+    assert_int_equal(share_count, 0);
+}
+
+/*
+ * ...and a share_buffer_len at exactly that capacity must still work, so
+ * the bound cannot be an off-by-one that turns away the only buffer the
+ * application ever passes.
+ */
+static void test_generate_accepts_share_buffer_len_at_capacity(void** state) {
+    (void)state;
+
+    unsigned int group_descriptor[2] = {1, 1};
+    uint8_t seed[SSKR_MIN_STRENGTH_BYTES] = {0};
+    uint8_t share_buffer[SHARE_HEX_BUFFER_LENGTH] = {0};
+    uint8_t share_len = 0;
+    uint8_t share_len_expected = 0;
+
+    int16_t share_count_expected = bolos_ux_sskr_size_get(
+        BIP39_MNEMONIC_SIZE_12, 1, group_descriptor, 1, &share_len_expected);
+
+    unsigned int share_count = bolos_ux_sskr_generate(
+        1, group_descriptor, 1, seed, sizeof(seed), &share_len, share_buffer,
+        sizeof(share_buffer), share_len_expected, share_count_expected);
+
+    assert_int_equal(share_count, 1);
+    assert_int_equal(share_len,
+                     SSKR_MIN_STRENGTH_BYTES + SSKR_METADATA_LENGTH_BYTES);
+}
+
+int main(void) {
+    const struct CMUnitTest tests[] = {
+        cmocka_unit_test(test_convert_rejects_threshold_above_count),
+        cmocka_unit_test(test_convert_rejects_zero_count),
+        cmocka_unit_test(test_convert_rejects_singleton_member),
+        cmocka_unit_test(test_convert_accepts_valid_descriptor),
+        cmocka_unit_test(test_size_get_returns_negative_error_codes),
+        cmocka_unit_test(
+            test_generate_rejects_share_buffer_len_beyond_capacity),
+        cmocka_unit_test(test_generate_accepts_share_buffer_len_at_capacity),
+    };
+    return cmocka_run_group_tests(tests, NULL, NULL);
+}


### PR DESCRIPTION
## What this changes

`bolos_ux_sskr_size_get()` (`src/common/sskr/seed_sskr.c`) propagates
`sskr_count_shards()`'s return value as-is, so an invalid group descriptor
comes back as a negative error code. `bolos_ux_bip39_to_sskr_convert()`
never checked its sign:

```c
uint16_t share_hex_buffer_len = share_count_expected * share_len_expected;
uint8_t  share_hex_buffer[SSKR_MAX_GROUP_COUNT * SSS_MAX_SHARE_COUNT *
                          (SSKR_MAX_STRENGTH_BYTES + SSKR_METADATA_LENGTH_BYTES)];
```

The product is a `uint16_t`, so the error code wraps into a very large
positive length, which is then passed to `bolos_ux_sskr_generate()` as
`share_buffer_len` -- the same value its failure path hands to
`memzero(share_buffer, share_buffer_len)`.

Measured against that `share_hex_buffer`, which is **592 bytes** in this
port (`SSKR_MAX_GROUP_COUNT` 1, `SSS_MAX_SHARE_COUNT` 16,
`SSKR_MAX_STRENGTH_BYTES` 32, `SSKR_METADATA_LENGTH_BYTES` 5):

| descriptor `{threshold, count}` | `sskr_count_shards()` | share length | resulting `uint16_t` length |
|---|---|---|---|
| `{2,3}` (valid)  | 3   | 21 | 63 |
| `{3,2}`          | -12 (`SSKR_ERROR_INVALID_MEMBER_THRESHOLD`)  | 21 | 65284 |
| `{1,0}`          | -18 (`SSKR_ERROR_INVALID_GROUP_COUNT`)      | 21 | 65158 |
| `{1,5}`          | -4  (`SSKR_ERROR_INVALID_SINGLETON_MEMBER`) | 21 | 65452 |

i.e. up to 65452 bytes of zeros written over a 592-byte stack array and
through the calling frame.

## No observable behaviour changes

**This is not a bug any user can hit today, and it is not presented as an
exploitable flaw.** Both callers of `bolos_ux_bip39_to_sskr_convert()`
constrain the descriptor before calling:

- **NBGL** -- `src/nbgl/ui.c` rejects a share count outside 1..16, a
  threshold of 0, a threshold above the share count, and 1-of-m with
  m > 1.
- **BAGL** -- `src/bagl/ux_sskr.c` derives the share count from a bounded
  menu index, bounds the threshold selector by the share count already
  chosen, and diverts 1-of-m with m > 1 to a warning screen.

Neither can produce an invalid descriptor. Nothing on screen, and nothing
about a valid 1-of-1 through 16-of-16 generation, changes.

## Why fix it anyway

That safety currently rests **entirely** on validation duplicated across
two separate UI files, and **not a single line of either is compiled into
any unit test target** -- so nothing detects a guard being moved, relaxed,
or a third caller appearing. Meanwhile
`bolos_ux_bip39_to_sskr_convert()` is declared in `common_sskr.h` and
takes the group descriptor straight from its caller.

A core function that writes into a buffer should not depend on that. The
same reasoning already produced the `groups_len` bound in these two
functions and the length/count bounds in `bolos_ux_sskr_combine()`; this
is the remaining gap on the generation side.

## The change

Two guards, one coherent defence:

1. `bolos_ux_bip39_to_sskr_convert()` rejects a negative count (or a zero
   share length) right where `bolos_ux_sskr_size_get()` returns it,
   erasing the decoded seed and returning 0, like the function's other
   failure exit.
2. `bolos_ux_sskr_generate()` refuses a `share_buffer_len` longer than a
   full set of maximum-size shards, so a length beyond any real buffer can
   never reach its `memzero()`. `share_hex_buffer`'s declaration now uses
   the same `SSKR_MAX_SHARE_BUFFER_LENGTH` expression, so the bound and
   the buffer it protects cannot drift apart.

Nothing else changes.

## Tests

New target `test_sskr_invalid_group_descriptor` (7 tests,
`tests/unit/tests/sskr_invalid_group_descriptor.c`), built with
AddressSanitizer and compiling `seed_sskr.c` directly so its frames are
instrumented, matching `test_sskr_generate_bound_groups`.

One caveat is worth stating, because it changes what the test can assert:
`memzero()` is `explicit_bzero()`, which **AddressSanitizer does not
intercept**. The overrun is not reported at the point of the write -- the
process simply dies later on a pointer the smashed frame no longer holds.
So the assertions here are *survival* plus the return value, not a
sanitizer report.

The red state was verified by reverting each half of the fix separately,
not assumed:

| state | result |
|---|---|
| neither guard | the three descriptor cases and the oversized-length case die with SIGSEGV (4 failures) |
| only the descriptor rejection removed | the three descriptor cases fail on the return value (3 failures) |
| only the length bound removed | the oversized-length case dies with SIGSEGV (1 failure) |
| both guards (this PR) | **7/7 pass** |

The suite also covers the nominal 2-of-3 case (still 3 shares of the same
total length), `bolos_ux_sskr_size_get()`'s three negative error codes
directly -- the contract the first guard consumes -- and a
`share_buffer_len` at exactly the maximum, so the bound cannot be an
off-by-one that turns away the only buffer the application passes.

Registered in the `foreach(target ...)` list: `ctest -N` goes from 36 to
37, and the full suite is **37/37** on a from-scratch build.

## Verification

- Full unit suite rebuilt from scratch in `ledger-app-dev-tools`:
  **37/37 green**. The only two build warnings are pre-existing and
  unrelated (`src/nbgl/bip39_mnemonic.c` incompatible pointer type,
  `src/common/common_seed.c` unused label).
- `clang-format --dry-run -Werror` clean on both touched files.
- Cross-compiled for **all six devices declared in `ledger_app.toml`**
  (`nanos`, `nanox`, `nanos+`, `stax`, `flex`, `apex_p`) with
  `ledger-app-builder-lite`: 6/6 build, zero warnings. Note `nanos` is not
  in `ci-workflow.yml`'s device matrix, so it was built by hand.
- **Size: unchanged on every target.** On `nanos` (the most constrained),
  `arm-none-eabi-size build/nanos/bin/app.elf` reports **32008 text /
  3708 bss** both before and after. The code does grow -- a symbol-size
  diff on `flex` shows `bolos_ux_bip39_to_sskr_convert` 420 -> 432 bytes
  and `bolos_ux_sskr_generate` 140 -> 144, +16 net, with no symbol added
  or removed -- but it lands inside existing alignment padding (`.text` on
  `nanos` is exactly `0x7d00`), so no `app.elf` changes size.
- **No Speculos script was needed or added.** The existing scripts cover
  secret-erasure paths, and this PR modifies none of them: the new
  `memzero(seed_buffer, ...)` sits on a rejection path that did not exist
  before. Stating that explicitly rather than leaving it open.
