### PR TITLE
tests: make the two BIP-39 buffer-guard tests exercise what they name

### DIFF
--- a/tests/unit/CMakeLists.txt
+++ b/tests/unit/CMakeLists.txt
@@ -274,8 +274,19 @@ add_executable(test_sskr_combine_invariants ./tests/sskr_combine_invariants.c ..
 target_include_directories(test_sskr_combine_invariants PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/../../src/common)
 target_link_libraries(test_sskr_combine_invariants PUBLIC cmocka gcov sskr sss testutils)
 
+# Built with AddressSanitizer. Both buffer guards this file covers --
+# the "word too long for current_word[]" bail-out in decode() and the
+# "output buffer too small" bail-out in encode() -- are guards whose whole
+# purpose is to prevent a write, so a test that only inspects the return
+# value cannot tell a working guard from a missing one: encode() has a
+# second, later check on `offset` that still returns 0 after an overrun has
+# already happened. seed_bip39.c is compiled directly into the target, so
+# its frames are instrumented and the sanitizer, not the return value, is
+# what observes the write.
 add_executable(test_bip39 ./tests/bip39.c ../../src/common/bip39/seed_rom_variables.c  ../../src/common/bip39/seed_bip39.c)
 target_include_directories(test_bip39 PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/../../src/common)
+target_compile_options(test_bip39 PRIVATE -fsanitize=address -fno-omit-frame-pointer)
+target_link_options(test_bip39 PRIVATE -fsanitize=address)
 target_link_libraries(test_bip39 PUBLIC cmocka gcov testutils)
 
 add_executable(test_roundtrip ./tests/roundtrip.c ../../src/common/bip39/seed_rom_variables.c ../../src/common/bip39/seed_bip39.c ../../src/common/sskr/seed_rom_variables.c ../../src/common/sskr/seed_sskr.c)

--- a/tests/unit/tests/bip39.c
+++ b/tests/unit/tests/bip39.c
@@ -117,11 +117,47 @@ static void test_bip39_decode_bad_checksum(void** state) {
     assert_int_equal(result, 0);
 }
 
-// Same phrase as above, but the last word is replaced with a string that
-// does not appear in the BIP-39 English wordlist.
-static const unsigned char bip39_unknown_word_mnemonic[] =
+// Same phrase as above, but the last word is replaced with a 17-character
+// string. bolos_ux_bip39_mnemonic_decode() accumulates each word into a
+// local `unsigned char current_word[10]` and bails out as soon as a word
+// does not fit, before ever consulting the wordlist -- so this vector
+// exercises the buffer guard, not the wordlist lookup. Under the sanitizer
+// this target is built with, dropping that guard is a stack overrun rather
+// than a silently wrong answer, which is why the case is worth naming.
+static const unsigned char bip39_overlong_word_mnemonic[] =
     "girl mad pet galaxy egg matter matrix prison refuse sense ordinary "
     "notarealbip39word";
+
+static void test_bip39_decode_word_too_long_for_buffer(void** state) {
+    (void)state;
+    unsigned char bits[32 + 1];
+
+    unsigned int result = bolos_ux_bip39_mnemonic_decode(
+        bip39_overlong_word_mnemonic, sizeof(bip39_overlong_word_mnemonic) - 1,
+        bits, sizeof(bits));
+
+    assert_int_equal(result, 0);
+}
+
+// Same phrase again, with a last word that is absent from the BIP-39 English
+// wordlist *and* short enough to reach the lookup: the longest word in the
+// list is 8 characters and `current_word` holds 10, so "abandonx" clears the
+// buffer guard above and reaches the "no match in the wordlist" guard, which
+// is the one this test is named for. No 8-character entry of the list starts
+// with "aband", and the lookup requires an exact length match as well as an
+// exact prefix, so "abandon" cannot match it either.
+//
+// What this test does and does not pin down, measured rather than assumed:
+// it is the first test in the suite to reach that guard at all (its two
+// lines had a zero execution count before), but the guard turns out to be
+// redundant for the return value. An unmatched word contributes no bits, so
+// `bi` ends short of `n * 11` and the check below the loop rejects the
+// phrase anyway; deleting the wordlist guard leaves this test green, with
+// that second check firing exactly once in its place. So this asserts that
+// an out-of-list word is rejected -- not that any one guard does it.
+static const unsigned char bip39_unknown_word_mnemonic[] =
+    "girl mad pet galaxy egg matter matrix prison refuse sense ordinary "
+    "abandonx";
 
 static void test_bip39_decode_unknown_word(void** state) {
     (void)state;
@@ -165,6 +201,13 @@ static void test_bip39_decode_wrong_length(void** state) {
 // 16 bytes of entropy encode to a 74-character mnemonic; an output buffer of
 // 10 bytes is far too small for even the first two words, so encode() must
 // fail cleanly (return 0) instead of writing past the buffer it was given.
+//
+// The returned 0 is only half the assertion, and on its own it is not the
+// interesting half: encode() checks `offset` again after each memcpy(), so
+// it still returns 0 when the length guard that precedes the copy is gone --
+// only after the copy has already run off the end. This target is built
+// with AddressSanitizer (see the CMake comment on it), so `out` is a
+// redzoned array and the write itself is observed rather than inferred.
 static void test_bip39_encode_insufficient_buffer(void** state) {
     (void)state;
     static const uint8_t entropy[16] = {0x00, 0x01, 0x02, 0x03, 0x04, 0x05,
@@ -266,6 +309,7 @@ int main(void) {
         cmocka_unit_test(test_bip39),
         cmocka_unit_test(test_bip39_seed_short_mnemonic),
         cmocka_unit_test(test_bip39_seed_length_boundary),
+        cmocka_unit_test(test_bip39_decode_word_too_long_for_buffer),
         cmocka_unit_test(test_bip39_decode_unknown_word),
         cmocka_unit_test(test_bip39_decode_bad_checksum),
         cmocka_unit_test(test_bip39_decode_wrong_length),


### PR DESCRIPTION
Two tests in `tests/unit/tests/bip39.c` were passing while checking something other than what their names and comments announced. Nothing in `src/` is changed by this PR: no production defect is fixed here, it is the tests that are repaired.

A test that passes is not evidence that it tests what it says. Both of these looked fine in review and in CI.

## What was wrong

**`test_bip39_decode_unknown_word` never reached the guard it is named for.** Its vector ended in `"notarealbip39word"` -- 17 characters. `bolos_ux_bip39_mnemonic_decode()` accumulates each word into a local `unsigned char current_word[10]` and bails out as soon as a word does not fit, *before* the wordlist is ever consulted. The test therefore landed on the "word too long for the buffer" guard, never on the "no match in the wordlist" one.

**`test_bip39_encode_insufficient_buffer` could not observe the write it forbids.** Its comment promised the call would "fail cleanly (return 0) instead of writing past the buffer it was given", but it asserted only the return value and the target had no sanitizer. `bolos_ux_bip39_mnemonic_encode()` re-checks `offset` after each `memcpy()`, so it still returns 0 once the length guard preceding the copy is gone -- only after the copy has already run off the end.

## How that was established

Not by reading the code. Two independent measurements:

- **Execution counts.** Across the whole suite, the two lines of the "no match in the wordlist" guard had a count of **zero** (`DA:112,0`, `DA:113,0`), while the buffer guard's body was reached **exactly once** (`DA:82,1`) -- by the very test claiming to cover the other one.
- **Guard removal.** Deleting the `if ((offset + word_len) > out_len)` check in `mnemonic_encode()` left the **entire suite green**, while the same call under AddressSanitizer reported a heap overflow.

## The fix

The decode test is split in two, each named for the guard it actually reaches. The 17-character vector is kept as `test_bip39_decode_word_too_long_for_buffer`, since that behaviour is worth covering under its own name. `test_bip39_decode_unknown_word` now uses `"abandonx"`: 8 characters, so it clears the buffer guard, and absent from the English wordlist -- which has 2048 entries of at most 8 characters, none of length 8 beginning with `"aband"`. The lookup requires an exact length match as well as an exact prefix, so `"abandon"` cannot match it either. Those two guard lines now have a non-zero count.

`test_bip39` is built with AddressSanitizer, following the pattern already used by `test_sskr_generate_bound_groups`. `seed_bip39.c` is compiled into the target, so its frames are instrumented and the write itself is observed rather than inferred. This covers the other tests in the file as a side effect.

No new target: both cases fit in `bip39.c`, so `ctest -N` is unchanged at **38** and the `foreach(target ...)` line is untouched. The target's own test count goes from 11 to 12.

## Verified by mutation

Each guard was removed, the test re-run, and the guard restored. Sources were compared by checksum after each pass.

| Mutation | Result |
|---|---|
| encode `(offset + word_len) > out_len` removed | **RED** -- `stack-buffer-overflow`, `WRITE of size 6` in `memcpy` at the copy site, attributed to `test_bip39_encode_insufficient_buffer` |
| decode `j >= sizeof(current_word)` removed | **RED** -- `stack-buffer-overflow` against `current_word` itself (`[32, 42)`, access at offset 42), attributed to `test_bip39_decode_word_too_long_for_buffer` |
| decode "no match in the wordlist" guard removed | **stays GREEN** -- see below |

Both of the first two were green before this change.

## One caveat, measured rather than glossed over

The third mutation does not fail, and that is reported here rather than worked around. The "no match in the wordlist" guard turns out to be **redundant for the return value**: an unmatched word contributes no bits, so `bi` ends short of `n * 11` and the `if (bi != n * 11)` check below the loop rejects the phrase anyway. Confirmed by running coverage on the mutant -- that second check goes from 0 to **exactly 1** execution, absorbing precisely this case.

So no test asserting only the return value can discriminate that guard on its own. What the corrected test does deliver is real and measured: it is the first test in the suite to reach the wordlist lookup at all, and the name stops being wrong. The limitation is written into the test file itself so the next reader does not have to rediscover it.

This is noted in the same spirit: `if (bi != n * 11)` has **never** had its body executed by the suite, before or after this change. It is only reachable if the guard above it is removed.

## Unrelated finding, not addressed here

While putting the sanitizer on this target I confirmed a real but unreachable one-byte overflow in `bolos_ux_bip39_mnemonic_encode()`. The guard admits `offset + word_len == out_len`; `offset` then reaches `out_len`, and if words remain the separator is written to `out[out_len]`:

```c
if ((offset + word_len) > out_len) { ... return 0; }   // equality allowed
memcpy(out + offset, ..., word_len);
offset += word_len;                                     // offset == out_len possible
if (offset > out_len) { ... return 0; }                 // cannot fire
if (i < (seed_len * 3 / 4) - 1) { out[offset++] = ' '; } // <-- out[out_len]
```

It is **not reachable from the application**: both callers pass a fixed capacity (216 and 257), far above the longest possible mnemonic (215 characters). It is triggerable by a direct call with `out_len = 7` or `15`. No test for it is added here, since it would be red against current code -- it belongs with its own fix (`>=` instead of `>`, or a check before the separator), which is a production change and out of scope for a test-only PR. Happy to follow up with it if you want it closed.

## Checks

- Full suite rebuilt from scratch in `ledger-app-dev-tools`: **38/38 green**, `ctest -N` = 38 (unchanged). `test_bip39` alone: 12/12 under ASan.
- Coverage of `seed_bip39.c`: **153/165 -> 158/165** lines, **no regression**, identical line sets. The gains are lines 112/113 (the target) plus three lines whose counters are an artefact of the sanitizer build's line attribution for the intercepted `memcpy` -- checked, not assumed.
- `clang-format --dry-run -Werror` clean on the touched file. The only build warnings are the two pre-existing ones (`bip39_mnemonic.c` incompatible pointer, `common_seed.c` unused label).
- **No file under `src/` is modified**, so no cross-compilation was required.
