### PR TITLE
build: register ctest targets from the ones actually built

### DIFF
--- a/tests/unit/CMakeLists.txt
+++ b/tests/unit/CMakeLists.txt
@@ -528,6 +528,23 @@ add_executable(test_bip85_derivation_path tests/bip85_derivation_path.c ../../sr
 target_include_directories(test_bip85_derivation_path PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/../../src)
 target_link_libraries(test_bip85_derivation_path PUBLIC cmocka gcov testutils)
 
-foreach(target test_sss test_sss_recover_erase_length test_sss_validate_parameters test_sskr test_sskr_to_seed_convert test_sskr_generate_combine_guards test_sskr_threshold_three_roundtrip test_sskr_share_len test_sskr_hex_check_guards test_sskr_deserialize_shard_bounds test_sskr_memzero test_sskr_shard_count test_sskr_generate_split_error test_sskr_generate_bound_groups test_sskr_combine_erase_on_failure test_sskr_count_shards_invariants test_sskr_generate_erase_on_split_failure test_sskr_combine_bounds test_sskr_invalid_group_descriptor test_sskr_combine_error test_sskr_combine_invariants test_sskr_interop_bc128 test_sskr_interop_bc128_bytewords test_sskr_entry_bounds test_sskr_byteword_sentinel test_sskr_cbor_additional_info test_bip39 test_bip39_entry_bounds test_roundtrip test_words test_base64 test_base85 test_bip85_dice_bits_per_roll test_bip85_dice_roll test_bip85_bip39_entropy test_bip85_hex_vector test_bip85_finalize_pwd test_bip85_drng_with_seed test_bip85_derivation_path test_compare_recovery_phrase_finish)
-    add_test(NAME ${target} COMMAND ${target})
+# Register every executable this file builds, instead of repeating their names
+# in a list kept by hand. A name missing from such a list costs nothing
+# visible: the target still compiles, still passes when run directly, and the
+# suite stays green -- it is simply never run by ctest or by CI again.
+#
+# Keep this at the end of the file: it reads the targets that exist at the
+# point it runs, so anything added below it would not be picked up. Adding a
+# test needs nothing but its add_executable() above; there is no list to
+# remember and no helper to know about.
+#
+# Every executable built here is a test, and the libraries (testutils, sss,
+# sskr, openssl) are filtered out by type rather than by name, so a new
+# library does not need this to be touched either.
+get_property(built_targets DIRECTORY PROPERTY BUILDSYSTEM_TARGETS)
+foreach(target ${built_targets})
+    get_target_property(target_type ${target} TYPE)
+    if(target_type STREQUAL "EXECUTABLE")
+        add_test(NAME ${target} COMMAND ${target})
+    endif()
 endforeach()


### PR DESCRIPTION
## What this is

`tests/unit/CMakeLists.txt` ends with the name of every test target repeated
in a list maintained by hand -- today a single line of over a thousand
characters:

```cmake
foreach(target test_sss test_sss_recover_erase_length ... test_compare_recovery_phrase_finish)
    add_test(NAME ${target} COMMAND ${target})
endforeach()
```

A target missing from that list costs nothing visible. It still compiles, it
still passes when run directly, and the suite stays green -- it is simply
never run by `ctest` or by CI again, and the reported test count stays
plausible. Nothing anywhere says a target was dropped.

## What it has cost

Twice, and both times the same way: resolving a merge whose incoming
`CMakeLists.txt` predated the entries it overwrote. This is a known failure
mode of hand-maintained lists, not a reproach to anyone.

**`64ec814`** took the 25-entry list of one parent over the 28-entry list of
the other (`fac28f3`) and dropped four names:

- `test_sskr_generate_bound_groups`
- `test_sskr_combine_erase_on_failure`
- `test_sskr_count_shards_invariants`
- `test_sskr_generate_erase_on_split_failure`

They came back at `a66df23`. Between the two, those four were not running.
They hold the bound on `groups_len` before the fixed-size `groups[]` array is
filled (`2caf439`) and the erasure of the output buffer when combining or
splitting fails (`e8b7e78`) -- real fixes, unexercised for the duration.

**`test_compare_recovery_phrase_finish`** went the same way, and the commit
that repaired it, `ee7e519`, records the gap in its own message:

> Before: ctest -N lists 30 tests, for 31 built targets.

It covers the root key erasure on a derivation failure.

## What this does

Derives the registered set from the targets that actually exist, instead of
restating it. CMake exposes them through the `BUILDSYSTEM_TARGETS` directory
property; filtering on `TYPE` keeps the executables and drops `testutils`,
`sss`, `sskr` and `openssl`:

```cmake
get_property(built_targets DIRECTORY PROPERTY BUILDSYSTEM_TARGETS)
foreach(target ${built_targets})
    get_target_property(target_type ${target} TYPE)
    if(target_type STREQUAL "EXECUTABLE")
        add_test(NAME ${target} COMMAND ${target})
    endif()
endforeach()
```

Filtering by type rather than by a `test_` name prefix means a new library
does not require this to be touched either. The property is scoped to this
directory, so cmocka's own targets are not in it. `BUILDSYSTEM_TARGETS` has
existed since CMake 3.7; this file requires 3.10.

Chosen over a wrapper function around `add_executable()` for two reasons: it
leaves the 40 existing declarations untouched, and -- the one that matters --
adding a test now requires nothing at all beyond its `add_executable()`. No
list to remember, and no local helper to discover first. The block stays at
the end of the file, where the list was, because it reads the targets defined
above it.

## The registered set is unchanged

Checked, not asserted. `ctest -N`, sorted, before and after:

```
$ diff /tmp/before.txt /tmp/after.txt
$ wc -l < /tmp/after.txt
40
```

Empty diff, 40 entries on both sides.

Verified on **both** branches of the OpenSSL conditional, since they produce a
different target under the same name: precompiled
(`-DPRECOMPILED_DEPENDENCIES_DIR`, where `openssl` is an `IMPORTED` library)
and built from git (where it is an `ExternalProject` utility target). Both
give the same 40.

## A newly built target is now registered on its own

Demonstrated rather than claimed. A throwaway executable added with a bare
`add_executable(test_zz_guardrail_demo tests/zz_guardrail_demo.c)` and
registered nowhere by hand:

```
  Test #41: test_zz_guardrail_demo
```

Removed again -- it is not in this branch. The oversight that happened twice
is no longer possible to make silently.

## Scope

One commit, one file. **Nothing under `src/` or `tests/unit/tests/` is
modified** -- this touches only the build mechanics. No target was renamed, no
`target_link_libraries` factored out, nothing else in the file reorganised.

40/40 pass, 0 `error:` in the build log. No cross-compilation was run and none
is needed, since nothing under `src/` changes.
