### PR TITLE
fix: declare seed_bip85.c's internal helpers in one place instead of seven

### DIFF
--- a/src/common/bip85/bip85_internal.h
+++ b/src/common/bip85/bip85_internal.h
@@ -1,0 +1,78 @@
+/*******************************************************************************
+ *   Ledger Seed Tool application
+ *   (c) 2016-2026 Ledger SAS
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ ********************************************************************************/
+
+#pragma once
+
+// Internals of seed_bip85.c: helpers that no other file in src/ calls, but
+// that keep external linkage so the unit suite can reach them. That intent is
+// already written on bip85_dice_bits_per_roll() -- "with external linkage,
+// purely so it can be linked into a unit test" -- so making them static is
+// not the answer; giving them a prototype is.
+//
+// Before this header, each of them was declared by hand, with `extern`, in
+// whichever test file needed it, and nothing checked those declarations
+// against the definitions: no translation unit saw both. This header is the
+// single place they are declared, included by seed_bip85.c so the compiler
+// checks the definitions, and by the tests so it checks their use.
+//
+// Nothing here is part of the application's BIP-85 interface. That is
+// common_bip85.h, and it is what callers outside this directory should use.
+
+#include <stdbool.h>
+#include <stddef.h>
+#include <stdint.h>
+
+#include "./seed_rom_variables.h"
+
+// Derivation-path builders. Each fills `path` with the BIP-32 path of the
+// matching BIP-85 application and returns the number of components written.
+unsigned int bip85_path_drng(unsigned int *path, unsigned int index);
+unsigned int bip85_path_bip39(unsigned int *path,
+                              uint8_t language,
+                              uint8_t words,
+                              unsigned int index);
+unsigned int bip85_path_hex(unsigned int *path, uint8_t num_bytes, unsigned int index);
+unsigned int bip85_path_pwd_base64(unsigned int *path, uint8_t pwd_len, unsigned int index);
+unsigned int bip85_path_pwd_base85(unsigned int *path, uint8_t pwd_len, unsigned int index);
+unsigned int bip85_path_dice(unsigned int *path,
+                             uint32_t sides,
+                             uint32_t rolls,
+                             unsigned int index);
+
+// Parameter validation, one per application.
+bool bip85_bip39_words_valid(uint8_t words);
+bool bip85_hex_num_bytes_valid(uint8_t num_bytes);
+bool bip85_pwd_base64_len_valid(uint8_t pwd_len);
+bool bip85_pwd_base85_len_valid(uint8_t pwd_len);
+bool bip85_dice_sides_valid(uint32_t sides);
+bool bip85_dice_rolls_valid(uint32_t rolls);
+
+// Entropy and output shaping.
+bool bip85_entropy_from_key(const uint8_t key[32], uint8_t *out, size_t out_len);
+bool bolos_ux_bip85_drng_with_seed(uint8_t *seed,
+                                   size_t seed_length,
+                                   uint8_t *digest,
+                                   size_t digest_length);
+uint8_t bip85_finalize_pwd(const char *buffer_pwd, char *pwd, uint8_t pwd_len);
+
+// DICE.
+uint8_t bip85_dice_bits_per_roll(uint32_t sides);
+int32_t bip85_dice_roll(uint32_t *out,
+                        size_t out_capacity,
+                        uint32_t sides,
+                        uint32_t rolls,
+                        const uint8_t seed[BIP85_ENTROPY_LENGTH]);

--- a/src/common/bip85/seed_bip85.c
+++ b/src/common/bip85/seed_bip85.c
@@ -19,6 +19,7 @@
 #include <stdint.h>
 #include <string.h>
 
+#include "./bip85_internal.h"
 #include "./common_bip85.h"
 #include "./seed_rom_variables.h"
 #include "constants.h"

--- a/tests/unit/CMakeLists.txt
+++ b/tests/unit/CMakeLists.txt
@@ -31,16 +31,20 @@ set(CMAKE_C_STANDARD_REQUIRED True)
 # problem, a function with external linkage and no prototype at all, where
 # there is nothing for the compiler to compare a definition against.
 #
-# It is not at zero. As of this commit it reports 42 functions, 26 of them in
-# src/: 17 in bip85/seed_bip85.c, 2 in sskr/seed_sskr.c, and one each in
-# bip39/seed_bip39.c, common_seed.c, bip85/base64.c, bip85/base85.c,
-# sskr/sss/sss.c, nbgl/bip39_mnemonic.c and nbgl/sskr_shares.c. Making them
-# static is not the automatic answer: several are referenced by extern
-# declarations in tests/unit/tests/, sss.c is kept diffable against upstream
-# bc-sskr, and bolos_ux_bip39_mnemonic_to_seed_hash_length128() exists
-# precisely to keep the pbkdf2 frame off its caller's stack, which static
-# would let the compiler undo. They are left as warnings deliberately; the
-# point of the flag is that a *new* one shows up.
+# It is not at zero. As of this commit it reports 25 functions, 9 of them in
+# src/: 2 in sskr/seed_sskr.c, and one each in bip39/seed_bip39.c,
+# common_seed.c, bip85/base64.c, bip85/base85.c, sskr/sss/sss.c,
+# nbgl/bip39_mnemonic.c and nbgl/sskr_shares.c. The seventeen this comment
+# used to list in bip85/seed_bip85.c are gone: they now come from
+# bip85/bip85_internal.h, which is the pattern the rest should follow.
+#
+# Making the remainder static is not the automatic answer: six of the nine
+# are reached by extern declarations in tests/unit/tests/, sss.c is kept
+# diffable against upstream bc-sskr, and
+# bolos_ux_bip39_mnemonic_to_seed_hash_length128() exists precisely to keep
+# the pbkdf2 frame off its caller's stack, which static would let the
+# compiler undo. They are left as warnings deliberately; the point of the
+# flag is that a *new* one shows up.
 #
 # -Wstrict-prototypes is already clean everywhere and is here as a ratchet.
 #

--- a/tests/unit/tests/bip85_bip39_entropy.c
+++ b/tests/unit/tests/bip85_bip39_entropy.c
@@ -7,9 +7,8 @@
 #include <string.h>
 
 #include "bip39/common_bip39.h"
+#include "common/bip85/bip85_internal.h"
 #include "testutils.h"
-
-#define BIP85_ENTROPY_LENGTH 64
 
 // bip85_entropy_from_key() covers only the HMAC-SHA512("bip-entropy-from-k",
 // key) half of bolos_ux_bip85_entropy(); the BIP32 derivation that produces
@@ -17,8 +16,6 @@
 // syscall against the device's real seed with no host equivalent, so it
 // cannot be exercised here. The three keys below stand in for that
 // derivation's output.
-extern bool bip85_entropy_from_key(const uint8_t key[32], uint8_t* out,
-                                   size_t out_len);
 
 // Independent oracle for all three vectors: the official BIP-85 master
 // xprv (bip-0085.mediawiki, bitcoin/bips), derived on

--- a/tests/unit/tests/bip85_derivation_path.c
+++ b/tests/unit/tests/bip85_derivation_path.c
@@ -6,24 +6,7 @@
 #include <stdint.h>
 #include <string.h>
 
-extern unsigned int bip85_path_drng(unsigned int* path, unsigned int index);
-extern unsigned int bip85_path_bip39(unsigned int* path, uint8_t language,
-                                     uint8_t words, unsigned int index);
-extern unsigned int bip85_path_hex(unsigned int* path, uint8_t num_bytes,
-                                   unsigned int index);
-extern unsigned int bip85_path_pwd_base64(unsigned int* path, uint8_t pwd_len,
-                                          unsigned int index);
-extern unsigned int bip85_path_pwd_base85(unsigned int* path, uint8_t pwd_len,
-                                          unsigned int index);
-extern unsigned int bip85_path_dice(unsigned int* path, uint32_t sides,
-                                    uint32_t rolls, unsigned int index);
-
-extern bool bip85_bip39_words_valid(uint8_t words);
-extern bool bip85_hex_num_bytes_valid(uint8_t num_bytes);
-extern bool bip85_pwd_base64_len_valid(uint8_t pwd_len);
-extern bool bip85_pwd_base85_len_valid(uint8_t pwd_len);
-extern bool bip85_dice_sides_valid(uint32_t sides);
-extern bool bip85_dice_rolls_valid(uint32_t rolls);
+#include "common/bip85/bip85_internal.h"
 
 // Everything the expected paths are built from is spelled out here as the
 // decimal numbers BIP-85 itself uses, plus the BIP-32 hardening offset.

--- a/tests/unit/tests/bip85_dice_bits_per_roll.c
+++ b/tests/unit/tests/bip85_dice_bits_per_roll.c
@@ -4,7 +4,7 @@
 #include <setjmp.h>
 #include <cmocka.h>
 
-extern uint8_t bip85_dice_bits_per_roll(uint32_t sides);
+#include "common/bip85/bip85_internal.h"
 
 // bits_per_roll must be ceil(log2(sides)): the minimum number of bits that
 // lets a rejection-sampling loop draw uniformly from [0, sides). Non-power-

--- a/tests/unit/tests/bip85_dice_roll.c
+++ b/tests/unit/tests/bip85_dice_roll.c
@@ -5,11 +5,7 @@
 #include <stdint.h>
 #include <string.h>
 
-#define BIP85_ENTROPY_LENGTH 64
-
-extern int32_t bip85_dice_roll(uint32_t* out, size_t out_capacity,
-                               uint32_t sides, uint32_t rolls,
-                               const uint8_t seed[BIP85_ENTROPY_LENGTH]);
+#include "common/bip85/bip85_internal.h"
 
 // d2 (sides = 2) has bits_per_roll = 1, so every byte of the SHAKE256
 // digest yields either 0 or 1 -- always < sides -- and is accepted. That

--- a/tests/unit/tests/bip85_drng_with_seed.c
+++ b/tests/unit/tests/bip85_drng_with_seed.c
@@ -6,11 +6,9 @@
 #include <stdint.h>
 #include <string.h>
 
-#define BIP85_DRNG_MAX_DIGEST_SIZE 256
+#include "common/bip85/bip85_internal.h"
 
-extern bool bolos_ux_bip85_drng_with_seed(uint8_t* seed, size_t seed_length,
-                                          uint8_t* digest,
-                                          size_t digest_length);
+#define BIP85_DRNG_MAX_DIGEST_SIZE 256
 
 static uint8_t seed[] = {0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08,
                          0x09, 0x0a, 0x0b, 0x0c, 0x0d, 0x0e, 0x0f, 0x10,

--- a/tests/unit/tests/bip85_finalize_pwd.c
+++ b/tests/unit/tests/bip85_finalize_pwd.c
@@ -5,11 +5,7 @@
 #include <stdint.h>
 #include <string.h>
 
-#define BASE64_ENCODE_LENGTH 88
-#define BASE85_ENCODE_LENGTH 80
-
-extern uint8_t bip85_finalize_pwd(const char* buffer_pwd, char* pwd,
-                                  uint8_t pwd_len);
+#include "common/bip85/bip85_internal.h"
 
 // Same fully-encoded vectors as tests/base64.c/base85.c -- already verified
 // there against base64_encode_64bytes()/base85_encode_64bytes() directly.

--- a/tests/unit/tests/bip85_hex_vector.c
+++ b/tests/unit/tests/bip85_hex_vector.c
@@ -6,9 +6,8 @@
 #include <stdint.h>
 #include <string.h>
 
+#include "common/bip85/bip85_internal.h"
 #include "testutils.h"
-
-#define BIP85_ENTROPY_LENGTH 64
 
 // bip85_entropy_from_key() covers only the HMAC-SHA512("bip-entropy-from-k",
 // key) half of bolos_ux_bip85_entropy(); the BIP32 derivation that produces
@@ -17,8 +16,6 @@
 // os_derive_bip32_no_throw(), a BOLOS syscall against the device's real seed
 // with no host equivalent, so it cannot be exercised here -- same limitation
 // already documented for test_bip85_bip39_entropy.
-extern bool bip85_entropy_from_key(const uint8_t key[32], uint8_t* out,
-                                   size_t out_len);
 
 // Vector 1 is the official BIP-85 HEX-application test vector published in
 // bip-0085.mediawiki (bitcoin/bips) itself, for the official master xprv on


### PR DESCRIPTION
## What this is

Seventeen functions in `src/common/bip85/seed_bip85.c` are defined with
external linkage and no prototype anywhere:

```
bip85_path_drng            bip85_bip39_words_valid      bip85_entropy_from_key
bip85_path_bip39           bip85_hex_num_bytes_valid    bolos_ux_bip85_drng_with_seed
bip85_path_hex             bip85_pwd_base64_len_valid   bip85_finalize_pwd
bip85_path_pwd_base64      bip85_pwd_base85_len_valid   bip85_dice_bits_per_roll
bip85_path_pwd_base85      bip85_dice_sides_valid       bip85_dice_roll
bip85_path_dice            bip85_dice_rolls_valid
```

The external linkage is not an oversight, and the file already says so on the
first of them:

> Kept outside the `HAVE_NBGL` guard below, and with external linkage, purely
> so it can be linked into a unit test

So `static` is not the answer -- it would break exactly what the linkage is
there for. What was missing is a prototype.

## Where they are declared today

In the tests, by hand. Each test file that reaches into `seed_bip85.c`
declares what it needs with its own `extern`: seventeen declarations spread
over seven files, twelve of them in `bip85_derivation_path.c` alone.

**Nothing checks any of them.** A test's `extern` and the real definition live
in different translation units, so a disagreement between the two is not a
compile error -- it is a silent ABI mismatch that links and runs.

That is measured here, not assumed. Widening `bip85_path_hex()`'s `num_bytes`
parameter from `uint8_t` to `uint32_t` **in the definition only**, leaving the
test's `extern` at `uint8_t`:

| tree | result |
| --- | --- |
| `bip85` today | builds with **0 errors**, and the test still passes |
| with this change | `error: conflicting types for 'bip85_path_hex'` |

## What this does

Adds `src/common/bip85/bip85_internal.h`, which declares the seventeen once,
and includes it from `seed_bip85.c` **and** from the seven test files in place
of their `extern` blocks. The compiler now checks the definitions against the
declarations, and the tests against the same declarations.

It is a separate header rather than an addition to `common_bip85.h` on
purpose. None of the seventeen is part of the application's BIP-85 interface
-- no file in `src/` outside `seed_bip85.c` calls any of them. `common_bip85.h`
stays what it is: the five entry points meant for callers outside this
directory.

**The seventeen `extern` declarations all turned out to match their
definitions exactly.** No divergence was hiding here. That is a result worth
stating rather than leaving the question unasked.

Three test files also carried their own copies of `BIP85_ENTROPY_LENGTH`,
`BASE64_ENCODE_LENGTH` and `BASE85_ENCODE_LENGTH`. The header brings in
`seed_rom_variables.h`, which is where those live, so the duplicates go with
it. `BIP85_DRNG_MAX_DIGEST_SIZE` comes from `src/constants.h`, which this
header does not pull in, so that one stays where it was.

The header declares all seventeen unconditionally, without reproducing the
`#ifdef HAVE_SHA3` / `#ifdef HAVE_HMAC` guards that surround some of the
definitions. Declaring a function that is not defined has no effect in C
unless it is called, and copying the guards would add noise plus a chance of
getting a condition wrong. Verified: zero warnings on all six targets and on
the unit build.

## No behaviour change

- `-Wmissing-prototypes` on `seed_bip85.c`: **17 -> 0**. Across the whole unit
  build: **42 -> 25**.
- `ctest -N` **40 before, 40 after**. **40/40 green**, 0 `error:` in the build
  log. No test added or removed, no test logic changed -- only declarations.
- All **six** targets of `ledger_app.toml` built, including `nanos`, which
  `ci-workflow.yml` does not build: **6/6, 0 error, 0 warning**. `nanos` at
  **32 008 / 3 708**.
- Sizes identical on all six. Since `arm-none-eabi-size` can hide a delta when
  a text region is fixed-size, I also compared **every `T`/`t` symbol and its
  size**: identical on all six targets. Nothing moved.
- `clang-format --dry-run -Werror` clean on both `src/` files.
  `tests/unit/tests/bip85_dice_bits_per_roll.c` does not satisfy it, but it
  already did not on `bip85` before this change -- left alone rather than
  reformatted, which would be unrelated churn.

No Speculos script was run and none is required: no secret-erasure path is
modified.

## Relation to #100

Rebased onto `bip85` now that #100 is merged. It conflicted on one line:
#100 added `#include "./common_bip85.h"` to the include block of
`seed_bip85.c`, where this branch adds `#include "./bip85_internal.h"`.
Resolved by keeping both.

#100 also added `-Wmissing-prototypes` to the unit suite with a comment
listing the warnings it deliberately does not fix, including the 17 in
`seed_bip85.c` this change removes. A third commit refreshes that count:
**42 -> 25** in total, **26 -> 9** in `src/`, measured on this tree rather
than deduced. It also narrows one claim in that comment that had become
vague -- "several are referenced by extern declarations in tests/" is now
"six of the nine", checked function by function.

Everything above was re-run on the new base: 40/40, six targets clean, sizes
and symbols still identical.
