### PR TITLE
fix: reject a zero share count in the SSKR share validator, and hold two guards that no test held

### DIFF
--- a/src/common/sskr/seed_sskr.c
+++ b/src/common/sskr/seed_sskr.c
@@ -335,6 +335,19 @@ unsigned int bolos_ux_sskr_hex_check(unsigned char* sskr_shares_hex,
     uint32_t checksum = 0;
     uint8_t checksum_len = sizeof(checksum);
 
+    // Every check this function performs -- CBOR tag, metadata shared by all
+    // shares, CRC-32 -- sits inside the loop below, so a zero count would fall
+    // straight through to the accepting return and report data nothing had
+    // looked at as valid. The count comes from the member-threshold nibble of
+    // the entered data and stays zero when the CBOR additional-info byte is one
+    // of the reserved values 25-31, which the share entry screens deliberately
+    // let through so that this function rejects them. Refuse by default here,
+    // the same way bolos_ux_sskr_combine() does.
+    if (sskr_shares_count == 0) {
+        memzero(sskr_shares_hex, sskr_shares_hex_length);
+        return 0;
+    }
+
     for (unsigned int i = 0; i < sskr_shares_count; i++) {
         checksum = crc32_nbo(
             sskr_shares_hex + i * (sskr_shares_hex_length / sskr_shares_count),

--- a/tests/unit/CMakeLists.txt
+++ b/tests/unit/CMakeLists.txt
@@ -201,6 +201,16 @@ add_executable(test_sskr_share_len ./tests/sskr_share_len.c ../../src/common/bip
 target_include_directories(test_sskr_share_len PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/../../src/common)
 target_link_libraries(test_sskr_share_len PUBLIC cmocka gcov sskr sss testutils)
 
+# The guards bolos_ux_sskr_hex_check() holds on entered shares. Built with
+# AddressSanitizer, like test_sskr_combine_bounds and
+# test_sskr_generate_bound_groups below, for the offsets this function derives
+# by dividing a caller-supplied buffer length by a caller-supplied share count.
+add_executable(test_sskr_hex_check_guards ./tests/sskr_hex_check_guards.c ../../src/common/bip39/seed_rom_variables.c ../../src/common/bip39/seed_bip39.c ../../src/common/sskr/seed_rom_variables.c ../../src/common/sskr/seed_sskr.c)
+target_include_directories(test_sskr_hex_check_guards PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/../../src/common)
+target_compile_options(test_sskr_hex_check_guards PRIVATE -fsanitize=address -fno-omit-frame-pointer)
+target_link_options(test_sskr_hex_check_guards PRIVATE -fsanitize=address)
+target_link_libraries(test_sskr_hex_check_guards PUBLIC cmocka gcov sskr sss testutils)
+
 add_executable(test_sskr_memzero ./tests/sskr_memzero.c ../../src/common/bip39/seed_rom_variables.c ../../src/common/bip39/seed_bip39.c ../../src/common/sskr/seed_rom_variables.c ../../src/common/sskr/seed_sskr.c)
 target_include_directories(test_sskr_memzero PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/../../src/common)
 target_link_libraries(test_sskr_memzero PUBLIC cmocka gcov sskr sss testutils)
@@ -478,6 +488,6 @@ add_executable(test_bip85_derivation_path tests/bip85_derivation_path.c ../../sr
 target_include_directories(test_bip85_derivation_path PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/../../src)
 target_link_libraries(test_bip85_derivation_path PUBLIC cmocka gcov testutils)
 
-foreach(target test_sss test_sss_recover_erase_length test_sss_validate_parameters test_sskr test_sskr_to_seed_convert test_sskr_generate_combine_guards test_sskr_threshold_three_roundtrip test_sskr_share_len test_sskr_memzero test_sskr_shard_count test_sskr_generate_split_error test_sskr_generate_bound_groups test_sskr_combine_erase_on_failure test_sskr_count_shards_invariants test_sskr_generate_erase_on_split_failure test_sskr_combine_bounds test_sskr_invalid_group_descriptor test_sskr_combine_error test_sskr_combine_invariants test_sskr_interop_bc128 test_sskr_interop_bc128_bytewords test_sskr_entry_bounds test_sskr_byteword_sentinel test_sskr_cbor_additional_info test_bip39 test_bip39_entry_bounds test_roundtrip test_words test_base64 test_base85 test_bip85_dice_bits_per_roll test_bip85_dice_roll test_bip85_bip39_entropy test_bip85_hex_vector test_bip85_finalize_pwd test_bip85_drng_with_seed test_bip85_derivation_path test_compare_recovery_phrase_finish)
+foreach(target test_sss test_sss_recover_erase_length test_sss_validate_parameters test_sskr test_sskr_to_seed_convert test_sskr_generate_combine_guards test_sskr_threshold_three_roundtrip test_sskr_share_len test_sskr_hex_check_guards test_sskr_memzero test_sskr_shard_count test_sskr_generate_split_error test_sskr_generate_bound_groups test_sskr_combine_erase_on_failure test_sskr_count_shards_invariants test_sskr_generate_erase_on_split_failure test_sskr_combine_bounds test_sskr_invalid_group_descriptor test_sskr_combine_error test_sskr_combine_invariants test_sskr_interop_bc128 test_sskr_interop_bc128_bytewords test_sskr_entry_bounds test_sskr_byteword_sentinel test_sskr_cbor_additional_info test_bip39 test_bip39_entry_bounds test_roundtrip test_words test_base64 test_base85 test_bip85_dice_bits_per_roll test_bip85_dice_roll test_bip85_bip39_entropy test_bip85_hex_vector test_bip85_finalize_pwd test_bip85_drng_with_seed test_bip85_derivation_path test_compare_recovery_phrase_finish)
     add_test(NAME ${target} COMMAND ${target})
 endforeach()

--- a/tests/unit/CMakeLists.txt
+++ b/tests/unit/CMakeLists.txt
@@ -197,8 +197,19 @@ target_link_libraries(test_sskr_generate_combine_guards PUBLIC cmocka gcov testu
 add_executable(test_sskr_threshold_three_roundtrip tests/sskr_threshold_three_roundtrip.c)
 target_link_libraries(test_sskr_threshold_three_roundtrip PUBLIC cmocka gcov testutils sskr sss)
 
+# Built with AddressSanitizer, like test_sskr_combine_bounds and
+# test_sskr_generate_bound_groups below. The bound this covers is what keeps
+# sskr_deserialize_shard() from reading an entered length's worth of bytes out
+# of a share buffer that is not that long, and the return value cannot tell
+# the bounded build from the unbounded one -- so the sanitizer is the
+# assertion. sskr.c lives in the shared `sskr` library and is not instrumented
+# itself, but the copy goes through the intercepted memcpy() and the buffer it
+# reads from is a stack array in this instrumented translation unit, so the
+# redzone still catches it.
 add_executable(test_sskr_share_len ./tests/sskr_share_len.c ../../src/common/bip39/seed_rom_variables.c ../../src/common/bip39/seed_bip39.c ../../src/common/sskr/seed_rom_variables.c ../../src/common/sskr/seed_sskr.c)
 target_include_directories(test_sskr_share_len PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/../../src/common)
+target_compile_options(test_sskr_share_len PRIVATE -fsanitize=address -fno-omit-frame-pointer)
+target_link_options(test_sskr_share_len PRIVATE -fsanitize=address)
 target_link_libraries(test_sskr_share_len PUBLIC cmocka gcov sskr sss testutils)
 
 # The guards bolos_ux_sskr_hex_check() holds on entered shares. Built with

--- a/tests/unit/tests/sskr_hex_check_guards.c
+++ b/tests/unit/tests/sskr_hex_check_guards.c
@@ -1,0 +1,87 @@
+/*
+ * The guards bolos_ux_sskr_hex_check() holds on shares typed in as ByteWords.
+ *
+ * A gcov run over the whole suite gives the rejecting branch of this function
+ * (seed_sskr.c, the memzero/return 0 arm) an execution count of zero: before
+ * this file, no test had ever made it say no.
+ *
+ * What is asserted here is that a share count of zero is refused. Every check
+ * the function performs -- CBOR tag, metadata shared by all shares, CRC-32 --
+ * lives inside a loop bounded by that count, so zero used to fall through to
+ * the accepting return and report whatever it was handed as valid without
+ * reading a byte of it. The count is not a constant of the build: it comes
+ * from the member-threshold nibble of the entered data, and the share entry
+ * screens leave it at zero for the reserved CBOR additional-info values 25-31,
+ * precisely so this function rejects them.
+ *
+ * The vector is the 128-bit Blockchain Commons share set already used by
+ * sskr_interop_bc128_bytewords.c, in the wire form the entry screen builds:
+ * CBOR tag D9 9D 75, short-form byte string header 0x55 (21 bytes), the
+ * serialized shard, then the CRC-32 in network byte order. Written out as
+ * bytes here rather than as ByteWords so that corrupting individual bytes of
+ * it is visible in the source.
+ *
+ * Built with AddressSanitizer: the offsets this function reads from are
+ * computed by dividing a caller-supplied buffer length by a caller-supplied
+ * share count, and both come from entered data on the device.
+ */
+
+#include <cmocka.h>
+#include <setjmp.h>
+#include <stdarg.h>
+#include <stddef.h>
+#include <stdint.h>
+#include <string.h>
+
+/* testutils.h has to come first: it defines WIDE, which
+ * sskr/seed_rom_variables.h uses without defining. Not sorted, hence the
+ * clang-format exclusion. */
+// clang-format off
+#include "testutils.h"
+#include "sskr/common_sskr.h"
+// clang-format on
+
+#define WIRE_LEN (29) /* tag(3) + length byte(1) + shard(21) + CRC(4) */
+
+/* Member index 0 of the 2-of-3 set; valid on its own as far as this function
+ * is concerned, which checks each share independently plus, from the second
+ * one on, that the first 8 bytes match. */
+static const uint8_t k_share[WIRE_LEN] = {
+    0xD9, 0x9D, 0x75, 0x55, 0x01, 0x00, 0x00, 0x01, 0x00, 0x72,
+    0x79, 0x90, 0x3D, 0xCB, 0x83, 0x3F, 0x4B, 0xF7, 0xD4, 0x33,
+    0xFD, 0xAE, 0x81, 0x59, 0x13, 0x5E, 0xF3, 0xB3, 0x38};
+
+static void test_hex_check_accepts_reference_share(void** state) {
+    (void)state;
+
+    uint8_t wire[WIRE_LEN];
+    memcpy(wire, k_share, sizeof(wire));
+
+    /* Control: without this the rejection below would prove nothing, since a
+     * function that refuses everything passes it. */
+    assert_int_equal(bolos_ux_sskr_hex_check(wire, sizeof(wire), 1), 1);
+}
+
+static void test_hex_check_rejects_zero_share_count(void** state) {
+    (void)state;
+
+    /* Not a share at all: no CBOR tag, no CRC, nothing that could pass a
+     * single one of this function's checks. */
+    uint8_t wire[WIRE_LEN];
+    memset(wire, 0xFF, sizeof(wire));
+
+    assert_int_equal(bolos_ux_sskr_hex_check(wire, sizeof(wire), 0), 0);
+
+    /* And erased on the way out, like every other failure path here. */
+    for (unsigned int i = 0; i < sizeof(wire); i++) {
+        assert_int_equal(wire[i], 0x00);
+    }
+}
+
+int main(void) {
+    const struct CMUnitTest tests[] = {
+        cmocka_unit_test(test_hex_check_accepts_reference_share),
+        cmocka_unit_test(test_hex_check_rejects_zero_share_count),
+    };
+    return cmocka_run_group_tests(tests, NULL, NULL);
+}

--- a/tests/unit/tests/sskr_hex_check_guards.c
+++ b/tests/unit/tests/sskr_hex_check_guards.c
@@ -1,25 +1,38 @@
 /*
- * The guards bolos_ux_sskr_hex_check() holds on shares typed in as ByteWords.
+ * The two guards bolos_ux_sskr_hex_check() is supposed to hold on shares typed
+ * in as ByteWords: refusing by default, and the CRC-32.
  *
  * A gcov run over the whole suite gives the rejecting branch of this function
  * (seed_sskr.c, the memzero/return 0 arm) an execution count of zero: before
- * this file, no test had ever made it say no.
+ * this file, no test had ever made it say no, and deleting the CRC-32
+ * comparison outright left the whole suite green. That matters more here than
+ * it would elsewhere, because the CRC-32 is the only integrity check standing
+ * between a mistyped ByteWord that happens to decode and the Shamir
+ * recombination underneath.
  *
- * What is asserted here is that a share count of zero is refused. Every check
- * the function performs -- CBOR tag, metadata shared by all shares, CRC-32 --
- * lives inside a loop bounded by that count, so zero used to fall through to
- * the accepting return and report whatever it was handed as valid without
- * reading a byte of it. The count is not a constant of the build: it comes
- * from the member-threshold nibble of the entered data, and the share entry
- * screens leave it at zero for the reserved CBOR additional-info values 25-31,
- * precisely so this function rejects them.
+ * Two properties are asserted:
+ *
+ *   - a share count of zero is refused. Every check the function performs --
+ *     CBOR tag, metadata shared by all shares, CRC-32 -- lives inside a loop
+ *     bounded by that count, so zero used to fall through to the accepting
+ *     return and report whatever it was handed as valid without reading a byte
+ *     of it. The count is not a constant of the build: it comes from the
+ *     member-threshold nibble of the entered data, and the share entry screens
+ *     leave it at zero for the reserved CBOR additional-info values 25-31,
+ *     precisely so this function rejects them.
+ *
+ *   - the CRC-32 is both compared and recomputed. One test corrupts a CRC byte
+ *     (the comparison catches it), one corrupts a payload byte and leaves the
+ *     stored CRC alone (only recomputing catches it). A test that did just the
+ *     first would still pass against a function that compared the stored CRC
+ *     with itself.
  *
  * The vector is the 128-bit Blockchain Commons share set already used by
  * sskr_interop_bc128_bytewords.c, in the wire form the entry screen builds:
  * CBOR tag D9 9D 75, short-form byte string header 0x55 (21 bytes), the
  * serialized shard, then the CRC-32 in network byte order. Written out as
- * bytes here rather than as ByteWords so that corrupting individual bytes of
- * it is visible in the source.
+ * bytes here rather than as ByteWords so that corrupting one byte of the CRC
+ * and one byte of the payload is visible in the source.
  *
  * Built with AddressSanitizer: the offsets this function reads from are
  * computed by dividing a caller-supplied buffer length by a caller-supplied
@@ -42,6 +55,8 @@
 // clang-format on
 
 #define WIRE_LEN (29) /* tag(3) + length byte(1) + shard(21) + CRC(4) */
+#define CRC_LEN (4)
+#define CRC_FIRST (WIRE_LEN - CRC_LEN)
 
 /* Member index 0 of the 2-of-3 set; valid on its own as far as this function
  * is concerned, which checks each share independently plus, from the second
@@ -51,14 +66,18 @@ static const uint8_t k_share[WIRE_LEN] = {
     0x79, 0x90, 0x3D, 0xCB, 0x83, 0x3F, 0x4B, 0xF7, 0xD4, 0x33,
     0xFD, 0xAE, 0x81, 0x59, 0x13, 0x5E, 0xF3, 0xB3, 0x38};
 
+/* An offset inside the serialized shard, past the CBOR header and clear of the
+ * CRC, so corrupting it leaves every check but the CRC-32 satisfied. */
+#define PAYLOAD_OFFSET (12)
+
 static void test_hex_check_accepts_reference_share(void** state) {
     (void)state;
 
     uint8_t wire[WIRE_LEN];
     memcpy(wire, k_share, sizeof(wire));
 
-    /* Control: without this the rejection below would prove nothing, since a
-     * function that refuses everything passes it. */
+    /* Control: without this the three rejections below would prove nothing,
+     * since a function that refuses everything passes all of them. */
     assert_int_equal(bolos_ux_sskr_hex_check(wire, sizeof(wire), 1), 1);
 }
 
@@ -78,10 +97,34 @@ static void test_hex_check_rejects_zero_share_count(void** state) {
     }
 }
 
+static void test_hex_check_rejects_corrupted_crc(void** state) {
+    (void)state;
+
+    uint8_t wire[WIRE_LEN];
+    memcpy(wire, k_share, sizeof(wire));
+    wire[CRC_FIRST] ^= 0x01;
+
+    assert_int_equal(bolos_ux_sskr_hex_check(wire, sizeof(wire), 1), 0);
+}
+
+static void test_hex_check_rejects_corrupted_payload(void** state) {
+    (void)state;
+
+    uint8_t wire[WIRE_LEN];
+    memcpy(wire, k_share, sizeof(wire));
+    wire[PAYLOAD_OFFSET] ^= 0x01;
+
+    /* The stored CRC is untouched: this only fails if the CRC is recomputed
+     * over the payload rather than taken on trust. */
+    assert_int_equal(bolos_ux_sskr_hex_check(wire, sizeof(wire), 1), 0);
+}
+
 int main(void) {
     const struct CMUnitTest tests[] = {
         cmocka_unit_test(test_hex_check_accepts_reference_share),
         cmocka_unit_test(test_hex_check_rejects_zero_share_count),
+        cmocka_unit_test(test_hex_check_rejects_corrupted_crc),
+        cmocka_unit_test(test_hex_check_rejects_corrupted_payload),
     };
     return cmocka_run_group_tests(tests, NULL, NULL);
 }

--- a/tests/unit/tests/sskr_share_len.c
+++ b/tests/unit/tests/sskr_share_len.c
@@ -1,5 +1,6 @@
 /*
- * Regression test for the unvalidated shard length in bolos_ux_sskr_combine().
+ * The shard-length bound in bolos_ux_sskr_combine(), on both sides of both of
+ * its edges, built with AddressSanitizer.
  *
  * The function reads the length of each serialized shard straight out of the
  * CBOR header of the entered data:
@@ -7,92 +8,180 @@
  *     uint8_t sskr_share_len = sskr_shares_hex[3] & 0x1F;
  *     if (sskr_share_len > 23) sskr_share_len = sskr_shares_hex[4];   // 0..255
  *
- * and hands it to sskr_combine_shards() unchecked. Down in
- * sskr_deserialize_shard() that becomes
+ * A serialized shard is SSKR_METADATA_LENGTH_BYTES plus a 16..32 byte value,
+ * so anything outside 21..37 is not a shard. What makes the bound load-bearing
+ * rather than tidy is what sits downstream: sskr_deserialize_shard() does
  *
  *     shard->value_len = source_len - SSKR_METADATA_LENGTH_BYTES;
- *     memcpy(shard->value, source + SSKR_METADATA_LENGTH_BYTES, shard->value_len);
+ *     memcpy(shard->value, source + 5, shard->value_len);
  *
- * and only then is the length validated -- the copy already happened.
+ * and only then validates the length -- the copy has already happened, reading
+ * source_len bytes out of a share buffer that is nowhere near that long and
+ * writing them into a fixed 32-byte field. Reordering that is a change to
+ * sskr.c, which is kept diffable against upstream bc-sskr; the bound in this
+ * wrapper is what keeps the reordering from being urgent, because here the
+ * length comes from data typed on the device rather than from a library user.
  *
- * How far that copy reaches on this path is bounded, and worth writing down
- * because it is not obvious. The destination is shards[0].value inside
- * sskr_combine_shards()'s own
- *
- *     sskr_shard_t shards[SSS_MAX_SHARE_COUNT * SSKR_MAX_GROUP_COUNT];
- *
- * which is 10 * 40 = 400 bytes on TARGET_NANOS; value sits at offset 8, and a
- * one-byte CBOR length cannot ask for more than 255 - 5 = 250. The write
- * therefore stays inside that array -- checked with sskr.c compiled under
- * AddressSanitizer, which reports nothing -- clobbering shards[1..6] while
- * they are still uninitialised. The loop then stops on the very error the copy
- * should have been refused by, and memzero() wipes the array on the way out.
- *
- * So this is robustness rather than memory safety: an input-derived length is
- * used before it is validated, and the only thing keeping that harmless is
- * arithmetic nobody wrote down. Raise SSS_MAX_SHARE_COUNT, widen the length
- * field or shrink sskr_shard_t and it stops holding.
- *
- * The assertion below is on the return value, which is all this can observe.
- * It is coupled to a separate defect: without the bound the call comes back
- * non-zero only because bolos_ux_sskr_combine() stores a negative error code
- * in a uint16_t, so its `output_len < 1` guard never fires. Fix that and the
- * assertion holds with or without the bound, and will need revisiting.
- *
- * A serialized shard is 5 metadata bytes plus a 16..32 byte value, so anything
- * outside 21..37 is not a shard and must be refused before any copy. Upstream
- * bc-sskr has the same ordering, but its callers are library users passing
- * their own sizes; here the value comes from data typed on the device, so the
- * bound belongs in this wrapper -- which also keeps sskr.c diffable against
- * upstream.
+ * That makes this test a memory-safety test, so it asserts on the sanitizer as
+ * much as on the return value. The return value alone cannot hold this bound:
+ * an out-of-range length also fails validation further down, so combine()
+ * answers 0 either way and the assertion passes on unbounded code. Deleting
+ * the bound and running the suite is how that was established, and it is why
+ * the over-long cases below hand combine() a buffer sized to the share it
+ * actually contains -- which is what the entry screens do -- instead of one
+ * padded out to the declared length.
  */
 
-#include <stdarg.h>
-#include <stdint.h>
-#include <stddef.h>
-#include <setjmp.h>
 #include <cmocka.h>
+#include <setjmp.h>
+#include <stdarg.h>
+#include <stddef.h>
+#include <stdint.h>
 #include <string.h>
 
+/* testutils.h has to come first: it defines WIDE, which
+ * sskr/seed_rom_variables.h uses without defining. Not sorted, hence the
+ * clang-format exclusion. */
+// clang-format off
 #include "testutils.h"
 #include "sskr/common_sskr.h"
 #include "sskr/sskr-constants.h"
+// clang-format on
 
-#define OVERLONG_VALUE_LEN (200)
-#define CBOR_LONG_HEADER   (5) /* tag(3) + 0x58 + one length byte */
+/* 2-of-3 over a 128-bit secret: 21-byte shards, so the CBOR header is the
+ * short form (tag + 0x40|21) and sskr_share_len sits at the low five bits of
+ * byte 3. Same share set as sskr_interop_bc128_bytewords.c, generated with
+ * Blockchain Commons' bc-sskr. */
+#define SHORT_HEADER (4)
+#define SHORT_SHARD_LEN (SSKR_MIN_SERIALIZED_LENGTH_BYTES) /* 21 */
+#define SHORT_WIRE (SHORT_HEADER + SHORT_SHARD_LEN + 4)
 
-static void test_combine_rejects_overlong_shard_length(void **state)
-{
-    (void) state;
+static const uint8_t k_min_len_shares[2 * SHORT_WIRE] = {
+    0xD9, 0x9D, 0x75, 0x55, 0x01, 0x00, 0x00, 0x01, 0x00, 0x72, 0x79, 0x90,
+    0x3D, 0xCB, 0x83, 0x3F, 0x4B, 0xF7, 0xD4, 0x33, 0xFD, 0xAE, 0x81, 0x59,
+    0x13, 0x5E, 0xF3, 0xB3, 0x38, 0xD9, 0x9D, 0x75, 0x55, 0x01, 0x00, 0x00,
+    0x01, 0x01, 0x1B, 0x3F, 0x98, 0x69, 0x92, 0x4E, 0x46, 0x03, 0x14, 0x4D,
+    0x4A, 0x40, 0x84, 0xF0, 0x90, 0xCC, 0xAE, 0x60, 0x76, 0x65};
 
-    /* One shard whose CBOR header claims a 200-byte body: well past the 37
-     * bytes a real serialized shard can occupy. */
-    uint8_t wire[CBOR_LONG_HEADER + OVERLONG_VALUE_LEN + 4];
-    uint8_t output[SSKR_MAX_STRENGTH_BYTES];
+static const uint8_t k_min_len_secret[16] = {0x59, 0xF2, 0x29, 0x3A, 0x5B, 0xCE,
+                                             0x7D, 0x4D, 0xE5, 0x9E, 0x71, 0xB4,
+                                             0x20, 0x7A, 0xC5, 0xD2};
 
-    memset(wire, 0x42, sizeof(wire));
-    wire[0] = 0xD9;
-    wire[1] = 0x9D;
-    wire[2] = 0x75;                      // CBOR tag #6.40309
-    wire[3] = 0x58;                      // byte string, 1-byte length follows
-    wire[4] = OVERLONG_VALUE_LEN;        // -> sskr_share_len = 200
+/* 2-of-3 over a 256-bit secret: 37-byte shards, the largest a shard can be, so
+ * the CBOR header is the long form (tag + 0x58 + one length byte) and
+ * sskr_share_len is read from byte 4. Same share set as tests/roundtrip.c. */
+#define LONG_HEADER (5)
+#define LONG_SHARD_LEN (SSKR_METADATA_LENGTH_BYTES + SSKR_MAX_STRENGTH_BYTES)
+#define LONG_WIRE (LONG_HEADER + LONG_SHARD_LEN)
 
-    /* Shard metadata starts after the header; keep the reserved nibble zero so
-     * the only thing wrong with this input is its length. */
-    wire[CBOR_LONG_HEADER + 2] = 0x00;
-    wire[CBOR_LONG_HEADER + 3] = 0x00;
-    wire[CBOR_LONG_HEADER + 4] = 0x00;
+static const uint8_t k_max_len_shares[2 * LONG_WIRE] = {
+    0xD9, 0x9D, 0x75, 0x58, 0x25, 0x01, 0x00, 0x00, 0x01, 0x00, 0xFF, 0x0F,
+    0xBB, 0x2A, 0x8B, 0xCC, 0x6F, 0x00, 0xC8, 0xE6, 0x83, 0xDF, 0xB0, 0xEB,
+    0x5F, 0x1C, 0x55, 0xEF, 0x12, 0xD9, 0x4B, 0x62, 0x97, 0x42, 0x42, 0xDA,
+    0x21, 0x11, 0xBA, 0xC6, 0x5F, 0xAA, 0xD9, 0x9D, 0x75, 0x58, 0x25, 0x01,
+    0x00, 0x00, 0x01, 0x01, 0xB4, 0x8E, 0x81, 0x9F, 0xBB, 0x8A, 0x1C, 0xC3,
+    0xCF, 0xFB, 0x10, 0xBB, 0xC7, 0xB7, 0x96, 0xBC, 0xBD, 0xB3, 0x4F, 0x1E,
+    0x21, 0xCE, 0x04, 0x94, 0x48, 0x1E, 0x79, 0x8C, 0x0D, 0x7E, 0xEA, 0xA2};
 
-    unsigned int len = bolos_ux_sskr_combine(wire, sizeof(wire), 1, output);
+static const uint8_t k_max_len_secret[32] = {
+    0xE3, 0x95, 0x5C, 0xDA, 0x30, 0x47, 0x71, 0xC0, 0x03, 0x18, 0x95,
+    0x63, 0x7F, 0x55, 0xC3, 0xAB, 0xE4, 0x51, 0x53, 0xC8, 0x7A, 0xBD,
+    0x81, 0xC5, 0x1E, 0xD1, 0x4E, 0x8A, 0xAF, 0xA1, 0xAF, 0x13};
 
-    /* Must be refused. Without the bound, sskr_deserialize_shard() copies
-     * 195 bytes into a 32-byte field first. */
-    assert_int_equal(len, 0);
+/* Far enough past the 37-byte maximum that the read runs well off the end of
+ * the buffer rather than a byte or two past it. */
+#define OVERLONG_SHARD_LEN (200)
+
+static void test_combine_accepts_minimum_shard_length(void** state) {
+    (void)state;
+
+    uint8_t wire[sizeof(k_min_len_shares)];
+    uint8_t output[SSKR_MAX_STRENGTH_BYTES] = {0};
+
+    memcpy(wire, k_min_len_shares, sizeof(wire));
+
+    /* 21 is SSKR_MIN_SERIALIZED_LENGTH_BYTES exactly: the bound must let it
+     * through, not just refuse what is outside. */
+    assert_int_equal(bolos_ux_sskr_combine(wire, sizeof(wire), 2, output),
+                     sizeof(k_min_len_secret));
+    assert_memory_equal(output, k_min_len_secret, sizeof(k_min_len_secret));
 }
 
-int main(void)
-{
+static void test_combine_accepts_maximum_shard_length(void** state) {
+    (void)state;
+
+    uint8_t wire[sizeof(k_max_len_shares)];
+    uint8_t output[SSKR_MAX_STRENGTH_BYTES] = {0};
+
+    memcpy(wire, k_max_len_shares, sizeof(wire));
+
+    /* 37 is SSKR_METADATA_LENGTH_BYTES + SSKR_MAX_STRENGTH_BYTES exactly. */
+    assert_int_equal(bolos_ux_sskr_combine(wire, sizeof(wire), 2, output),
+                     sizeof(k_max_len_secret));
+    assert_memory_equal(output, k_max_len_secret, sizeof(k_max_len_secret));
+}
+
+static void test_combine_rejects_shard_length_below_minimum(void** state) {
+    (void)state;
+
+    uint8_t wire[sizeof(k_min_len_shares)];
+    uint8_t output[SSKR_MAX_STRENGTH_BYTES] = {0};
+
+    memcpy(wire, k_min_len_shares, sizeof(wire));
+
+    /* One below the minimum, in the short-form length nibble of byte 3: a
+     * 20-byte shard leaves a 15-byte value, under the 16-byte minimum. */
+    wire[3] = 0x40 | (SHORT_SHARD_LEN - 1);
+
+    /* This edge documents the bound rather than holding it: too short is also
+     * refused by sskr_deserialize_shard()'s own first check, so this case
+     * still passes with the bound deleted. The two above the maximum are the
+     * ones that hold it, and they are the dangerous side. */
+    assert_int_equal(bolos_ux_sskr_combine(wire, sizeof(wire), 1, output), 0);
+}
+
+static void test_combine_rejects_shard_length_above_maximum(void** state) {
+    (void)state;
+
+    /* A single share, in a buffer holding exactly the 42 bytes it occupies on
+     * the wire -- the entry screens size their buffer for a real share, not
+     * for whatever length the header claims. */
+    uint8_t wire[LONG_WIRE];
+    uint8_t output[SSKR_MAX_STRENGTH_BYTES] = {0};
+
+    memcpy(wire, k_max_len_shares, sizeof(wire));
+
+    /* One above the maximum, in the long-form length byte. Without the bound
+     * the copy reads 33 bytes from 10 bytes in, one past the end of wire[],
+     * and writes them into a 32-byte field. */
+    wire[4] = LONG_SHARD_LEN + 1;
+
+    assert_int_equal(bolos_ux_sskr_combine(wire, sizeof(wire), 1, output), 0);
+}
+
+static void test_combine_rejects_overlong_shard_length(void** state) {
+    (void)state;
+
+    /* Same single-share buffer as above, this time with a length that is not
+     * merely one too many. */
+    uint8_t wire[LONG_WIRE];
+    uint8_t output[SSKR_MAX_STRENGTH_BYTES] = {0};
+
+    memcpy(wire, k_max_len_shares, sizeof(wire));
+    wire[4] = OVERLONG_SHARD_LEN;
+
+    /* Must be refused before any copy. Without the bound,
+     * sskr_deserialize_shard() reads 195 bytes starting 10 bytes into a
+     * 42-byte buffer and writes them into a 32-byte field. */
+    assert_int_equal(bolos_ux_sskr_combine(wire, sizeof(wire), 1, output), 0);
+}
+
+int main(void) {
     const struct CMUnitTest tests[] = {
+        cmocka_unit_test(test_combine_accepts_minimum_shard_length),
+        cmocka_unit_test(test_combine_accepts_maximum_shard_length),
+        cmocka_unit_test(test_combine_rejects_shard_length_below_minimum),
+        cmocka_unit_test(test_combine_rejects_shard_length_above_maximum),
         cmocka_unit_test(test_combine_rejects_overlong_shard_length),
     };
     return cmocka_run_group_tests(tests, NULL, NULL);


### PR DESCRIPTION
One fix and two guards put under test, all on the same path: validating SSKR
shares typed in as ByteWords.

## The fix: the validator answered "valid" without reading the data

`bolos_ux_sskr_hex_check()` returned 1 for a share count of zero. Everything
it checks -- the CBOR tag, the metadata all shares in a group must have in
common, the CRC-32 -- sits inside a loop bounded by that count, so a count of
zero skipped all of it and fell through to the accepting return. The CRC-32,
the only integrity check on entered shares, was never evaluated in that case.

The count is not a constant of the build. It is read from the member-threshold
nibble of the entered data, in all three entry paths (`src/nbgl/sskr_shares.c`
and the two BAGL twins):

```c
case 7:  if ((buffer[3] & 0x1F) <  24) { count = (byte & 0x0F) + 1; }  break;
case 8:  if ((buffer[3] & 0x1F) == 24) { count = (byte & 0x0F) + 1; }  break;
```

Neither branch fires for the reserved CBOR additional-info values 25-31, so
the count keeps the zero `sskr_shares_reset()` left it with, and
`sskr_shares_complete_check()` returns true after the first share
(`shareindex 1 < sharecount 0` is false). Those reserved values are exactly
what the CBOR fix already in the tree deliberately lets through, on the
premise that this function would reject them:

> Force the same maximum bound used below for an out-of-range declared
> length, so entry can still complete and `bolos_ux_sskr_hex_check()`
> rejects it

It did not reject it. Now it refuses a zero count up front, erasing the buffer
the way the other failure path in that function does.

### What the user sees

**The final screen does not change**, and it is worth being explicit about
that. In all three UI paths the shares were already reported as invalid one
step further down: `bolos_ux_sskr_combine()` has the zero-count guard this
function was missing, so `compare_recovery_phrase()` came back with
`reconstructed == false`, and both the NBGL `sskr_shares_check()` and the two
BAGL callers turn that into the same result as a `hex_check` failure --
"The SSKR Recovery Phrase you have entered is not valid" / `ux_sskr_invalid_flow`.

What changes is that the rejection now happens *before* the seed comparison is
attempted rather than after, so the transient processing screen on the two
BAGL paths (`screen_processing_init()` on Nano S, the loading flow on Nano X)
no longer appears for this input. And a function whose only job is to validate
no longer returns "valid" for input it has not read, which is what makes the
next caller safe rather than lucky.

### The other half, left to you

There is a second place this could be addressed, and I have deliberately not
touched it. The two branches above are mutually exclusive on
`buffer[3] & 0x1F` -- under 24 the member-threshold nibble is byte 7, at 24 it
is byte 8 -- and for the reserved values 25-31 there is no `else`: the count
is simply never assigned, so it keeps the zero `sskr_shares_reset()` left it
with. Giving it a defined non-zero value there would let the loop run once and
reject the share on its CRC-32, which is what the comment quoted above
describes.

I have not done it for two reasons. It is redundant now that the validator
refuses by default: that fixes the function's contract for every caller,
whereas an entry-side assignment fixes one caller at a time and says nothing
about what the function promises. And the same switch is duplicated verbatim
in `src/nbgl/sskr_shares.c`, `src/bagl/nanos_enter_phrase.c` and
`src/bagl/nanox_enter_phrase.c`, so doing it properly means the same patch
three times -- and doing it in one place only would make the three UI stacks
disagree. Whether that duplication is worth collapsing is your call, not
something to decide inside a bug fix.

## Two guards that no test held

Both were found by deleting them and running the suite: it stayed entirely
green in each case.

**The CRC-32.** It is the only integrity check between a mistyped ByteWord
that happens to decode and the Shamir recombination underneath. Two cases now
cover it, because two things can go wrong independently: a corrupted CRC byte
(fails only if the stored CRC is compared at all) and a corrupted payload byte
with the stored CRC left alone (fails only if the CRC is recomputed rather
than taken on trust). A test doing just the first would still pass against a
function comparing the stored CRC with itself.

**The 21..37 shard-length bound in `bolos_ux_sskr_combine()`.** There was
already a test named for this bound, and it stayed green without it. Its own
comment had predicted exactly that: the return-value defect it was coupled to
has since been fixed, so an out-of-range length now fails validation further
down and `combine()` answers 0 either way.

That bound is what keeps `sskr_deserialize_shard()` from copying an entered
length's worth of bytes before it validates that length:

```c
shard->value_len = source_len - SSKR_METADATA_LENGTH_BYTES;
memcpy(shard->value, source + 5, shard->value_len);

int16_t error = sskr_check_secret_length(shard->value_len);   /* too late */
```

So the sanitizer is the assertion now, not the return value. The target is
built with AddressSanitizer, and the over-long cases hand `combine()` a buffer
sized to the share it really contains -- which is what the entry screens do --
rather than one padded out to the declared length. With the bound deleted, a
declared length of 38 reads 33 bytes from ten bytes into a 42-byte buffer:

```
ERROR: AddressSanitizer: stack-buffer-overflow
READ of size 33
    #0 memcpy
    #1 sskr_deserialize_shard sskr.c:156
    #2 sskr_combine_shards sskr.c:586
```

**Reordering the copy and the validation in `sskr.c` is deliberately not part
of this PR** -- that file is kept diffable against upstream bc-sskr, and the
bound in the wrapper is what makes the reordering unnecessary for now. Happy
to open it separately if you want it done properly at the library level.

## Verification

Every guard checked by mutation: delete it, confirm the intended test goes
red, restore, re-verify the source checksum. No mutation is left in any
commit.

| guard removed | result |
|---|---|
| zero share count in `hex_check()` | `test_hex_check_rejects_zero_share_count` red |
| CRC-32 comparison | `test_hex_check_rejects_corrupted_crc` **and** `..._corrupted_payload` red |
| 21..37 shard-length bound | `test_sskr_share_len` red, ASan `stack-buffer-overflow` |

One case is honest about not holding anything: a declared length of 20 is also
refused by `sskr_deserialize_shard()`'s own first check, so it survives the
mutation. It documents the lower edge; the two cases above the upper edge are
what hold the bound, and that is the dangerous side. This is written into the
test file rather than left implicit.

Vectors are ones already in the suite -- the 128-bit Blockchain Commons share
set and the 256-bit set from `tests/roundtrip.c` -- written out as wire bytes
so the corrupted byte is visible in the source.

- `ctest -N`: 38 -> 39 targets, 39/39 green, no new compiler warnings.
- `seed_sskr.c` line coverage 195/209 -> 201/212. The three lines of the
  rejecting arm of `hex_check()` go from zero executions to non-zero: the
  suite had never made that function say no. No line regressed.
- All six targets in `ledger_app.toml` built by hand, including `nanos`,
  which `ci-workflow.yml` does not build: 6/6, zero warnings.
  `arm-none-eabi-size` is unchanged on all six, but that is because `.text`
  is a fixed-size region -- measured at the symbol level the fix costs 28
  bytes of code on `nanos` and 26 on the others, with BSS unchanged.
- `clang-format --dry-run -Werror` clean on all three files touched.
- No Speculos script needed: no existing secret-erasure path is modified.

## Unrelated finding, not addressed here

`common_sskr.h` declares `bolos_ux_sskr_hex_check()` taking a
`const unsigned char *`, while `seed_sskr.c` defines it taking
`unsigned char *` and writes through it (`memzero`). The two never meet in a
single translation unit today, so it compiles. Mentioning it rather than
touching it.
