### PR TITLE
fix: clean up the Shamir split's output buffer on failure, and bound the group count that sizes it

### DIFF
--- a/src/common/sskr/sskr.c
+++ b/src/common/sskr/sskr.c
@@ -182,7 +182,8 @@ static int16_t sskr_deserialize_shard(const uint8_t* source,
  * @param[in] groups_len        Number of groups in the `groups` array.
  *
  * @return Total number of shards on success, or a negative error code:
- *         - SSKR_ERROR_INVALID_GROUP_LENGTH: if `groups_len` is less than 1.
+ *         - SSKR_ERROR_INVALID_GROUP_LENGTH: if `groups_len` is less than 1 or
+ * greater than SSKR_MAX_GROUP_COUNT.
  *         - SSKR_ERROR_INVALID_GROUP_THRESHOLD: if `group_threshold` exceeds
  * `groups_len`.
  *         - SSKR_ERROR_INVALID_GROUP_COUNT: if any group has a count less
@@ -197,7 +198,13 @@ int16_t sskr_count_shards(uint8_t group_threshold,
                           uint8_t groups_len) {
     uint8_t shard_count = 0;
 
-    if (groups_len < 1) {
+    // The upper bound matters as much as the lower one: every buffer sized
+    // from a group count in this file is dimensioned on SSKR_MAX_GROUP_COUNT,
+    // starting with sskr_generate_shards_internal()'s group_shares, which
+    // sss_split_secret() then fills with groups_len shares. Rejecting an
+    // over-long group list here holds all of them at once, the same way
+    // bolos_ux_sskr_size_get() already holds its own groups[] array.
+    if (groups_len < 1 || groups_len > SSKR_MAX_GROUP_COUNT) {
         return SSKR_ERROR_INVALID_GROUP_LENGTH;
     }
 

--- a/src/common/sskr/sss/sss.c
+++ b/src/common/sskr/sss/sss.c
@@ -136,6 +136,18 @@ int16_t sss_split_secret(uint8_t threshold, uint8_t share_count,
         for (uint8_t i = threshold - 2; i < share_count;
              ++i, share += secret_length) {
             if (interpolate(n, x, secret_length, y, i, share) != CX_OK) {
+                // Same failure, same cleanup as sss_recover_secret() does.
+                // The caller's buffer already holds real shares here: the
+                // loop above wrote threshold - 2 of them, and interpolate()
+                // wrote whole shares of its own before the one that failed.
+                // Erase share_count * secret_length -- the capacity sss.h
+                // requires of that buffer, and exactly what the success path
+                // writes -- and no more.
+                memzero(result, (size_t)share_count * secret_length);
+                memzero(digest, sizeof(digest));
+                memzero(x, sizeof(x));
+                memzero(y, sizeof(y));
+
                 return SSS_ERROR_INTERPOLATION_FAILURE;
             }
         }

--- a/tests/unit/CMakeLists.txt
+++ b/tests/unit/CMakeLists.txt
@@ -296,6 +296,18 @@ target_link_libraries(test_sskr_count_shards_invariants PUBLIC cmocka gcov sskr 
 add_executable(test_sskr_generate_erase_on_split_failure tests/sskr_generate_erase_on_split_failure.c)
 target_link_libraries(test_sskr_generate_erase_on_split_failure PUBLIC cmocka gcov sskr sss testutils)
 
+# Built with AddressSanitizer: without the bound under test, the overflow of
+# group_shares happens inside sss_split_secret()/interpolate() through plain
+# loads and stores, which ASan does instrument -- so it is the assertion for
+# the case that matters. sskr.c, sss.c and interpolate.c are compiled directly
+# into this target rather than linked from libsskr/libsss so their stack
+# frames are instrumented too, the same way test_sskr_combine_bounds does it.
+add_executable(test_sskr_bound_group_count ./tests/sskr_bound_group_count.c ../../src/common/sskr/sskr.c ../../src/common/sskr/sss/sss.c ../../src/common/sskr/sss/interpolate.c)
+target_include_directories(test_sskr_bound_group_count PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/../../src/common/sskr ${CMAKE_CURRENT_SOURCE_DIR}/../../src/common/sskr/sss)
+target_compile_options(test_sskr_bound_group_count PRIVATE -fsanitize=address -fno-omit-frame-pointer)
+target_link_options(test_sskr_bound_group_count PRIVATE -fsanitize=address)
+target_link_libraries(test_sskr_bound_group_count PUBLIC cmocka gcov testutils)
+
 # Built with AddressSanitizer: this one is about what the code writes, not
 # what it returns, so the sanitizer is the assertion.
 add_executable(test_sskr_combine_bounds ./tests/sskr_combine_bounds.c ../../src/common/bip39/seed_rom_variables.c ../../src/common/bip39/seed_bip39.c ../../src/common/sskr/seed_rom_variables.c ../../src/common/sskr/seed_sskr.c)

--- a/tests/unit/CMakeLists.txt
+++ b/tests/unit/CMakeLists.txt
@@ -213,6 +213,14 @@ target_compile_options(test_sss_recover_erase_length PRIVATE -fsanitize=address 
 target_link_options(test_sss_recover_erase_length PRIVATE -fsanitize=address)
 target_link_libraries(test_sss_recover_erase_length PUBLIC cmocka gcov testutils)
 
+# The twin of the above, on the splitting side. No AddressSanitizer here: the
+# assertion is a canary field placed immediately after the caller's buffer, and
+# ASan would add nothing -- memzero() resolves to explicit_bzero(), which this
+# toolchain's ASan does not intercept (the reason the recovery-side test needs
+# a canary too). Linking libsss is therefore enough.
+add_executable(test_sss_split_erase_on_failure tests/sss_split_erase_on_failure.c)
+target_link_libraries(test_sss_split_erase_on_failure PUBLIC cmocka gcov testutils sss)
+
 add_executable(test_sss_validate_parameters tests/sss_validate_parameters.c)
 target_link_libraries(test_sss_validate_parameters PUBLIC cmocka gcov testutils sss)
 

--- a/tests/unit/tests/sskr_bound_group_count.c
+++ b/tests/unit/tests/sskr_bound_group_count.c
@@ -1,0 +1,126 @@
+/*
+ * Regression test for the missing upper bound on `groups_len` in
+ * sskr_count_shards() (src/common/sskr/sskr.c).
+ *
+ * Every buffer in this file that is sized from a group count is dimensioned
+ * on SSKR_MAX_GROUP_COUNT (1 in this port):
+ *
+ *     uint8_t group_shares[SSS_MAX_SECRET_SIZE * SSKR_MAX_GROUP_COUNT];
+ *     sskr_shard_t shards[SSS_MAX_SHARE_COUNT * SSKR_MAX_GROUP_COUNT];
+ *
+ * but sskr_count_shards(), the one validator every generation entry point
+ * runs first, only rejected `groups_len < 1`. Nothing checked the other end.
+ * sskr_generate_shards_internal() then passes groups_len straight to
+ * sss_split_secret() as its share_count, which writes groups_len shares of
+ * master_secret_len bytes each into a 32-byte group_shares -- 64 bytes for
+ * two groups at maximum strength.
+ *
+ * Not reachable from the application: bolos_ux_sskr_size_get() and
+ * bolos_ux_sskr_generate() (seed_sskr.c) already reject groups_len above
+ * SSKR_MAX_GROUP_COUNT before filling their own groups[] array (see
+ * sskr_generate_bound_groups.c), and bolos_ux_bip39_to_sskr_convert()
+ * hard-codes 1. sskr_generate_shards() and sskr_count_shards() are public
+ * entry points in sskr.h nonetheless, with the same standing as the other
+ * defensive bounds this file's callees already hold, and the check now sits
+ * with the rest of the group validation instead of one layer up.
+ *
+ * Verification technique: interpolate() reaches past group_shares with
+ * ordinary loads and stores, not a memzero()/explicit_bzero() call, so --
+ * unlike the erase in sss_recover_erase_length.c, which this toolchain's
+ * AddressSanitizer does not intercept -- ASan's stack-buffer-overflow
+ * instrumentation does apply. Confirmed by running this file against the
+ * unbounded version: it aborts with
+ *
+ *     stack-buffer-overflow ... interpolate ... sss_split_secret ...
+ *     sskr_generate_shards_internal
+ *     [64, 96) 'group_shares' <== Memory access at offset 96 overflows
+ *
+ * sskr.c, sss.c and interpolate.c are compiled directly into this target
+ * (rather than linked from libsskr/libsss) so ASan instruments their stack
+ * frames, matching test_sskr_combine_bounds and
+ * test_sss_recover_erase_length.
+ */
+
+#include <cmocka.h>
+#include <cx.h>
+#include <setjmp.h>
+#include <stdarg.h>
+#include <stddef.h>
+#include <stdint.h>
+#include <string.h>
+
+#include "sskr-constants.h"
+#include "sskr.h"
+#include "sss-constants.h"
+#include "testutils.h"
+
+#define SECRET_LEN (SSKR_MAX_STRENGTH_BYTES)
+#define BUFFER_LEN (1024)
+
+static void test_count_shards_rejects_more_groups_than_this_build_holds(
+    void** state) {
+    (void)state;
+
+    const sskr_group_descriptor_t groups[] = {{.threshold = 2, .count = 2},
+                                              {.threshold = 2, .count = 2}};
+
+    int16_t result = sskr_count_shards(1, groups, SSKR_MAX_GROUP_COUNT + 1);
+
+    assert_int_equal(result, SSKR_ERROR_INVALID_GROUP_LENGTH);
+}
+
+/* The overflowing path: without the bound, sss_split_secret() writes
+ * groups_len shares into a group_shares sized for SSKR_MAX_GROUP_COUNT of
+ * them. Maximum strength is used so the two shares need 64 bytes of a
+ * 32-byte buffer rather than exactly filling it. */
+static void test_generate_shards_rejects_more_groups_than_it_can_hold(
+    void** state) {
+    (void)state;
+
+    const uint8_t master_secret[SECRET_LEN] = {0};
+    const sskr_group_descriptor_t groups[] = {{.threshold = 2, .count = 2},
+                                              {.threshold = 2, .count = 2}};
+    uint8_t output[BUFFER_LEN];
+    uint8_t shard_len = 0;
+
+    memset(output, 0xFF, sizeof(output));
+
+    int16_t result = sskr_generate_shards(
+        SSKR_MAX_GROUP_COUNT + 1, groups, SSKR_MAX_GROUP_COUNT + 1,
+        master_secret, SECRET_LEN, &shard_len, output, sizeof(output), cx_rng);
+
+    assert_int_equal(result, SSKR_ERROR_INVALID_GROUP_LENGTH);
+}
+
+/* Boundary guard, so the bound cannot drift into rejecting the only group
+ * count this build actually supports. */
+static void test_generate_shards_still_accepts_the_supported_group_count(
+    void** state) {
+    (void)state;
+
+    const uint8_t master_secret[SECRET_LEN] = {0};
+    const sskr_group_descriptor_t groups[] = {{.threshold = 2, .count = 2}};
+    uint8_t output[BUFFER_LEN];
+    uint8_t shard_len = 0;
+
+    memset(output, 0xFF, sizeof(output));
+
+    int16_t result = sskr_generate_shards(1, groups, SSKR_MAX_GROUP_COUNT,
+                                          master_secret, SECRET_LEN, &shard_len,
+                                          output, sizeof(output), cx_rng);
+
+    assert_int_equal(result, 2);
+    assert_int_equal(shard_len, SSKR_METADATA_LENGTH_BYTES + SECRET_LEN);
+}
+
+int main(void) {
+    const struct CMUnitTest tests[] = {
+        cmocka_unit_test(
+            test_count_shards_rejects_more_groups_than_this_build_holds),
+        cmocka_unit_test(
+            test_generate_shards_rejects_more_groups_than_it_can_hold),
+        cmocka_unit_test(
+            test_generate_shards_still_accepts_the_supported_group_count),
+    };
+    return cmocka_run_group_tests(tests, NULL, NULL);
+}

--- a/tests/unit/tests/sss_split_erase_on_failure.c
+++ b/tests/unit/tests/sss_split_erase_on_failure.c
@@ -1,0 +1,180 @@
+/*
+ * Regression test for the un-erased output buffer on the
+ * interpolation-failure path of sss_split_secret()
+ * (src/common/sskr/sss/sss.c).
+ *
+ * sss_split_secret() and sss_recover_secret() fail in the same place, on
+ * the same interpolate() call, and used to draw different conclusions from
+ * it. The recovery side erases what it wrote before bailing out:
+ *
+ *     memzero(secret, share_length);
+ *     memzero(digest, sizeof(digest));
+ *     memzero(verify, sizeof(verify));
+ *     return SSS_ERROR_INTERPOLATION_FAILURE;
+ *
+ * The split side returned the error code and nothing else, leaving its own
+ * digest/x/y cleanup on the success path only and the caller's `result`
+ * buffer holding whatever had been written into it so far. That buffer is
+ * not scratch: for threshold >= 3 the first loop has already filled
+ * threshold - 2 shares from the random generator, and interpolate() writes
+ * whole shares of its own before the call that fails. Shamir shares are
+ * sensitive material.
+ *
+ * This was not a live leak. The only caller,
+ * sskr_generate_shards_internal(), already erases the group_shares and
+ * member_shares buffers it hands over on this exact path (covered by
+ * sskr_generate_erase_on_split_failure.c). What it was is a function whose
+ * safety depended entirely on its caller's discipline, in a file that is
+ * also exposed as a library, and whose twin already did the work itself.
+ *
+ * Forcing a genuine interpolation failure without faulting the secret
+ * sharing math: interpolate()'s first action is cx_bn_lock(), which fails
+ * immediately if a BN context is already locked. Its own cleanup path
+ * unlocks on the way out, so no matching unlock is needed here -- the same
+ * technique as sss_recover_erase_length.c and
+ * sskr_combine_erase_on_failure.c.
+ *
+ * Two thresholds, because they reach that failure with the output buffer
+ * in two different states:
+ *
+ *   - threshold 2: `for (i = threshold - 2; ...)` starts at 0, so
+ *     interpolate() fails on the very first share and the first loop ran
+ *     zero times. Nothing in `result` came from this call at all -- the
+ *     erase is the only thing that can clean it.
+ *   - threshold 3: the first loop has already written share 0 from the
+ *     random generator, so `result` holds a real share when the failure
+ *     hits, and the erase has to reach it.
+ *
+ * `shares` and `canary` are fields of one struct rather than separate
+ * stack arrays, so the layout is guaranteed by the language instead of
+ * left to the compiler: `canary` is guaranteed to sit immediately after
+ * the output buffer. The erase must stop at share_count * secret_length,
+ * the capacity sss.h requires of that buffer and exactly what the success
+ * path writes -- not at some larger fixed size. Erasing past the caller's
+ * buffer is not a hypothetical here: it is the precise defect
+ * sss_recover_erase_length.c exists for, on the recovery side of this same
+ * file. The canary is checked directly rather than left to a sanitizer,
+ * because memzero() resolves to explicit_bzero(), which this toolchain's
+ * AddressSanitizer does not appear to intercept (see that same file).
+ *
+ * WHAT THIS FILE DOES NOT CHECK, deliberately: `digest`, `x` and `y` are
+ * stack locals of sss_split_secret(). Once it returns, a unit test has no
+ * reliable way to inspect them -- the frame is gone, and reading it back
+ * would be undefined behaviour that any change of compiler or
+ * optimisation level could quietly invalidate. Their erasure is asserted
+ * by reading the code and by symmetry with sss_recover_secret(), not by
+ * observation. The identical cleanup on the *success* path, which predates
+ * this change, is untested for exactly the same reason. Neither is worked
+ * around with stack probing or by re-including the translation unit to
+ * expose the locals; the part that is genuinely observable -- the caller's
+ * buffer -- is what is asserted.
+ */
+
+#include <cmocka.h>
+#include <cx.h>
+#include <setjmp.h>
+#include <stdarg.h>
+#include <stddef.h>
+#include <stdint.h>
+#include <string.h>
+
+#include "sss-constants.h"
+#include "sss.h"
+#include "testutils.h"
+
+#define SECRET_LEN (SSS_MIN_SECRET_SIZE)
+#define CANARY_LEN (SSS_MAX_SECRET_SIZE)
+#define PATTERN (0xEE)
+#define PRIOR_BYTE (0xFF)
+#define CANARY_BYTE (0xA5)
+
+/* Stands in for cx_rng. A fixed non-zero pattern rather than real
+ * randomness: "the buffer is all zero afterwards" then means the erase ran,
+ * not that the generator happened to hand back zeros. */
+static unsigned char* fill_with_pattern(uint8_t* buffer, size_t length) {
+    memset(buffer, PATTERN, length);
+    return buffer;
+}
+
+/* threshold 2: the first loop runs zero times, so interpolate() fails
+ * before anything in the output buffer belongs to this call. */
+static void test_split_failure_erases_an_untouched_output(void** state) {
+    (void)state;
+
+    const uint8_t threshold = 2;
+    const uint8_t share_count = 2;
+    const uint8_t secret[SECRET_LEN] = {0};
+    struct {
+        uint8_t shares[2 * SECRET_LEN];
+        uint8_t canary[CANARY_LEN];
+    } guarded;
+
+    memset(guarded.shares, PRIOR_BYTE, sizeof(guarded.shares));
+    memset(guarded.canary, CANARY_BYTE, sizeof(guarded.canary));
+
+    /* Force interpolate()'s own cx_bn_lock() to fail: it refuses to lock an
+     * already-locked context. Its cleanup path unlocks whatever is locked
+     * when it bails out, so this releases the lock again on the way out --
+     * no matching unlock needed here. */
+    assert_int_equal(cx_bn_lock(1, 0), CX_OK);
+
+    int16_t result =
+        sss_split_secret(threshold, share_count, secret, SECRET_LEN,
+                         guarded.shares, fill_with_pattern);
+
+    assert_int_equal(result, SSS_ERROR_INTERPOLATION_FAILURE);
+
+    uint8_t expected_shares[sizeof(guarded.shares)];
+    memset(expected_shares, 0x00, sizeof(expected_shares));
+    assert_memory_equal(guarded.shares, expected_shares,
+                        sizeof(guarded.shares));
+
+    uint8_t expected_canary[sizeof(guarded.canary)];
+    memset(expected_canary, CANARY_BYTE, sizeof(expected_canary));
+    assert_memory_equal(guarded.canary, expected_canary,
+                        sizeof(guarded.canary));
+}
+
+/* threshold 3: the first loop writes share 0 into the output buffer before
+ * the failing interpolate() call, so the buffer holds a real share at the
+ * moment the function gives up. */
+static void test_split_failure_erases_shares_already_written(void** state) {
+    (void)state;
+
+    const uint8_t threshold = 3;
+    const uint8_t share_count = 3;
+    const uint8_t secret[SECRET_LEN] = {0};
+    struct {
+        uint8_t shares[3 * SECRET_LEN];
+        uint8_t canary[CANARY_LEN];
+    } guarded;
+
+    memset(guarded.shares, PRIOR_BYTE, sizeof(guarded.shares));
+    memset(guarded.canary, CANARY_BYTE, sizeof(guarded.canary));
+
+    assert_int_equal(cx_bn_lock(1, 0), CX_OK);
+
+    int16_t result =
+        sss_split_secret(threshold, share_count, secret, SECRET_LEN,
+                         guarded.shares, fill_with_pattern);
+
+    assert_int_equal(result, SSS_ERROR_INTERPOLATION_FAILURE);
+
+    uint8_t expected_shares[sizeof(guarded.shares)];
+    memset(expected_shares, 0x00, sizeof(expected_shares));
+    assert_memory_equal(guarded.shares, expected_shares,
+                        sizeof(guarded.shares));
+
+    uint8_t expected_canary[sizeof(guarded.canary)];
+    memset(expected_canary, CANARY_BYTE, sizeof(expected_canary));
+    assert_memory_equal(guarded.canary, expected_canary,
+                        sizeof(guarded.canary));
+}
+
+int main(void) {
+    const struct CMUnitTest tests[] = {
+        cmocka_unit_test(test_split_failure_erases_an_untouched_output),
+        cmocka_unit_test(test_split_failure_erases_shares_already_written),
+    };
+    return cmocka_run_group_tests(tests, NULL, NULL);
+}


### PR DESCRIPTION
Two related cleanup/bounds defects in the Shamir layer, found from opposite
ends of the same call. Four commits, each a fix followed by its test.

## 1. `sss_split_secret()` did not clean up where its twin does

`sss_split_secret()` and `sss_recover_secret()` (`src/common/sskr/sss/sss.c`)
fail in the same place, on the same `interpolate()` call. They drew opposite
conclusions from it.

`sss_recover_secret()` cleans up before returning:

```c
if (interpolate(threshold, x, share_length, shares, SSS_DIGEST_INDEX,
                digest) != CX_OK ||
    interpolate(threshold, x, share_length, shares, SSS_SECRET_INDEX,
                secret) != CX_OK) {
    memzero(secret, share_length);        // the caller's output buffer
    memzero(digest, sizeof(digest));
    memzero(verify, sizeof(verify));

    return SSS_ERROR_INTERPOLATION_FAILURE;
}
```

`sss_split_secret()` returned the code and nothing else:

```c
for (uint8_t i = threshold - 2; i < share_count; ++i, share += secret_length) {
    if (interpolate(n, x, secret_length, y, i, share) != CX_OK) {
        return SSS_ERROR_INTERPOLATION_FAILURE;   // no memzero
    }
}

memzero(digest, sizeof(digest));   // success path only
memzero(x, sizeof(x));
memzero(y, sizeof(y));
```

### What this is, and what it is not

**This is not a live secret leak, and it should not be read as one.**

- `digest` does not hold the secret. It is `HMAC-SHA256(random, secret)[:4]`
  followed by `secret_length - 4` random bytes: a truncated fingerprint.
- `x` holds only share indices, `y` only pointers.
- The one caller already compensates. `sskr_generate_shards_internal()`
  (`src/common/sskr/sskr.c`) does `memzero(group_shares, ...)` and
  `memzero(member_shares, ...)` on this exact error path.

**The output buffer is a different matter.** `share` points into `result`,
the caller's buffer, and the failure happens *after* the first loop has
written `threshold - 2` shares into it and `interpolate()` has written whole
shares of its own. Those are Shamir shares, and they were left in place.

Not a hypothetical: with the erase removed, the test's own diff shows the
buffer holding a real share at the moment the function gives up.

```
- [00000000] ee ee ee ee ee ee ee ee   ee ee ee ee ee ee ee ee
+ [00000000] 00 00 00 00 00 00 00 00   00 00 00 00 00 00 00 00
```

So the defect is narrower than a leak but real: **a function whose twin
cleans its own output buffer on failure did not, and its safety rested
entirely on its caller's discipline** -- in a file that is also exposed as a
library.

### The erase bound

`share_count * secret_length` -- the capacity `sss.h` requires of that buffer
(*"The size of this buffer must be `share_count * secret_length` bytes"*),
and exactly what the success path writes. Deliberately not a fixed maximum:
`sss_recover_secret()` had precisely that defect on its own side, erasing
`SSS_MAX_SECRET_SIZE` from a buffer only required to hold `share_length`.

Erasing only the bytes this particular call happened to write would leave
earlier shares in place in a buffer reused across calls -- `member_shares`,
reused across groups in `sskr_generate_shards_internal()`, is one -- which
would be the same defect through the back door.

Return codes, the success path and the `threshold == 1` branch are unchanged.

## 2. `sskr_count_shards()` bounded the group count on one side only

Checking that the erase bound was safe for the real callers turned up a
separate, pre-existing defect, and this one *is* a memory-safety bug.

Every buffer in `sskr.c` sized from a group count is dimensioned on
`SSKR_MAX_GROUP_COUNT` (1 in this port):

```c
uint8_t group_shares[SSS_MAX_SECRET_SIZE * SSKR_MAX_GROUP_COUNT];
sskr_shard_t shards[SSS_MAX_SHARE_COUNT * SSKR_MAX_GROUP_COUNT];
```

but `sskr_count_shards()`, the one validator every generation entry point
runs first, only rejected `groups_len < 1`. Nothing checked the other end.
`sskr_generate_shards_internal()` then passes `groups_len` straight to
`sss_split_secret()` as its `share_count`, which writes that many shares
into a 32-byte `group_shares` -- 64 bytes for two groups at maximum strength.

AddressSanitizer, on the ordinary success path, nothing faulted:

```
ERROR: AddressSanitizer: stack-buffer-overflow
    #0 interpolate                    src/common/sskr/sss/interpolate.c:222
    #1 sss_split_secret               src/common/sskr/sss/sss.c:138
    #2 sskr_generate_shards_internal  src/common/sskr/sskr.c:285
    #3 sskr_generate_shards           src/common/sskr/sskr.c:367

  This frame has 3 object(s):
    [64, 96) 'group_shares' (line 282) <== Memory access at offset 96 overflows
```

(line numbers as of the base commit, from `sskr_generate_shards()` called
with two groups and nothing faulted)

**Not reachable from the application.** `bolos_ux_sskr_size_get()` and
`bolos_ux_sskr_generate()` (`seed_sskr.c`) already reject `groups_len` above
`SSKR_MAX_GROUP_COUNT` before filling their own `groups[]` array, and
`bolos_ux_bip39_to_sskr_convert()` hard-codes 1. But
`sskr_count_shards()` and `sskr_generate_shards()` are public entry points in
`sskr.h`, with the same standing as the other defensive bounds their callees
already hold, and the check belongs with the rest of the group validation
rather than repeated in each caller.

The fix is the same error code and the same shape as the lower bound it
joins, and as the check `bolos_ux_sskr_size_get()` already makes. No existing
caller passes a group count above `SSKR_MAX_GROUP_COUNT`, so nothing that
worked before behaves differently.

## What the tests can and cannot check

`tests/unit/tests/sss_split_erase_on_failure.c` covers two thresholds,
because they reach the failing `interpolate()` with the output buffer in
different states: at threshold 2 the `for (i = threshold - 2; ...)` loop
starts at 0 and nothing in the buffer came from this call, so only the erase
can clean it; at threshold 3 the first loop has already written share 0. The
failure is forced the way the two existing tests force it -- `interpolate()`'s
first action is `cx_bn_lock()`, which refuses an already-locked BN context,
and its own cleanup path unlocks on the way out. No secret sharing math is
faulted.

The output buffer and a canary are fields of one struct, so the canary is
guaranteed by the language to sit immediately after the buffer rather than by
whatever the compiler did with two separate arrays. That is what holds the
erase to `share_count * secret_length`. It is asserted directly rather than
left to a sanitizer, because `memzero()` resolves to `explicit_bzero()`,
which this toolchain's AddressSanitizer does not appear to intercept.

**What it cannot check is stated in the file header rather than worked
around.** `digest`, `x` and `y` are stack locals; once `sss_split_secret()`
returns, reading them back would be undefined behaviour that any compiler or
optimisation change could quietly invalidate. Their erasure rests on reading
the code and on symmetry with `sss_recover_secret()`, not on observation. The
identical cleanup on the *success* path, which predates this change, is
untested for exactly the same reason. No stack probing, no re-inclusion of
the translation unit to expose the locals.

`tests/unit/tests/sskr_bound_group_count.c` is the opposite case: the
overflow there happens through `interpolate()`'s ordinary loads and stores,
which ASan does instrument, so the sanitizer is the assertion. `sskr.c`,
`sss.c` and `interpolate.c` are compiled into that target rather than linked
so their frames are instrumented, matching `test_sskr_combine_bounds`.

## Verification

**Both fixes verified by mutation, replayed against the committed tree.**

| mutation | result |
|---|---|
| `memzero(result, ...)` removed | both cases of `test_sss_split_erase_on_failure` fail on the buffer comparison |
| `\|\| groups_len > SSKR_MAX_GROUP_COUNT` removed | `test_sskr_bound_group_count` the only failure out of 42, on the ASan report above |
| restored | 42/42 green, sources checksummed back to their committed state |

- `ctest -N` 40 -> **42**, 42/42 green. No change to the ctest registration
  was needed; the two `add_executable()` calls are picked up on their own.
- Line coverage, measured on the base commit and on this branch:
  `sss.c` 76/80 -> **84/84**, `sskr.c` 215/237 -> **219/237**.
- All six devices in `ledger_app.toml` cross-compiled, **6/6, no warnings**:
  nanos 32008/3708, nanox 45880/28672, nanos+ 46152/40960, stax 72305/36864,
  flex 72845/36864, apex_p 69233/40960 -- byte-identical to the base commit.
  Note that `nanos` is declared supported but is absent from
  `ci-workflow.yml`, so it was built by hand; it matters here because it has
  its own `SSS_MAX_SHARE_COUNT` (10 rather than 16), hence differently sized
  `x[]` and `y[]` in the function being changed.
- Sizes are identical on the linked image although the objects did change:
  on nanos `sss.o` 590 -> 618 (+28) and `sskr.o` 1496 -> 1480 (-16, because
  with `SSKR_MAX_GROUP_COUNT == 1` the two-sided test folds into a single
  `!= 1`). `objdump -h` is byte-identical between base and branch: the
  `.text` section carries two `. = ALIGN(PAGE_SIZE);` before `_nvram_data`,
  which absorbs the difference.
- `clang-format --dry-run -Werror` clean on all four files.
- **No Speculos script.** Neither error path is reachable through the user
  interface: the interpolation failure needs a faulted BN context, and the
  group count is hard-coded to 1 by the only UI caller. The value of both
  changes is at the library boundary, which is where the unit tests sit.
