### PR TITLE
fix: make the BIP-39, SSKR and BIP-85 sources agree with their public headers

### DIFF
--- a/src/common/bip39/seed_bip39.c
+++ b/src/common/bip39/seed_bip39.c
@@ -19,6 +19,7 @@
 #include <os.h>
 
 #include "../common.h"
+#include "./common_bip39.h"
 #include "./seed_rom_variables.h"
 
 // separated function to lower the stack usage when jumping into pbkdf algorithm
@@ -32,7 +33,7 @@ unsigned int bolos_ux_bip39_mnemonic_to_seed_hash_length128(
     return mnemonic_length;
 }
 
-void bolos_ux_bip39_mnemonic_to_seed(unsigned char* mnemonic,
+void bolos_ux_bip39_mnemonic_to_seed(const unsigned char* mnemonic,
                                      unsigned int mnemonic_length,
                                      unsigned char* seed) {
     // Need to keep BIP39 mnemonic in case we want to generate SSKR from it
@@ -49,7 +50,7 @@ void bolos_ux_bip39_mnemonic_to_seed(unsigned char* mnemonic,
     PRINTF("BIP39 seed computed: 64 bytes\n");
 }
 
-unsigned int bolos_ux_bip39_mnemonic_decode(unsigned char* mnemonic,
+unsigned int bolos_ux_bip39_mnemonic_decode(const unsigned char* mnemonic,
                                             unsigned int mnemonic_length,
                                             unsigned char* bits,
                                             unsigned int bitslength) {
@@ -141,7 +142,8 @@ unsigned int bolos_ux_bip39_mnemonic_decode(unsigned char* mnemonic,
 }
 
 unsigned int bolos_ux_bip39_mnemonic_encode(const uint8_t* seed,
-                                            uint8_t seed_len, char* out,
+                                            uint8_t seed_len,
+                                            unsigned char* out,
                                             size_t out_len) {
     if (seed_len % 4 || seed_len < 16 || seed_len > 32) {
         return 0;
@@ -187,7 +189,7 @@ unsigned int bolos_ux_bip39_mnemonic_encode(const uint8_t* seed,
     return offset;
 }
 
-unsigned int bolos_ux_bip39_mnemonic_check(unsigned char* mnemonic,
+unsigned int bolos_ux_bip39_mnemonic_check(const unsigned char* mnemonic,
                                            unsigned int mnemonic_length) {
     unsigned char bits[32 + 1];
 

--- a/src/common/bip85/seed_bip85.c
+++ b/src/common/bip85/seed_bip85.c
@@ -19,6 +19,7 @@
 #include <stdint.h>
 #include <string.h>
 
+#include "./common_bip85.h"
 #include "./seed_rom_variables.h"
 #include "constants.h"
 

--- a/src/common/sskr/common_sskr.h
+++ b/src/common/sskr/common_sskr.h
@@ -32,10 +32,10 @@
 bool bolos_ux_sskr_byteword_to_hex(const unsigned char *byteword, uint8_t *value);
 
 // Combine hex value SSKR shares into seed
-void bolos_ux_sskr_to_seed_convert(const unsigned char *sskr_shares_hex,
+void bolos_ux_sskr_to_seed_convert(unsigned char *sskr_shares_hex,
                                    unsigned int sskr_shares_hex_length,
                                    unsigned int sskr_shares_count,
-                                   const unsigned char *words_buffer,
+                                   unsigned char *words_buffer,
                                    unsigned int *words_buffer_length,
                                    unsigned char *seed);
 
@@ -48,7 +48,7 @@ unsigned int bolos_ux_bip39_to_sskr_convert(unsigned char *bip39_words_buffer,
                                             unsigned char *sskr_words_buffer,
                                             unsigned int *sskr_words_buffer_length);
 
-unsigned int bolos_ux_sskr_hex_check(const unsigned char *sskr_shares_hex,
+unsigned int bolos_ux_sskr_hex_check(unsigned char *sskr_shares_hex,
                                      unsigned int sskr_shares_hex_length,
                                      unsigned int sskr_share_count);
 

--- a/src/common/sskr/seed_sskr.c
+++ b/src/common/sskr/seed_sskr.c
@@ -21,6 +21,7 @@
 
 #include "../bip39/common_bip39.h"
 #include "../common.h"
+#include "./common_sskr.h"
 #include "./seed_rom_variables.h"
 #include "./sskr.h"
 

--- a/src/nbgl/bip39_mnemonic.c
+++ b/src/nbgl/bip39_mnemonic.c
@@ -134,8 +134,8 @@ bool bip39_mnemonic_from_sskr_shares(unsigned char* seed) {
     mnemonic.length = BIP39_MNEMONIC_MAX_LENGTH;
 
     bolos_ux_sskr_to_seed_convert(
-        (const unsigned char*)sskr_shares_get(), sskr_shares_length_get(),
-        sskr_sharecount_get(), (const unsigned char*)bip39_mnemonic_get(),
+        (unsigned char*)sskr_shares_get(), sskr_shares_length_get(),
+        sskr_sharecount_get(), (unsigned char*)bip39_mnemonic_get(),
         &mnemonic.length, seed);
 
     if (mnemonic.length > 0) {

--- a/src/nbgl/bip39_mnemonic.c
+++ b/src/nbgl/bip39_mnemonic.c
@@ -131,12 +131,21 @@ bool bip39_mnemonic_check(bool* match) {
 }
 
 bool bip39_mnemonic_from_sskr_shares(unsigned char* seed) {
-    mnemonic.length = BIP39_MNEMONIC_MAX_LENGTH;
+    // mnemonic.length is a size_t, like every other field of this struct,
+    // while every length in the common bolos_ux_* API is an unsigned int.
+    // They are the same type on the 32-bit ARM targets, which is why handing
+    // &mnemonic.length straight to an unsigned int * parameter went unnoticed;
+    // on a 64-bit host it gives the callee the address of an 8-byte object it
+    // only writes 4 bytes of. Convert at the boundary rather than move either
+    // convention.
+    unsigned int words_buffer_length = BIP39_MNEMONIC_MAX_LENGTH;
 
     bolos_ux_sskr_to_seed_convert(
         (unsigned char*)sskr_shares_get(), sskr_shares_length_get(),
         sskr_sharecount_get(), (unsigned char*)bip39_mnemonic_get(),
-        &mnemonic.length, seed);
+        &words_buffer_length, seed);
+
+    mnemonic.length = words_buffer_length;
 
     if (mnemonic.length > 0) {
         PRINTF("BIP39 mnemonic: %zu characters\n", mnemonic.length);

--- a/tests/unit/CMakeLists.txt
+++ b/tests/unit/CMakeLists.txt
@@ -344,20 +344,6 @@ target_link_libraries(test_sskr_entry_bounds PUBLIC cmocka gcov sskr sss testuti
 add_executable(test_bip39_entry_bounds ./tests/bip39_entry_bounds.c ../../src/common/bip39/seed_rom_variables.c ../../src/common/bip39/seed_bip39.c ../../src/common/sskr/seed_rom_variables.c ../../src/common/sskr/seed_sskr.c ../../src/nbgl/bip39_mnemonic.c ../../src/nbgl/sskr_shares.c)
 target_compile_definitions(test_bip39_entry_bounds PRIVATE SCREEN_SIZE_WALLET)
 target_include_directories(test_bip39_entry_bounds PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/../../src/common ${CMAKE_CURRENT_SOURCE_DIR}/../../src)
-# Expected, harmless compiler warning from this target only, in the same spirit
-# as the -Wunused-label note further down: bip39_mnemonic_from_sskr_shares()
-# hands &mnemonic.length (size_t *) to bolos_ux_sskr_to_seed_convert(), which
-# takes unsigned int *. Those are the same type on every device this app is
-# built for (32-bit ARM, ILP32) and a different one on a 64-bit test host, where
-# GCC 14 makes the mismatch a hard error by default. Downgraded back to a
-# warning rather than silenced, so a genuine one in this target would still be
-# visible, and rather than changing the signature in src/, which is correct for
-# the targets that matter:
-#   src/nbgl/bip39_mnemonic.c:139:9: warning: passing argument 5 of
-#     'bolos_ux_sskr_to_seed_convert' from incompatible pointer type
-#     [-Wincompatible-pointer-types]
-# The function itself is never called from this test.
-target_compile_options(test_bip39_entry_bounds PRIVATE -Wno-error=incompatible-pointer-types)
 target_link_libraries(test_bip39_entry_bounds PUBLIC cmocka gcov sskr sss testutils)
 
 add_executable(test_sskr_byteword_sentinel ./tests/sskr_byteword_sentinel.c ../../src/common/bip39/seed_rom_variables.c ../../src/common/bip39/seed_bip39.c ../../src/common/sskr/seed_rom_variables.c ../../src/common/sskr/seed_sskr.c ../../src/nbgl/sskr_shares.c)

--- a/tests/unit/CMakeLists.txt
+++ b/tests/unit/CMakeLists.txt
@@ -22,7 +22,35 @@ ENABLE_TESTING()
 # specify C standard
 set(CMAKE_C_STANDARD 11)
 set(CMAKE_C_STANDARD_REQUIRED True)
-set(CMAKE_C_FLAGS_DEBUG "${CMAKE_C_FLAGS_DEBUG} -Wall -pedantic -g -O0 --coverage")
+# -Wmissing-prototypes is here for a defect this suite could not see: a
+# function whose definition contradicts the declaration callers use, in a
+# file that never includes its own public header. Six such divergences lived
+# in seed_bip39.c and seed_sskr.c for as long as those files did not include
+# common_bip39.h / common_sskr.h. They do now, which makes any future
+# divergence a compilation error; this flag covers the other half of the
+# problem, a function with external linkage and no prototype at all, where
+# there is nothing for the compiler to compare a definition against.
+#
+# It is not at zero. As of this commit it reports 42 functions, 26 of them in
+# src/: 17 in bip85/seed_bip85.c, 2 in sskr/seed_sskr.c, and one each in
+# bip39/seed_bip39.c, common_seed.c, bip85/base64.c, bip85/base85.c,
+# sskr/sss/sss.c, nbgl/bip39_mnemonic.c and nbgl/sskr_shares.c. Making them
+# static is not the automatic answer: several are referenced by extern
+# declarations in tests/unit/tests/, sss.c is kept diffable against upstream
+# bc-sskr, and bolos_ux_bip39_mnemonic_to_seed_hash_length128() exists
+# precisely to keep the pbkdf2 frame off its caller's stack, which static
+# would let the compiler undo. They are left as warnings deliberately; the
+# point of the flag is that a *new* one shows up.
+#
+# -Wstrict-prototypes is already clean everywhere and is here as a ratchet.
+#
+# Not added to the application build: measured there, the two flags report
+# 120 warnings on stax and 151 on nanos, roughly half of them inside the SDK
+# itself (39 and 49 in syscalls.c alone, plus lib_standard_app), which this
+# repository cannot act on. ENABLE_SDK_WERROR defaults to 0 and is not
+# overridden here, so they would not break that build -- they would just bury
+# the app's own diagnostics.
+set(CMAKE_C_FLAGS_DEBUG "${CMAKE_C_FLAGS_DEBUG} -Wall -Wmissing-prototypes -Wstrict-prototypes -pedantic -g -O0 --coverage")
 
 set(GCC_COVERAGE_LINK_FLAGS "--coverage -lgcov")
 set(CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS} ${GCC_COVERAGE_LINK_FLAGS}")


### PR DESCRIPTION
## What this is

Six public functions had a declaration that contradicted their definition,
and **the compiler could not see it**: no translation unit ever included both
the public header and the definition.

- `src/common/sskr/seed_sskr.c` included `sskr.h`, `common.h`,
  `seed_rom_variables.h` and `common_bip39.h` -- but not its own
  `common_sskr.h`.
- `src/common/bip39/seed_bip39.c` included `common.h` and
  `seed_rom_variables.h` -- but not its own `common_bip39.h`.

Forcing the include on `bip85` and building gives:

```
seed_bip39.c:36:6:   error: conflicting types for 'bolos_ux_bip39_mnemonic_to_seed'
seed_bip39.c:53:14:  error: conflicting types for 'bolos_ux_bip39_mnemonic_decode'
seed_bip39.c:144:14: error: conflicting types for 'bolos_ux_bip39_mnemonic_encode'
seed_bip39.c:191:14: error: conflicting types for 'bolos_ux_bip39_mnemonic_check'
seed_sskr.c:115:6:   error: conflicting types for 'bolos_ux_sskr_to_seed_convert'
seed_sskr.c:332:14:  error: conflicting types for 'bolos_ux_sskr_hex_check'
```

Making each `.c` read its own public header is the point of the change. The
six divergences then have to be resolved, and which side is wrong differs
from one function to the next.

## The part that actually matters: the contract was false

The type conflict is not the damaging bit. This is:

```c
void bolos_ux_sskr_to_seed_convert(const unsigned char *sskr_shares_hex, ...,
                                   const unsigned char *words_buffer,
                                   unsigned int *words_buffer_length,
                                   unsigned char *seed);
```

`words_buffer` is an **output** buffer -- the mnemonic is written into it by
`bolos_ux_bip39_mnemonic_encode()`. `sskr_shares_hex` is **wiped**,
`memzero`'d through `bolos_ux_sskr_combine()` on the failure path. The header
offered callers a read-only contract over an output buffer and over a buffer
that gets destroyed. Same for `bolos_ux_sskr_hex_check()`, which `memzero`s
its input on every rejecting path.

That it was already doing harm is visible in the calling code:
`src/nbgl/bip39_mnemonic.c` had to insert two `(const unsigned char*)` casts
to satisfy a prototype that was not true. Casts silence the compiler, so the
defect had already leaked out of the file it was born in. Both are removed
here.

## Which side was wrong, function by function

The declaration was wrong (the `const` is dropped):

| function | parameter | why |
| --- | --- | --- |
| `bolos_ux_sskr_to_seed_convert` | `sskr_shares_hex` | wiped via `bolos_ux_sskr_combine()` |
| `bolos_ux_sskr_to_seed_convert` | `words_buffer` | output buffer, written by `mnemonic_encode()` |
| `bolos_ux_sskr_hex_check` | `sskr_shares_hex` | `memzero`'d on every reject path |

The definition was wrong (the `const` is added):

| function | parameter | why |
| --- | --- | --- |
| `bolos_ux_bip39_mnemonic_to_seed` | `mnemonic` | read only, copied into a local before hashing |
| `bolos_ux_bip39_mnemonic_decode` | `mnemonic` | read only, byte by byte into a local |
| `bolos_ux_bip39_mnemonic_check` | `mnemonic` | read only, forwarded to `decode()` |

One of a different kind: `bolos_ux_bip39_mnemonic_encode()` is declared with
`unsigned char *out` and defined with `char *out`. Every caller passes an
`unsigned char *` (two of them through a cast) and the rest of the family
takes `unsigned char *` buffers, so the definition is the odd one out and
follows the declaration.

I looked for other casts rather than assuming there were only two. The
remaining `(const unsigned char*)` at `common_seed.c:90` and
`sskr_shares.c:88` are legitimate `char *` to `const unsigned char *`
conversions and are left alone.

## A third file in the same situation

`src/common/bip85/seed_bip85.c` did not include `common_bip85.h` either --
found by looking for the pattern rather than for the symptom. Nothing had
drifted there, so that commit is the include and nothing else. It is worth
having anyway: those five definitions sit inside the
`#if defined(HAVE_NBGL)` region, so they are only compiled for stax, flex and
apex_p and the unit suite never sees them -- exactly the situation in which a
divergence goes unnoticed longest.

## The `size_t *` / `unsigned int *` mismatch

`bip39_mnemonic_from_sskr_shares()` handed `&mnemonic.length` (a `size_t *`)
to `bolos_ux_sskr_to_seed_convert()`, which takes an `unsigned int *`. Same
type on every device this app is built for (32-bit ARM, ILP32); on a 64-bit
host the callee writes the low four bytes of an eight-byte object. This was
one of the two pre-existing warnings of the unit build, and the reason
`test_bip39_entry_bounds` carried a `-Wno-error=incompatible-pointer-types`
flag.

Fixed at the boundary rather than by moving either convention, because both
sides are internally consistent and the mismatch only exists where they meet:

- Widening the signature to `size_t *` forces
  `G_bolos_ux_context.words_buffer_length` (`src/bagl/ux_nano.h`) to `size_t`
  while its sibling `sskr_words_buffer_length` stays `unsigned int` -- it
  feeds `bolos_ux_bip39_to_sskr_convert()`, also `unsigned int *`. That trades
  one inconsistency for another, inside a shared context struct, on the one
  configuration the unit suite cannot exercise.
- Narrowing `mnemonic.length` to `unsigned int` would make it disagree with
  every other field of `bip39_buffer_t`, with the return type of
  `bip39_mnemonic_length_get()`, with the parameter of
  `bip39_mnemonic_shrink()`, and with the surrounding `"%zu"` traces.

A local `unsigned int` carries the length across the call and is assigned back
afterwards. The callee always writes it, so the result is identical on every
target. The `-Wno-error` flag and its 15-line justification go away with it.

## The guarantee is structural

This is what the change buys, and it is not a claim -- it is checked. With the
includes in place, reintroducing a divergence on **either** side fails the
build:

```
seed_bip39.c:53:14: error: conflicting types for 'bolos_ux_bip39_mnemonic_decode'
seed_sskr.c:332:14: error: conflicting types for 'bolos_ux_sskr_hex_check'
```

Verified by putting the `const` back in the header for one function and taking
it off the definition for another, then restoring the sources and re-checking
their `md5sum`. The protection is no longer a test that turns red, it is a
compiler that refuses to produce a binary.

`-Wmissing-prototypes` is added to the unit suite for the other half of the
problem: a function with external linkage and no prototype anywhere, where
there is nothing for the compiler to compare a definition against.
`-Wstrict-prototypes` comes along as a ratchet -- it is already clean
everywhere.

## What is left, and why

`-Wmissing-prototypes` does not start at zero. It reports 42 functions, 26 of
them in `src/`: 17 in `bip85/seed_bip85.c`, 2 in `sskr/seed_sskr.c`, and one
each in `bip39/seed_bip39.c`, `common_seed.c`, `bip85/base64.c`,
`bip85/base85.c`, `sskr/sss/sss.c`, `nbgl/bip39_mnemonic.c` and
`nbgl/sskr_shares.c`. **None of them is fixed here**, and the breakdown plus
the reason for each group is written in a comment next to the flag rather than
hidden. Making them `static` is not the automatic answer:

- several are reached by `extern` declarations from `tests/unit/tests/`, so
  `static` would break the test build;
- `sss.c` is deliberately kept diffable against upstream bc-sskr;
- `bolos_ux_bip39_mnemonic_to_seed_hash_length128()` exists precisely to keep
  the pbkdf2 frame off its caller's stack, which `static` would let the
  compiler undo.

The two functions in `seed_sskr.c` are `bolos_ux_sskr_size_get()` and
`bolos_ux_sskr_generate()`. They have no header declaration at all, which is a
different situation from the six above and one the test files already document
as deliberate; I left them and their tests untouched.

**Not added to the application build.** Measured there, the two flags report
120 warnings on stax and 151 on nanos, roughly half of them inside the SDK
itself (39 and 49 in `syscalls.c` alone, plus `lib_standard_app`), which this
repository cannot act on. `ENABLE_SDK_WERROR` defaults to `0` and is not
overridden here, so they would not break that build -- they would just bury the
app's own diagnostics.

## No behaviour changes

These are qualifiers and includes, not logic.

- Unit suite: `ctest -N` **40 before, 40 after** -- no test added, **no test
  file modified**. **40/40 green**, 0 `error:` in the build log.
- Compiler warnings on the unit build: **2 -> 1**. The
  `-Wincompatible-pointer-types` one is gone; what remains is the unrelated
  unused `cleanup` label in `common_seed.c`, deliberately out of scope here.
- All **six** targets of `ledger_app.toml` built, including `nanos`, which
  `ci-workflow.yml` does not build: **6/6, 0 error, 0 warning**. `nanos` at
  **32 008 / 3 708**.
- Sizes are identical on all six. Since `arm-none-eabi-size` can hide a delta
  when a text region is fixed-size, I also compared **every `T`/`t` symbol and
  its size**: `diff` reports them identical on all six targets. The change
  costs nothing.
- `clang-format --dry-run -Werror` clean on all five touched source files.

No Speculos script was run and none is required: no secret-erasure path is
modified.
