### PR TITLE
fix: reserve the separator's byte in the BIP-39 encode bound

### DIFF
--- a/src/common/bip39/seed_bip39.c
+++ b/src/common/bip39/seed_bip39.c
@@ -168,7 +168,11 @@ unsigned int bolos_ux_bip39_mnemonic_encode(const uint8_t* seed,
         }
         word_len =
             BIP39_WORDLIST_OFFSETS[idx + 1] - BIP39_WORDLIST_OFFSETS[idx];
-        if ((offset + word_len) > out_len) {
+        // every word but the last is followed by a separator, so its byte has
+        // to be claimed together with the word: bounding the word alone lets
+        // offset reach out_len and puts the separator at out[out_len]
+        uint8_t separator_len = (i < (seed_len * 3 / 4) - 1) ? 1 : 0;
+        if ((offset + word_len + separator_len) > out_len) {
             memzero(bits, sizeof(bits));
             return 0;
         }
@@ -179,7 +183,7 @@ unsigned int bolos_ux_bip39_mnemonic_encode(const uint8_t* seed,
             memzero(bits, sizeof(bits));
             return 0;
         }
-        if (i < (seed_len * 3 / 4) - 1) {
+        if (separator_len) {
             out[offset++] = ' ';
         }
     }

--- a/tests/unit/tests/bip39.c
+++ b/tests/unit/tests/bip39.c
@@ -3,6 +3,7 @@
 #include <stdarg.h>
 #include <stddef.h>
 #include <stdint.h>
+#include <stdlib.h>
 #include <string.h>
 
 #include "bip39/common_bip39.h"
@@ -281,6 +282,150 @@ static void test_bip39_encode_insufficient_buffer(void** state) {
     assert_int_equal(result, 0);
 }
 
+// The same guard as the test above, seen one byte further along. It bounds
+// the word about to be copied, but not the separator that follows it:
+//
+//     if ((offset + word_len) > out_len) {  // equality accepted
+//         ...
+//     }
+//     memcpy(out + offset, ..., word_len);
+//     offset += word_len;                   // offset == out_len now possible
+//     if (offset > out_len) {               // so this can never fire
+//         ...
+//     }
+//     if (i < (seed_len * 3 / 4) - 1) {
+//         out[offset++] = ' ';              // writes out[out_len]
+//     }
+//
+// When a capacity lands exactly on a word boundary and words still remain,
+// the first guard accepts the word, `offset` becomes exactly out_len, the
+// second guard cannot fire, and the separator goes one byte past the end.
+//
+// The return value does not tell the two behaviours apart. A separator is
+// only written when a word follows, and after the overrun `offset` is
+// out_len + 1, so that next word never fits and encode() returns 0 either
+// way -- as it already did. The observable is the write itself, so each
+// capacity is tried twice: once into a buffer followed by sentinel bytes,
+// which holds with or without a sanitizer, and once into a heap block sized
+// exactly to the capacity, which AddressSanitizer redzones (this target is
+// built with it, see the CMake comment).
+//
+// Not reachable from the application. Both callers pass a fixed capacity --
+// BIP39_MNEMONIC_MAX_LENGTH = 24 * (8 + 1) = 216 in src/nbgl/bip39_mnemonic.c,
+// and the caller-owned words_buffer handed to src/common/sskr/seed_sskr.c,
+// 257 on the BAGL side -- while the longest possible mnemonic is
+// 24 * 8 + 23 = 215 characters, so `offset` never reaches out_len there.
+// bolos_ux_bip39_mnemonic_encode() is declared in bip39/common_bip39.h and
+// takes out_len from whoever calls it, which is what the bound is for.
+
+// Entropy 00 01 .. 0f -- the vector used by the test above -- encodes to the
+// 74-character
+//
+//     abandon amount liar amount expire adjust cage candy arch gather
+//     drum buyer
+//
+// whose word lengths are 7 6 4 6 6 6 4 5 4 6 4 5. Counting the separators,
+// `offset` sits at each of the values below right after copying a word that
+// still has successors: these are exactly the capacities that trip the
+// guard. 74, the offset after the last word, is not among them -- no
+// separator follows it.
+#define ENCODE_ENTROPY_MNEMONIC_LENGTH (74)
+#define ENCODE_SENTINEL_BYTE (0xa5)
+#define ENCODE_SENTINEL_LENGTH (16)
+
+static const uint8_t encode_entropy[16] = {0x00, 0x01, 0x02, 0x03, 0x04, 0x05,
+                                           0x06, 0x07, 0x08, 0x09, 0x0a, 0x0b,
+                                           0x0c, 0x0d, 0x0e, 0x0f};
+
+static const char encode_entropy_mnemonic[] =
+    "abandon amount liar amount expire adjust cage candy arch gather drum "
+    "buyer";
+
+static const size_t encode_word_boundaries[] = {7,  14, 19, 26, 33, 40,
+                                                45, 51, 56, 63, 68};
+
+static void test_bip39_encode_separator_stays_in_bounds(void** state) {
+    (void)state;
+
+    for (size_t k = 0;
+         k < sizeof(encode_word_boundaries) / sizeof(encode_word_boundaries[0]);
+         k++) {
+        const size_t capacity = encode_word_boundaries[k];
+        unsigned char
+            block[ENCODE_ENTROPY_MNEMONIC_LENGTH + ENCODE_SENTINEL_LENGTH];
+
+        memset(block, ENCODE_SENTINEL_BYTE, sizeof(block));
+
+        // none of these capacities can hold the whole mnemonic, so a clean
+        // failure is the only correct answer -- a non-zero return here would
+        // be a truncated mnemonic reported as a success, which is worse than
+        // the overrun being fixed
+        assert_int_equal(
+            bolos_ux_bip39_mnemonic_encode(
+                encode_entropy, sizeof(encode_entropy), block, capacity),
+            0);
+
+        // nothing at or past out[out_len] may have been touched
+        for (size_t i = capacity; i < sizeof(block); i++) {
+            assert_int_equal(block[i], ENCODE_SENTINEL_BYTE);
+        }
+    }
+}
+
+// Same capacities, destination alone in a heap block of exactly that size, so
+// the byte past the end belongs to AddressSanitizer's redzone rather than to
+// the sentinel above.
+static void test_bip39_encode_separator_stays_in_bounds_heap(void** state) {
+    (void)state;
+
+    for (size_t k = 0;
+         k < sizeof(encode_word_boundaries) / sizeof(encode_word_boundaries[0]);
+         k++) {
+        const size_t capacity = encode_word_boundaries[k];
+        unsigned char* out = malloc(capacity);
+
+        assert_non_null(out);
+        assert_int_equal(
+            bolos_ux_bip39_mnemonic_encode(
+                encode_entropy, sizeof(encode_entropy), out, capacity),
+            0);
+        free(out);
+    }
+}
+
+// The bound must not be tightened past what the mnemonic actually needs: a
+// capacity of exactly its length still has to encode, and return that length.
+// One byte less is the last failing capacity, and it must fail cleanly rather
+// than return a truncated phrase.
+static void test_bip39_encode_exact_capacity_succeeds(void** state) {
+    (void)state;
+    unsigned char
+        block[ENCODE_ENTROPY_MNEMONIC_LENGTH + ENCODE_SENTINEL_LENGTH];
+
+    memset(block, ENCODE_SENTINEL_BYTE, sizeof(block));
+
+    assert_int_equal(
+        bolos_ux_bip39_mnemonic_encode(encode_entropy, sizeof(encode_entropy),
+                                       block, ENCODE_ENTROPY_MNEMONIC_LENGTH),
+        ENCODE_ENTROPY_MNEMONIC_LENGTH);
+    assert_memory_equal(block, encode_entropy_mnemonic,
+                        ENCODE_ENTROPY_MNEMONIC_LENGTH);
+    for (size_t i = ENCODE_ENTROPY_MNEMONIC_LENGTH; i < sizeof(block); i++) {
+        assert_int_equal(block[i], ENCODE_SENTINEL_BYTE);
+    }
+
+    memset(block, ENCODE_SENTINEL_BYTE, sizeof(block));
+
+    assert_int_equal(bolos_ux_bip39_mnemonic_encode(
+                         encode_entropy, sizeof(encode_entropy), block,
+                         ENCODE_ENTROPY_MNEMONIC_LENGTH - 1),
+                     0);
+    for (size_t i = ENCODE_ENTROPY_MNEMONIC_LENGTH - 1; i < sizeof(block);
+         i++) {
+        assert_int_equal(block[i], ENCODE_SENTINEL_BYTE);
+    }
+}
+
 // bolos_ux_bip39_mnemonic_encode() rejects seed_len before touching `out` if
 // it fails any of three conditions: not a multiple of 4, below 16, or above
 // 32. Only the valid lengths (16/24/32) are exercised elsewhere (the
@@ -375,6 +520,9 @@ int main(void) {
         cmocka_unit_test(test_bip39_decode_checksum_mask_covers_fourth_bit),
         cmocka_unit_test(test_bip39_decode_wrong_length),
         cmocka_unit_test(test_bip39_encode_insufficient_buffer),
+        cmocka_unit_test(test_bip39_encode_separator_stays_in_bounds),
+        cmocka_unit_test(test_bip39_encode_separator_stays_in_bounds_heap),
+        cmocka_unit_test(test_bip39_encode_exact_capacity_succeeds),
         cmocka_unit_test(test_bip39_encode_rejects_invalid_seed_len),
         cmocka_unit_test(test_bip39_roundtrip_12_words),
         cmocka_unit_test(test_bip39_roundtrip_18_words),


### PR DESCRIPTION
This is the follow-up offered in #97, which described this defect in its body
and left it out on purpose as a production change outside the scope of a test
batch.

## The defect

`bolos_ux_bip39_mnemonic_encode()` bounds the word it is about to copy, but
not the separator that follows it:

```c
if ((offset + word_len) > out_len) {  // equality accepted
    ...
}
memcpy(out + offset, ..., word_len);
offset += word_len;                   // offset == out_len now possible
if (offset > out_len) {               // so this can never fire
    ...
}
if (i < (seed_len * 3 / 4) - 1) {
    out[offset++] = ' ';              // writes out[out_len]
}
```

The first guard accepts `offset + word_len == out_len`. When a capacity lands
exactly on a word boundary and words still remain, `offset` is exactly
`out_len` after the copy, the second guard cannot fire -- it compares the same
two values the first guard just allowed to be equal -- and the separator goes
to `out[out_len]`, one byte past the end.

With 16 bytes of entropy and `out_len = 7` it happens on the first iteration:
the first word is `abandon`, exactly 7 characters.

```
AddressSanitizer: heap-buffer-overflow
WRITE of size 1 at 0x502000000037
    #0 bolos_ux_bip39_mnemonic_encode src/common/bip39/seed_bip39.c:183
0x502000000037 is located 0 bytes after 7-byte region
```

## Not reachable from the application

Both callers pass a fixed capacity: `BIP39_MNEMONIC_MAX_LENGTH` =
`24 * (8 + 1)` = 216 in `src/nbgl/bip39_mnemonic.c`, and the caller-owned
`words_buffer` handed to `src/common/sskr/seed_sskr.c`, which is 257
(`WORDS_BUFFER_MAX_SIZE_B`) on the BAGL side. The longest possible mnemonic is
24 words of 8 characters plus 23 separators = 215, so `offset` never reaches
`out_len` on either path. This is robustness, not an exploitable flaw.

The argument is the same as for the earlier fixes in this series:
`bolos_ux_bip39_mnemonic_encode()` is declared in
`src/common/bip39/common_bip39.h` and takes `out_len` from whoever calls it,
so its safety should not rest on both current callers being generous.

## The fix

The word and the separator it owes are claimed together. The condition is
computed once and drives both the bound and the write, so the two cannot drift
apart again -- which is how they drifted here.

This rejects nothing that used to succeed: a successful encode wrote every
word and every separator inside the buffer, so the wider bound already held at
every iteration.

## What it returns in the limit case

`0`, as it already did -- there is no path here that returns a non-zero
`offset` for a truncated mnemonic. A separator is only written when a word
follows it, and after the overrun `offset` is `out_len + 1`, so that next word
never fit and the function already returned 0. The change removes the
out-of-bounds write and leaves every return value identical.

The second guard (`offset > out_len`) is left alone. It could not fire before
this change and still cannot; whether to remove it is a separate question from
fixing the overrun.

## Equivalence with the previous behaviour, checked differentially

Rather than argue it, both versions of the function were built into the same
harness and run over 48160 calls -- 32 seeds x seed_len 16/20/24/28/32 x
out_len 0..300 -- recording the return value, every byte inside the declared
capacity, and the byte just past it.

- Return values: identical on all 48160 cases.
- The 29523 calls that succeed: identical byte for byte, including the byte
  past the end.
- The byte past the end was modified in 2720 cases by the old version, always
  with `0x20`, and in 0 cases by the new one.
- The 2720 differing cases are exactly those, all with a return value of 0. On
  them the old version had already copied a partial word into the caller's
  buffer before running off the end; the new one returns before writing that
  word. Strictly fewer bytes written, never more, and no caller reads the
  buffer when the return is 0: `src/common/sskr/seed_sskr.c` passes the 0 back
  as `*words_buffer_length` and `common_seed.c` treats it as a failed
  reconstruction, and `src/nbgl/bip39_mnemonic.c` guards every use with
  `mnemonic.length > 0`.

Both capacities the application actually passes, 216 and 257, are byte-for-byte
identical between the two versions across the whole sample. That also bounds
reachability exactly: a separator is only written after word `i < n - 1`, where
`offset` is `sum(len w_0..w_i) + i`, maximised at n = 24, i = 22 as
`23 * 8 + 22 = 206`. No capacity above 206 can trip the overrun, and the
smallest one any caller passes is 216.

## Tests

The overrun is invisible to the return value, per the paragraph above, so
asserting the return value would have passed either way -- the same shape of
empty test the encode buffer already had before #97 split it. What is observed
is the write.

Entropy `00 01 .. 0f`, the vector already used by
`test_bip39_encode_insufficient_buffer`, encodes to the 74-character

```
abandon amount liar amount expire adjust cage candy arch gather drum buyer
```

with word lengths 7 6 4 6 6 6 4 5 4 6 4 5. Counting the separators, `offset`
sits at 7, 14, 19, 26, 33, 40, 45, 51, 56, 63 and 68 right after copying a
word that still has successors: every capacity that trips the bound. 74 is not
among them -- it is the offset after the last word, and no separator follows
it. The boundaries are read off the mnemonic the entropy actually produces
rather than guessed.

Each capacity is checked twice: once into a buffer followed by sentinel bytes,
asserted intact from `out[out_len]` on, which holds with or without a
sanitizer; and once into a heap block sized exactly to the capacity, which
AddressSanitizer redzones. `test_bip39` has been built with ASan since #97.

A third test keeps the bound from being tightened too far: a capacity of
exactly 74 must still encode and return 74, byte for byte, and 73 -- the last
failing capacity -- must fail cleanly rather than return a truncated phrase.

No new target; these join the existing `test_bip39`, so `ctest -N` still lists
43. 43/43 green.

## Verified by mutation

Both directions, replayed on the committed tree.

- Fix reverted: `test_bip39` the only red target of 43. The sentinel test
  fails with `32 != 165` -- a space where `0xa5` should be -- and the heap
  test raises the ASan trace quoted above.
- Bound over-tightened instead (a separator reserved after the last word too):
  `test_bip39_encode_exact_capacity_succeeds` and the three roundtrip tests go
  red, along with `test_roundtrip` and `test_bip85_bip39_entropy`. Both halves
  discriminate separately.

Restored and re-verified clean after each.

## Other checks

Line coverage of `seed_bip39.c`: 158/165 to 159/166 -- one more instrumented
line, covered; the uncovered count is unchanged at 7.

All six devices of `ledger_app.toml` compile and link, `nanos` included, with
no new warnings. `bolos_ux_bip39_mnemonic_encode()` grows by 28 bytes on
`nanos` and 48 on `nanox`. In the linked image five of the six are unchanged
byte for byte, the extra code fitting inside existing section padding
(`nanos` stays at 32008 text / 3708 bss); `nanox` crosses an alignment
boundary and its `.text` goes 45880 to 46136.

`clang-format --dry-run -Werror` clean on both files.

The Speculos scripts are not affected: no secret-erasure path is touched.
