### PR TITLE
tests: hold two guards that nothing was holding

### DIFF
--- a/tests/unit/CMakeLists.txt
+++ b/tests/unit/CMakeLists.txt
@@ -343,6 +343,16 @@ target_compile_options(test_sskr_generate_bound_groups PRIVATE -fsanitize=addres
 target_link_options(test_sskr_generate_bound_groups PRIVATE -fsanitize=address)
 target_link_libraries(test_sskr_generate_bound_groups PUBLIC cmocka gcov testutils sskr sss)
 
+# The seed_len bounds of the same entry point. Same source list and same
+# sanitizer setup as test_sskr_generate_bound_groups above: seed_sskr.c is
+# compiled in rather than linked so its frames are instrumented, since these
+# lengths are what the shard buffers are sized from.
+add_executable(test_sskr_generate_seed_len_bounds ./tests/sskr_generate_seed_len_bounds.c ../../src/common/bip39/seed_rom_variables.c ../../src/common/bip39/seed_bip39.c ../../src/common/sskr/seed_rom_variables.c ../../src/common/sskr/seed_sskr.c)
+target_include_directories(test_sskr_generate_seed_len_bounds PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/../../src ${CMAKE_CURRENT_SOURCE_DIR}/../../src/common ${CMAKE_CURRENT_SOURCE_DIR}/../../src/common/sskr/sss)
+target_compile_options(test_sskr_generate_seed_len_bounds PRIVATE -fsanitize=address -fno-omit-frame-pointer)
+target_link_options(test_sskr_generate_seed_len_bounds PRIVATE -fsanitize=address)
+target_link_libraries(test_sskr_generate_seed_len_bounds PUBLIC cmocka gcov testutils sskr sss)
+
 # Blockchain Commons 128-bit vector, raw Shamir math level (no CBOR/CRC).
 add_executable(test_sskr_interop_bc128 tests/sskr_interop_bc128.c)
 target_link_libraries(test_sskr_interop_bc128 PUBLIC cmocka gcov testutils sskr sss)

--- a/tests/unit/tests/bip39.c
+++ b/tests/unit/tests/bip39.c
@@ -117,6 +117,66 @@ static void test_bip39_decode_bad_checksum(void** state) {
     assert_int_equal(result, 0);
 }
 
+// The vector above swaps in "abandon", which is index 0 and so changes the
+// entropy bits as well as the checksum bits. It therefore says nothing about
+// how *many* checksum bits decode() actually compares. A 12-word phrase
+// carries a 4-bit checksum, which is why decode() masks with 0xF0 for n == 12;
+// narrowing that mask to 0xE0 would compare only three of the four and admit
+// any phrase whose fourth checksum bit is wrong. Nothing held that width: with
+// mask = 0xE0 the whole suite stayed green. This vector pins it.
+//
+// Derivation, starting from the 16-byte entropy already used below by
+// test_bip39_roundtrip_12_words:
+//
+//   entropy    62 50 b6 8d af 74 6d 12 a2 4d 58 b4 78 7a 71 4b
+//   SHA-256    3313908a3667d9ad2f7f6bd844ab737430b84651f0bd70ebd6646a7d0564c379
+//   SHA-256[0] 0x33 = 0011 0011, so the four checksum bits are 0011
+//
+// The checksum occupies the last 4 of the 132 bits, i.e. the low nibble of
+// the twelfth word's 11-bit index. "nose" is index 1203 = 100 1011 0011,
+// low nibble 0011 -- the correct checksum. Clearing its last bit gives index
+// 1202 = 100 1011 0010 = "north": the same 128 entropy bits, and a checksum
+// of 0010, wrong in the fourth bit and only there.
+//
+// What decode() then compares, with buffer[0] = SHA-256[0] = 0x33 and
+// bits[16] = 0x20 (the "north" nibble, left-aligned):
+//
+//   0x33 & 0xF0 = 0x30 != 0x20 = bits[16] & 0xF0  -> rejected, as it must be
+//   0x33 & 0xE0 = 0x20 == 0x20 = bits[16] & 0xE0  -> accepted, the weakening
+//
+// Checked independently against SHA-256 and the BIP-39 English wordlist: the
+// two phrases decode to byte-identical entropy and differ in that one
+// checksum bit alone. The valid phrase is asserted here too, so a failure
+// cannot be blamed on something unrelated to the mask.
+static const unsigned char bip39_valid_12_word_mnemonic[] =
+    "girl mad pet galaxy egg matter matrix prison refuse sense ordinary "
+    "nose";
+
+static const unsigned char bip39_fourth_checksum_bit_mnemonic[] =
+    "girl mad pet galaxy egg matter matrix prison refuse sense ordinary "
+    "north";
+
+static void test_bip39_decode_checksum_mask_covers_fourth_bit(void** state) {
+    (void)state;
+    static const uint8_t entropy[16] = {0x62, 0x50, 0xb6, 0x8d, 0xaf, 0x74,
+                                        0x6d, 0x12, 0xa2, 0x4d, 0x58, 0xb4,
+                                        0x78, 0x7a, 0x71, 0x4b};
+    unsigned char bits[32 + 1];
+
+    assert_int_equal(
+        bolos_ux_bip39_mnemonic_decode(bip39_valid_12_word_mnemonic,
+                                       sizeof(bip39_valid_12_word_mnemonic) - 1,
+                                       bits, sizeof(bits)),
+        1);
+    assert_memory_equal(bits, entropy, sizeof(entropy));
+
+    assert_int_equal(
+        bolos_ux_bip39_mnemonic_decode(
+            bip39_fourth_checksum_bit_mnemonic,
+            sizeof(bip39_fourth_checksum_bit_mnemonic) - 1, bits, sizeof(bits)),
+        0);
+}
+
 // Same phrase as above, but the last word is replaced with a 17-character
 // string. bolos_ux_bip39_mnemonic_decode() accumulates each word into a
 // local `unsigned char current_word[10]` and bails out as soon as a word
@@ -312,6 +372,7 @@ int main(void) {
         cmocka_unit_test(test_bip39_decode_word_too_long_for_buffer),
         cmocka_unit_test(test_bip39_decode_unknown_word),
         cmocka_unit_test(test_bip39_decode_bad_checksum),
+        cmocka_unit_test(test_bip39_decode_checksum_mask_covers_fourth_bit),
         cmocka_unit_test(test_bip39_decode_wrong_length),
         cmocka_unit_test(test_bip39_encode_insufficient_buffer),
         cmocka_unit_test(test_bip39_encode_rejects_invalid_seed_len),

--- a/tests/unit/tests/sskr_generate_seed_len_bounds.c
+++ b/tests/unit/tests/sskr_generate_seed_len_bounds.c
@@ -1,0 +1,198 @@
+/*
+ * Coverage for the seed_len bounds in bolos_ux_sskr_generate()
+ * (seed_sskr.c). No defect is fixed here: the guard
+ *
+ *     if (!(SSKR_MIN_STRENGTH_BYTES <= seed_len &&
+ *           seed_len <= SSKR_MAX_STRENGTH_BYTES) ||
+ *         (seed_len % 2 != 0)) {
+ *         return 0;
+ *     }
+ *
+ * is present and correct. Nothing held it: the three files that already call
+ * bolos_ux_sskr_generate() (sskr_bound_group_count.c,
+ * sskr_generate_bound_groups.c, sskr_invalid_group_descriptor.c) all vary the
+ * group descriptor and always pass a well-formed seed_len, so deleting the
+ * guard outright left the whole suite green.
+ *
+ * Why the return value alone cannot hold it, and what these tests assert
+ * instead:
+ *
+ * sskr_generate_shards() -- the next call in the function -- opens with
+ * sskr_check_secret_length(), which applies the very same three conditions
+ * and returns SSKR_ERROR_SECRET_TOO_SHORT / _TOO_LONG /
+ * _LENGTH_NOT_EVEN. bolos_ux_sskr_generate() then sees a negative count and
+ * returns 0 as well. So an out-of-range seed_len yields 0 either way, and a
+ * test that only looked at the return value would keep passing with the
+ * guard deleted.
+ *
+ * The difference is what happens to the caller's buffer on the way out. The
+ * guard returns before touching it; the failure path that catches the
+ * negative count first runs memzero(share_buffer, share_buffer_len) and
+ * clears the whole thing. These tests therefore fill share_buffer with a
+ * sentinel and require it to come back untouched -- rejection before any
+ * write, which is the guard's observable contribution.
+ *
+ * (The two checks are not exact duplicates for a second reason, not
+ * exercised here: seed_len is an unsigned int at this level, whereas
+ * sskr_generate_shards() takes a uint16_t and sskr_check_secret_length()
+ * takes a uint8_t. The guard is the only one that sees the full width.)
+ *
+ * The two accepted boundaries, 16 and 32, are covered as well, so that
+ * tightening either end by one step is caught rather than silently
+ * narrowing what the function accepts.
+ *
+ * Target setup mirrors test_sskr_generate_bound_groups: seed_sskr.c is
+ * compiled directly into this target rather than linked, under ASan, so any
+ * incidental overrun these lengths might provoke is reported.
+ */
+
+#include <cmocka.h>
+#include <setjmp.h>
+#include <stdarg.h>
+#include <stddef.h>
+#include <stdint.h>
+#include <string.h>
+
+#include "sskr/sskr-constants.h"
+#include "testutils.h"
+
+/* One maximum-size shard, which is all a 1-of-1 descriptor ever produces.
+ * Comfortably below the share_buffer_len cap bolos_ux_sskr_generate()
+ * enforces, so that bound stays out of the way of this one. */
+#define SHARE_BUFFER_LENGTH \
+    (SSKR_MAX_STRENGTH_BYTES + SSKR_METADATA_LENGTH_BYTES)
+
+/* Long enough for the largest seed_len tried below (34, one step past the
+ * upper bound), so no case can read past the end of the seed. */
+#define SEED_BUFFER_LENGTH (SSKR_MAX_STRENGTH_BYTES + 2)
+
+#define SENTINEL 0xa5
+
+/* bolos_ux_sskr_generate() is a public entry point (external linkage) but is
+ * only ever called from within seed_sskr.c itself, so it is not declared in
+ * common_sskr.h. */
+extern unsigned int bolos_ux_sskr_generate(
+    uint8_t groups_threshold, unsigned int* group_descriptor,
+    uint8_t groups_len, unsigned char* seed, unsigned int seed_len,
+    uint8_t* share_len, unsigned char* share_buffer,
+    unsigned int share_buffer_len, uint8_t share_len_expected,
+    int16_t share_count_expected);
+
+/*
+ * Call bolos_ux_sskr_generate() varying nothing but seed_len. Everything
+ * else is the single configuration this port supports -- a 1-of-1 group,
+ * groups_len at SSKR_MAX_GROUP_COUNT -- and the expected share length and
+ * count are what that descriptor yields for the seed_len given, so a
+ * rejection can only come from the seed_len itself and not from a
+ * descriptor the function would have turned away first.
+ *
+ * share_buffer and *share_len are set to the sentinel before the call, so
+ * the caller can tell "returned without writing" from "wrote, then
+ * returned".
+ */
+static unsigned int generate_with_seed_len(unsigned int seed_len,
+                                           uint8_t* share_buffer,
+                                           uint8_t* share_len) {
+    unsigned int group_descriptor[2] = {1, 1};
+    unsigned char seed[SEED_BUFFER_LENGTH] = {0};
+
+    memset(share_buffer, SENTINEL, SHARE_BUFFER_LENGTH);
+    *share_len = SENTINEL;
+
+    return bolos_ux_sskr_generate(
+        1, group_descriptor, SSKR_MAX_GROUP_COUNT, seed, seed_len, share_len,
+        share_buffer, SHARE_BUFFER_LENGTH,
+        (uint8_t)(seed_len + SSKR_METADATA_LENGTH_BYTES), 1);
+}
+
+static void assert_untouched(const uint8_t* share_buffer, uint8_t share_len) {
+    for (size_t i = 0; i < SHARE_BUFFER_LENGTH; i++) {
+        assert_int_equal(share_buffer[i], SENTINEL);
+    }
+    assert_int_equal(share_len, SENTINEL);
+}
+
+/*
+ * Below SSKR_MIN_STRENGTH_BYTES. Even, and so within the other two
+ * conditions -- only the lower bound rejects it.
+ */
+static void test_generate_rejects_seed_len_below_minimum(void** state) {
+    (void)state;
+
+    uint8_t share_buffer[SHARE_BUFFER_LENGTH];
+    uint8_t share_len;
+
+    assert_int_equal(generate_with_seed_len(14, share_buffer, &share_len), 0);
+    assert_untouched(share_buffer, share_len);
+}
+
+/*
+ * Above SSKR_MAX_STRENGTH_BYTES, and even -- only the upper bound rejects
+ * it.
+ */
+static void test_generate_rejects_seed_len_above_maximum(void** state) {
+    (void)state;
+
+    uint8_t share_buffer[SHARE_BUFFER_LENGTH];
+    uint8_t share_len;
+
+    assert_int_equal(generate_with_seed_len(34, share_buffer, &share_len), 0);
+    assert_untouched(share_buffer, share_len);
+}
+
+/*
+ * Inside [SSKR_MIN_STRENGTH_BYTES, SSKR_MAX_STRENGTH_BYTES] but odd -- only
+ * the parity condition rejects it. SSKR splits the secret into two halves,
+ * so an odd length has no valid split.
+ */
+static void test_generate_rejects_odd_seed_len(void** state) {
+    (void)state;
+
+    uint8_t share_buffer[SHARE_BUFFER_LENGTH];
+    uint8_t share_len;
+
+    assert_int_equal(generate_with_seed_len(17, share_buffer, &share_len), 0);
+    assert_untouched(share_buffer, share_len);
+}
+
+/*
+ * The two accepted ends. A 12-word phrase is 16 bytes of entropy and a
+ * 24-word phrase 32, so both are lengths the application really passes;
+ * tightening either end by one step would break it.
+ */
+static void test_generate_accepts_seed_len_at_minimum(void** state) {
+    (void)state;
+
+    uint8_t share_buffer[SHARE_BUFFER_LENGTH];
+    uint8_t share_len;
+
+    assert_int_equal(generate_with_seed_len(SSKR_MIN_STRENGTH_BYTES,
+                                            share_buffer, &share_len),
+                     1);
+    assert_int_equal(share_len,
+                     SSKR_MIN_STRENGTH_BYTES + SSKR_METADATA_LENGTH_BYTES);
+}
+
+static void test_generate_accepts_seed_len_at_maximum(void** state) {
+    (void)state;
+
+    uint8_t share_buffer[SHARE_BUFFER_LENGTH];
+    uint8_t share_len;
+
+    assert_int_equal(generate_with_seed_len(SSKR_MAX_STRENGTH_BYTES,
+                                            share_buffer, &share_len),
+                     1);
+    assert_int_equal(share_len,
+                     SSKR_MAX_STRENGTH_BYTES + SSKR_METADATA_LENGTH_BYTES);
+}
+
+int main(void) {
+    const struct CMUnitTest tests[] = {
+        cmocka_unit_test(test_generate_rejects_seed_len_below_minimum),
+        cmocka_unit_test(test_generate_rejects_seed_len_above_maximum),
+        cmocka_unit_test(test_generate_rejects_odd_seed_len),
+        cmocka_unit_test(test_generate_accepts_seed_len_at_minimum),
+        cmocka_unit_test(test_generate_accepts_seed_len_at_maximum),
+    };
+    return cmocka_run_group_tests(tests, NULL, NULL);
+}


### PR DESCRIPTION
Two guards that were already present and already correct, but that no test
held: deleting either one left the whole unit suite green. Nothing in `src/`
is modified and no defect is fixed here -- this is coverage over code that is
right today, so that it stays right.

## The 12-word checksum mask

`bolos_ux_bip39_mnemonic_decode()` compares a 12-word phrase's checksum under
mask `0xF0` -- the four bits such a phrase carries. No test held that width:
replacing `0xF0` with `0xE0`, so that three bits are compared instead of four,
left every test passing. In concrete terms, a one-bit weakening of the
checksum verification on the most common phrase length would have gone
unnoticed.

The existing bad-checksum vector cannot hold it, because its last word is
"abandon" (index 0), which changes the entropy bits as well as the checksum
bits. It proves that *some* mismatch is rejected, not *how many* bits are
compared.

### Where the new vector comes from

Derived, not guessed, and the derivation is written out in the test:

```
entropy    62 50 b6 8d af 74 6d 12 a2 4d 58 b4 78 7a 71 4b   (already used by
                                                              the 12-word
                                                              roundtrip test)
SHA-256    3313908a3667d9ad2f7f6bd844ab737430b84651f0bd70ebd6646a7d0564c379
SHA-256[0] 0x33 = 0011 0011  ->  the four checksum bits are 0011
```

The checksum is the last 4 of the 132 bits, i.e. the low nibble of the twelfth
word's 11-bit index. "nose" is index 1203 = `100 1011 0011`, low nibble `0011`
-- the correct checksum. Clearing its last bit gives index 1202 = "north": the
same 128 entropy bits, and checksum `0010`, wrong in the fourth bit and only
there.

What `decode()` then compares, with `buffer[0] = 0x33` and `bits[16] = 0x20`:

```
0x33 & 0xF0 = 0x30 != 0x20 = bits[16] & 0xF0   -> rejected, as it must be
0x33 & 0xE0 = 0x20 == 0x20 = bits[16] & 0xE0   -> accepted, the weakening
```

Checked independently against SHA-256 and the BIP-39 English wordlist: the two
phrases decode to byte-identical entropy and differ in that one checksum bit
alone. The valid phrase is asserted in the same test, so a failure cannot be
put down to something unrelated to the mask.

## The `seed_len` bounds of `bolos_ux_sskr_generate()`

The function rejects a `seed_len` outside
`[SSKR_MIN_STRENGTH_BYTES, SSKR_MAX_STRENGTH_BYTES]` or of odd length. The
three files that already call it all vary the group descriptor and always pass
a well-formed `seed_len`, so deleting the check left the suite green.

The return value alone cannot hold it. `sskr_generate_shards()`, called
immediately after, opens with `sskr_check_secret_length()`, which applies the
same three conditions; the caller then sees a negative count and returns 0 as
well. An out-of-range `seed_len` yields 0 either way.

What differs is the exit path. The check returns before touching the caller's
buffer, whereas the negative-count path first runs
`memzero(share_buffer, share_buffer_len)` over the whole of it. The three
rejection cases therefore fill `share_buffer` with a sentinel and require it
back untouched.

One case per condition, each violating only the condition it targets -- 14
below the lower bound, 34 above the upper one, 17 odd and in range -- plus the
two accepted ends, 16 and 32, so that tightening either by one step is caught
rather than silently narrowing what the function accepts.

## Verified by mutation

Both mutations were applied to the committed tree and reverted afterwards
(`md5sum` confirmed on both `src/` files):

- `mask = 0xF0` -> `0xE0`: `test_bip39` is the only failing target of 43, and
  `test_bip39_decode_checksum_mask_covers_fourth_bit` the only failing case in
  it.
- the `seed_len` check deleted outright: `test_sskr_generate_seed_len_bounds`
  is the only failing target of 43, with its three rejection cases red on the
  sentinel assertion and the two accepted ends still green.

As a check that the accepted boundaries are not dead weight, tightening both
bounds by one step (`SSKR_MIN_STRENGTH_BYTES + 2`,
`SSKR_MAX_STRENGTH_BYTES - 2`) turns exactly those two cases red and leaves the
three rejections green.

## The rest

- `ctest -N` 42 -> 43: one new target, `test_sskr_generate_seed_len_bounds`.
  The checksum vector goes into `bip39.c`, which already has one. Registration
  is derived from the built targets, so the `add_executable()` was all that was
  needed.
- 43/43 pass. Line coverage: `seed_sskr.c` 201/212 -> 202/212, `seed_bip39.c`
  158/165 -> 158/165, unchanged. That zero is the point rather than an
  oversight -- the mask lines were already being executed, so line coverage
  said nothing about how many bits were compared.
- No `src/` file is modified, so no cross-compilation is needed and the
  Speculos scripts are unaffected.
- `clang-format --dry-run -Werror` clean on both touched files.
