### PR TITLE
fix: validate the shard length before the copy it governs

### DIFF
--- a/src/common/sskr/sskr.c
+++ b/src/common/sskr/sskr.c
@@ -153,12 +153,16 @@ static int16_t sskr_deserialize_shard(const uint8_t* source,
     }
     shard->member_index = source[4] & 0xf;
     shard->value_len = source_len - SSKR_METADATA_LENGTH_BYTES;
-    memcpy(shard->value, source + SSKR_METADATA_LENGTH_BYTES, shard->value_len);
 
+    // source_len is supplied by the caller and shard->value is a fixed-size
+    // field, so this check has to happen before the copy it governs, not
+    // after it.
     int16_t error = sskr_check_secret_length(shard->value_len);
     if (error) {
         return error;
     }
+
+    memcpy(shard->value, source + SSKR_METADATA_LENGTH_BYTES, shard->value_len);
     return shard->value_len;
 }
 

--- a/tests/unit/CMakeLists.txt
+++ b/tests/unit/CMakeLists.txt
@@ -222,6 +222,21 @@ target_compile_options(test_sskr_hex_check_guards PRIVATE -fsanitize=address -fn
 target_link_options(test_sskr_hex_check_guards PRIVATE -fsanitize=address)
 target_link_libraries(test_sskr_hex_check_guards PUBLIC cmocka gcov sskr sss testutils)
 
+# The other half of the bound test_sskr_share_len holds: what happens in
+# sskr_deserialize_shard() when a length that far out reaches it anyway.
+# Built with AddressSanitizer, and with sskr.c compiled into the test itself
+# rather than linked from libsskr -- that function is static, and reached
+# through sskr_combine_shards() the overrun it is about lands inside that
+# caller's own shards[] array, which is intra-object and something ASan does
+# not report. The file says the same at more length. libsskr is deliberately
+# absent from target_link_libraries below: linking it too would duplicate
+# every symbol in the translation unit.
+add_executable(test_sskr_deserialize_shard_bounds ./tests/sskr_deserialize_shard_bounds.c)
+target_include_directories(test_sskr_deserialize_shard_bounds PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/../../src/common ${CMAKE_CURRENT_SOURCE_DIR}/../../src/common/sskr/sss)
+target_compile_options(test_sskr_deserialize_shard_bounds PRIVATE -fsanitize=address -fno-omit-frame-pointer)
+target_link_options(test_sskr_deserialize_shard_bounds PRIVATE -fsanitize=address)
+target_link_libraries(test_sskr_deserialize_shard_bounds PUBLIC cmocka gcov testutils sss)
+
 add_executable(test_sskr_memzero ./tests/sskr_memzero.c ../../src/common/bip39/seed_rom_variables.c ../../src/common/bip39/seed_bip39.c ../../src/common/sskr/seed_rom_variables.c ../../src/common/sskr/seed_sskr.c)
 target_include_directories(test_sskr_memzero PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/../../src/common)
 target_link_libraries(test_sskr_memzero PUBLIC cmocka gcov sskr sss testutils)
@@ -499,6 +514,6 @@ add_executable(test_bip85_derivation_path tests/bip85_derivation_path.c ../../sr
 target_include_directories(test_bip85_derivation_path PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/../../src)
 target_link_libraries(test_bip85_derivation_path PUBLIC cmocka gcov testutils)
 
-foreach(target test_sss test_sss_recover_erase_length test_sss_validate_parameters test_sskr test_sskr_to_seed_convert test_sskr_generate_combine_guards test_sskr_threshold_three_roundtrip test_sskr_share_len test_sskr_hex_check_guards test_sskr_memzero test_sskr_shard_count test_sskr_generate_split_error test_sskr_generate_bound_groups test_sskr_combine_erase_on_failure test_sskr_count_shards_invariants test_sskr_generate_erase_on_split_failure test_sskr_combine_bounds test_sskr_invalid_group_descriptor test_sskr_combine_error test_sskr_combine_invariants test_sskr_interop_bc128 test_sskr_interop_bc128_bytewords test_sskr_entry_bounds test_sskr_byteword_sentinel test_sskr_cbor_additional_info test_bip39 test_bip39_entry_bounds test_roundtrip test_words test_base64 test_base85 test_bip85_dice_bits_per_roll test_bip85_dice_roll test_bip85_bip39_entropy test_bip85_hex_vector test_bip85_finalize_pwd test_bip85_drng_with_seed test_bip85_derivation_path test_compare_recovery_phrase_finish)
+foreach(target test_sss test_sss_recover_erase_length test_sss_validate_parameters test_sskr test_sskr_to_seed_convert test_sskr_generate_combine_guards test_sskr_threshold_three_roundtrip test_sskr_share_len test_sskr_hex_check_guards test_sskr_deserialize_shard_bounds test_sskr_memzero test_sskr_shard_count test_sskr_generate_split_error test_sskr_generate_bound_groups test_sskr_combine_erase_on_failure test_sskr_count_shards_invariants test_sskr_generate_erase_on_split_failure test_sskr_combine_bounds test_sskr_invalid_group_descriptor test_sskr_combine_error test_sskr_combine_invariants test_sskr_interop_bc128 test_sskr_interop_bc128_bytewords test_sskr_entry_bounds test_sskr_byteword_sentinel test_sskr_cbor_additional_info test_bip39 test_bip39_entry_bounds test_roundtrip test_words test_base64 test_base85 test_bip85_dice_bits_per_roll test_bip85_dice_roll test_bip85_bip39_entropy test_bip85_hex_vector test_bip85_finalize_pwd test_bip85_drng_with_seed test_bip85_derivation_path test_compare_recovery_phrase_finish)
     add_test(NAME ${target} COMMAND ${target})
 endforeach()

--- a/tests/unit/tests/sskr_deserialize_shard_bounds.c
+++ b/tests/unit/tests/sskr_deserialize_shard_bounds.c
@@ -1,0 +1,250 @@
+/*
+ * sskr_deserialize_shard() derives the length of the copy from source_len,
+ * which its caller supplies, and writes into sskr_shard_t::value -- a fixed
+ * 32-byte field. The length check that bounds it, sskr_check_secret_length(),
+ * used to run after the memcpy, so a source_len of 60 wrote 55 bytes into
+ * those 32 before returning SSKR_ERROR_SECRET_TOO_LONG.
+ *
+ * Why this needs its own translation unit rather than the public entry point.
+ * sskr_deserialize_shard() is static, and reached the only way the application
+ * reaches it -- through sskr_combine_shards() -- the overrun lands inside that
+ * function's own
+ *
+ *     sskr_shard_t shards[SSS_MAX_SHARE_COUNT * SSKR_MAX_GROUP_COUNT];
+ *
+ * clobbering shards[1..] while they are still uninitialised but never leaving
+ * the array. That is an intra-object overrun: AddressSanitizer places its
+ * redzones between objects, not between the fields of one, and reports
+ * nothing. A test driving sskr_combine_shards() under ASan would therefore
+ * pass whichever order the two statements are in, and prove nothing. Building
+ * sskr.c into this file instead lets the destination be an object of its own,
+ * so the write is observable -- see the two overlong tests below, which check
+ * it twice over: once with sentinel bytes, which hold with or without a
+ * sanitizer, and once against an exact-size heap block, which ASan flags
+ * immediately.
+ *
+ * Note what this is and is not. Through the application the bound in
+ * bolos_ux_sskr_combine() keeps source_len in 21..37 before the call, so the
+ * ordering was never reachable from the device, and the overrun described
+ * above stayed inside the caller's array: robustness rather than memory
+ * safety, with arithmetic nobody wrote down as the only thing keeping it
+ * harmless. sskr_combine_shards() is public API in sskr.h, though, and a
+ * caller there passes its own shard_len with nothing checking it.
+ */
+
+// clang-format off
+/* The root .clang-format has duplicate keys, so its `SortIncludes: false`
+ * never applies and includes get sorted -- which breaks this file, since
+ * testutils.h supplies the WIDE qualifier that headers below rely on, and
+ * sskr.c must come last of all. */
+#include <stdarg.h>
+#include <stddef.h>
+#include <stdint.h>
+#include <setjmp.h>
+#include <cmocka.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include "testutils.h"
+#include "sskr/sskr-constants.h"
+#include "sskr/shard.h"
+
+/* Built into this file on purpose: sskr_deserialize_shard() is static.
+ * The target does not link libsskr, which would duplicate every symbol.
+ * The directory prefix matters: an unprefixed "sskr.c" resolves to this
+ * directory's own tests/sskr.c, which has a main() of its own. */
+#include "sskr/sskr.c"
+// clang-format on
+
+/* sskr_check_secret_length() bounds value_len with SSKR_MAX_STRENGTH_BYTES,
+ * not with sizeof(shard->value). They are the same today; if they ever stop
+ * being, the check stops protecting the field and this fails to build. */
+_Static_assert(
+    sizeof(((sskr_shard_t*)0)->value) == SSKR_MAX_STRENGTH_BYTES,
+    "sskr_check_secret_length() no longer bounds sskr_shard_t::value");
+
+#define PAYLOAD_BYTE (0x42)
+#define SENTINEL_BYTE (0xa5)
+#define SENTINEL_LEN (64)
+
+/* A serialized shard whose metadata is deliberately unremarkable: group
+ * threshold 1 of 1, reserved nibble clear. The only thing under test is the
+ * length, so nothing else may be a reason to refuse the input. */
+static void build_shard(uint8_t* source, uint16_t source_len) {
+    memset(source, PAYLOAD_BYTE, source_len);
+    source[0] = 0x00;
+    source[1] = 0x01;
+    source[2] = 0x00; /* group_threshold 1, group_count 1 */
+    source[3] = 0x00;
+    source[4] = 0x00; /* reserved nibble clear, member_index 0 */
+}
+
+static void test_deserialize_shard_accepts_maximum_length(void** state) {
+    (void)state;
+
+    uint8_t source[SSKR_METADATA_LENGTH_BYTES + SSKR_MAX_STRENGTH_BYTES];
+    sskr_shard_t shard;
+
+    build_shard(source, sizeof(source));
+    memset(&shard, 0, sizeof(shard));
+
+    assert_int_equal(sskr_deserialize_shard(source, sizeof(source), &shard),
+                     SSKR_MAX_STRENGTH_BYTES);
+    assert_int_equal(shard.value_len, SSKR_MAX_STRENGTH_BYTES);
+    /* The copy still happens on the accepted path. */
+    assert_memory_equal(shard.value, source + SSKR_METADATA_LENGTH_BYTES,
+                        SSKR_MAX_STRENGTH_BYTES);
+}
+
+static void test_deserialize_shard_rejects_one_past_maximum(void** state) {
+    (void)state;
+
+    uint8_t source[SSKR_METADATA_LENGTH_BYTES + SSKR_MAX_STRENGTH_BYTES + 1];
+    sskr_shard_t shard;
+
+    build_shard(source, sizeof(source));
+    memset(&shard, 0, sizeof(shard));
+
+    assert_int_equal(sskr_deserialize_shard(source, sizeof(source), &shard),
+                     SSKR_ERROR_SECRET_TOO_LONG);
+}
+
+static void test_deserialize_shard_accepts_minimum_length(void** state) {
+    (void)state;
+
+    uint8_t source[SSKR_MIN_SERIALIZED_LENGTH_BYTES];
+    sskr_shard_t shard;
+
+    build_shard(source, sizeof(source));
+    memset(&shard, 0, sizeof(shard));
+
+    assert_int_equal(sskr_deserialize_shard(source, sizeof(source), &shard),
+                     SSKR_MIN_STRENGTH_BYTES);
+    assert_int_equal(shard.value_len, SSKR_MIN_STRENGTH_BYTES);
+    assert_memory_equal(shard.value, source + SSKR_METADATA_LENGTH_BYTES,
+                        SSKR_MIN_STRENGTH_BYTES);
+}
+
+static void test_deserialize_shard_rejects_one_below_minimum(void** state) {
+    (void)state;
+
+    uint8_t source[SSKR_MIN_SERIALIZED_LENGTH_BYTES - 1];
+    sskr_shard_t shard;
+
+    build_shard(source, sizeof(source));
+    memset(&shard, 0, sizeof(shard));
+
+    assert_int_equal(sskr_deserialize_shard(source, sizeof(source), &shard),
+                     SSKR_ERROR_NOT_ENOUGH_SERIALIZED_BYTES);
+}
+
+/* The third code sskr_check_secret_length() can produce, so that moving the
+ * call is shown not to have lost any of them. */
+static void test_deserialize_shard_rejects_odd_value_length(void** state) {
+    (void)state;
+
+    uint8_t source[SSKR_MIN_SERIALIZED_LENGTH_BYTES + 1];
+    sskr_shard_t shard;
+
+    build_shard(source, sizeof(source));
+    memset(&shard, 0, sizeof(shard));
+
+    assert_int_equal(sskr_deserialize_shard(source, sizeof(source), &shard),
+                     SSKR_ERROR_SECRET_LENGTH_NOT_EVEN);
+}
+
+/* 60 bytes: the value the overrun was measured at, 55 bytes into a 32-byte
+ * field. Sentinels rather than a sanitizer, so this holds even in a build
+ * without one -- and the value field itself is checked too, since the fix
+ * means nothing at all is written on the refused path. */
+#define OVERLONG_SOURCE_LEN (60)
+
+static void test_deserialize_shard_overlong_writes_nothing(void** state) {
+    (void)state;
+
+    uint8_t source[OVERLONG_SOURCE_LEN];
+    uint8_t block[sizeof(sskr_shard_t) + SENTINEL_LEN];
+    sskr_shard_t* shard = (sskr_shard_t*)block;
+
+    build_shard(source, sizeof(source));
+    memset(block, SENTINEL_BYTE, sizeof(block));
+
+    assert_int_equal(sskr_deserialize_shard(source, sizeof(source), shard),
+                     SSKR_ERROR_SECRET_TOO_LONG);
+
+    /* Nothing landed in the value field. */
+    for (size_t i = 0; i < sizeof(shard->value); i++) {
+        assert_int_equal(shard->value[i], SENTINEL_BYTE);
+    }
+    /* Nor past the end of the structure it lives in. */
+    for (size_t i = sizeof(sskr_shard_t); i < sizeof(block); i++) {
+        assert_int_equal(block[i], SENTINEL_BYTE);
+    }
+}
+
+/* Same input, destination alone in a heap block sized exactly to the
+ * structure, so the write has no neighbour to hide in and AddressSanitizer
+ * reports it directly rather than through a surviving sentinel. */
+static void test_deserialize_shard_overlong_stays_in_its_allocation(
+    void** state) {
+    (void)state;
+
+    uint8_t source[OVERLONG_SOURCE_LEN];
+    sskr_shard_t* shard = malloc(sizeof(sskr_shard_t));
+
+    assert_non_null(shard);
+    build_shard(source, sizeof(source));
+    memset(shard, 0, sizeof(sskr_shard_t));
+
+    assert_int_equal(sskr_deserialize_shard(source, sizeof(source), shard),
+                     SSKR_ERROR_SECRET_TOO_LONG);
+
+    free(shard);
+}
+
+/* Moving the check must not let it overtake the two that already ran before
+ * the copy. Both inputs are overlong as well, so if the length check now came
+ * first these would report a length error instead. */
+static void test_deserialize_shard_reports_reserved_bits_first(void** state) {
+    (void)state;
+
+    uint8_t source[OVERLONG_SOURCE_LEN];
+    sskr_shard_t shard;
+
+    build_shard(source, sizeof(source));
+    source[4] = 0x10; /* reserved nibble set */
+    memset(&shard, 0, sizeof(shard));
+
+    assert_int_equal(sskr_deserialize_shard(source, sizeof(source), &shard),
+                     SSKR_ERROR_INVALID_RESERVED_BITS);
+}
+
+static void test_deserialize_shard_reports_group_threshold_first(void** state) {
+    (void)state;
+
+    uint8_t source[OVERLONG_SOURCE_LEN];
+    sskr_shard_t shard;
+
+    build_shard(source, sizeof(source));
+    source[2] = 0x10; /* group threshold 2 of group count 1 */
+    memset(&shard, 0, sizeof(shard));
+
+    assert_int_equal(sskr_deserialize_shard(source, sizeof(source), &shard),
+                     SSKR_ERROR_INVALID_GROUP_THRESHOLD);
+}
+
+int main(void) {
+    const struct CMUnitTest tests[] = {
+        cmocka_unit_test(test_deserialize_shard_accepts_maximum_length),
+        cmocka_unit_test(test_deserialize_shard_rejects_one_past_maximum),
+        cmocka_unit_test(test_deserialize_shard_accepts_minimum_length),
+        cmocka_unit_test(test_deserialize_shard_rejects_one_below_minimum),
+        cmocka_unit_test(test_deserialize_shard_rejects_odd_value_length),
+        cmocka_unit_test(test_deserialize_shard_overlong_writes_nothing),
+        cmocka_unit_test(
+            test_deserialize_shard_overlong_stays_in_its_allocation),
+        cmocka_unit_test(test_deserialize_shard_reports_reserved_bits_first),
+        cmocka_unit_test(test_deserialize_shard_reports_group_threshold_first),
+    };
+    return cmocka_run_group_tests(tests, NULL, NULL);
+}


### PR DESCRIPTION
`sskr_deserialize_shard()` derived the length of a copy from a caller-supplied
value, performed the copy into a fixed-size field, and validated the length
afterwards. This moves the existing check above the copy.

```c
shard->value_len = source_len - SSKR_METADATA_LENGTH_BYTES;
memcpy(shard->value, source + SSKR_METADATA_LENGTH_BYTES, shard->value_len);

int16_t error = sskr_check_secret_length(shard->value_len);   // too late
if (error) {
    return error;
}
```

`sskr_shard_t::value` is 32 bytes. A `source_len` of 60 therefore wrote 55
bytes into it and only then returned `SSKR_ERROR_SECRET_TOO_LONG`.

## What the fix is, and what it is not

It is four lines moved. No new logic, no new error code, no constant touched:
the wire format, the accepted value lengths and all eighteen error codes are
exactly as they were.

**Not reachable from the interface.** `sskr_deserialize_shard()` is `static`
with a single call site, `sskr_combine_shards()`, and the only caller of that
in this application is `bolos_ux_sskr_combine()`, which bounds the length to
21..37 before calling. That bound is itself under test since #98.

**And through that path it was not a memory-safety hole.** The copy overran
`shards[0].value` but stayed inside `sskr_combine_shards()`'s own

```c
sskr_shard_t shards[SSS_MAX_SHARE_COUNT * SSKR_MAX_GROUP_COUNT];
```

overwriting entries that were still uninitialised, and a one-byte CBOR length
cannot ask for more than 250 bytes. So this is robustness rather than memory
safety, and the only thing that kept it harmless was arithmetic nobody had
written down. Raise `SSS_MAX_SHARE_COUNT`, widen the length field or shrink
`sskr_shard_t` and it stops holding.

The actual argument for fixing it is one level up: `sskr_combine_shards()` is
public API in `sskr.h`, and a caller there passes its own `shard_len` with
nothing checking it at all.

## Verified not to change behaviour

Two differential harnesses, the same source compiled once against each version
and the outputs compared. Neither is part of this branch.

At `sskr_deserialize_shard()`, over **17,039,360 calls** -- every `source_len`
the public API can express crossed with every possible value of the two
metadata bytes the other guards read, plus the full `uint16_t` range of
`source_len`:

| digest over | result |
|---|---|
| return codes | **identical** |
| return code + whole struct + value bytes, on accepted inputs | **identical** |
| the same, on all inputs | differs |

The accepted set is the same on both sides, 21,888 inputs, so no share that
was valid is now refused and none that was refused is now accepted. The error
histogram matches per code (`-1`: 1,376,340, `-2`: 4,080, `-3`: 7,350,230,
`-6`: 7,735,915, `-7`: 19,456, `-16`: 531,451). The precedence between
`SSKR_ERROR_INVALID_GROUP_THRESHOLD`, `SSKR_ERROR_INVALID_RESERVED_BITS` and
the length errors is unchanged, and two tests pin it directly by feeding an
input that is both overlong and otherwise invalid.

The third row is the one intended difference: on a **refused** input the old
code wrote up to 250 bytes into `shard->value` and the new code writes
nothing. Nobody observes it -- the single call site stops its loop on a
negative return, skips `sskr_combine_shards_internal()` behind `if (!result)`,
and `memzero()`s the array on the way out.

At `sskr_combine_shards()`, over 5,376 calls including 20 real
reconstructions and byte-by-byte corruption of the metadata, the digest over
return value **and the full output buffer** is identical on both sides. The
Blockchain Commons interoperability vectors already in the suite stay green,
so conformance to the published format is held against an external source.

## Tests

New target `test_sskr_deserialize_shard_bounds`, nine cases: 21 and 37
accepted with the value actually copied, 20 and 38 refused with the codes they
refused with before, an odd length for the third code the check produces, the
two precedence cases, and the overlong case twice.

Twice, because the obvious way of writing it proves nothing. Reached through
`sskr_combine_shards()` the overrun lands **inside** that function's own
`shards[]` array, and AddressSanitizer places its redzones between objects,
not between the fields of one -- it reports nothing, so a test driving the
public entry point under ASan would pass whichever order the two statements
are in. This target builds `sskr.c` into the test instead, which lets the
destination be an object of its own: once framed by sentinel bytes, which hold
with or without a sanitizer, and once alone in a heap block sized exactly to
the structure, which ASan flags directly. The target is built with ASan, and
does not link `libsskr`, which would duplicate every symbol.

**Verified by mutation.** With the original order restored, only this target
fails, out of 40: the sentinels come back overwritten (`66 != 165`) and ASan
reports `heap-buffer-overflow WRITE of size 55` at the `memcpy`.

The file also pins `sizeof(sskr_shard_t::value)` to `SSKR_MAX_STRENGTH_BYTES`
with a static assertion -- `sskr_check_secret_length()` bounds `value_len` with
the constant, not with the size of the field it protects, and the two are only
equal by convention.

## One consequence worth flagging

This makes the 21..37 bound in `bolos_ux_sskr_combine()` redundant for memory
safety, and `test_sskr_share_len` can no longer discriminate it. Measured as a
truth table rather than assumed:

| `sskr.c` | bound in the wrapper | suite |
|---|---|---|
| fixed | present | 40/40 |
| fixed | **removed** | 40/40 -- the downstream check now absorbs it |
| original | present | the new target fails |
| original | **removed** | `test_sskr_share_len` and the new target fail |

The bound is still worth keeping as an early, cheap rejection close to the
entered data, and its `memzero()` of the input buffer has no equivalent
downstream. But it is no longer load-bearing, and the test that holds it will
stay green if it is ever removed. Flagging it rather than quietly changing
that test, since #98 only just landed.

## On diverging from upstream

`src/common/sskr/sskr.c` is a vendored copy of Blockchain Commons' bc-sskr,
and upstream has the same ordering -- checked against `BlockchainCommons/bc-sskr`
`master`, `src/encoding.c`, `deserialize_shard()`. So these are four lines a
future resync would revert, which is worth saying plainly.

It still seems the right place for it. The bound that makes the ordering
harmless today only covers this application's path, while `sskr_combine_shards()`
is public API. And this copy has already diverged structurally rather than
cosmetically -- different file name, different type name, `uint8_t` where
upstream has `size_t` for every metadata field including `value_len`, `int16_t`
returns, the `memzero` macro, plus Ledger-specific conditionals in bc-shamir --
so there is no mechanical diff against upstream left to preserve. Happy to move
the check into the wrapper instead if you would rather keep this file closer to
upstream. The defect is also worth reporting upstream, where `value_len` is a
`size_t` and the copy is not capped at 250 bytes as it is here.

## Checks

- `ctest -N` 39 -> 40, **40/40 green**, clean build from scratch, no `error:`
  and no new `warning:` (the two that remain are pre-existing).
- Coverage of `sskr.c`: **213/229 -> 215/237 lines, no regression**. The two
  lines this is about go from a zero counter to non-zero -- the
  `SSKR_ERROR_NOT_ENOUGH_SERIALIZED_BYTES` return and the length check's
  `return error`. The denominator moves only because `lcov` merges both
  compilations of the file into one record and the sanitized one instruments
  eight stack-array declarations that the ordinary build emits no code for;
  all eight are declarations, so percentages are not comparable here but line
  counts are.
- All six devices in `ledger_app.toml` built by hand, `nanos` included since
  CI does not build it: 6/6, no errors, no warnings, `arm-none-eabi-size`
  unchanged everywhere. Measured on the sum of `T` symbol sizes instead, the
  change **removes 32 bytes** on five of them (`sskr_combine_shards` 840 ->
  808) and none on `nanos`, where the SSKR recombination path is dropped at
  link time.
- `clang-format --dry-run -Werror` clean on both touched files.
- No Speculos script needed: no secret-erasure path is modified.
