### PR TITLE
tests: replay the Shamir suite against the TARGET_NANOS GF(2^8) variant

### DIFF
--- a/tests/unit/CMakeLists.txt
+++ b/tests/unit/CMakeLists.txt
@@ -372,6 +372,82 @@ add_executable(test_sskr_combine_invariants ./tests/sskr_combine_invariants.c ..
 target_include_directories(test_sskr_combine_invariants PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/../../src/common)
 target_link_libraries(test_sskr_combine_invariants PUBLIC cmocka gcov sskr sss testutils)
 
+# ---------------------------------------------------------------------------
+# The same Shamir tests, replayed against the TARGET_NANOS build of the GF(2^8)
+# arithmetic.
+#
+# interpolate.c carries two different implementations of the field
+# multiplication every share is built from. Under
+# `#if defined(TARGET_NANOS) && !defined API_LEVEL` it defines its own
+# cx_bn_gf2_n_mul() -- a shift-and-XOR loop written by hand on top of
+# elementary BN primitives; everywhere else the SDK's cx_bn_gf2_n_mul() is
+# called instead. Only the second one was ever built here, so the one that
+# ships on Nano S ran nowhere but on the device: had the two disagreed on a
+# single input, shares produced on a Nano S would not have recombined
+# anywhere else, silently.
+#
+# Nothing in src/ changes for this. The nine BN primitives the local
+# implementation uses (cx_bn_alloc, cx_bn_cnt_bits, cx_bn_copy, cx_bn_destroy,
+# cx_bn_nbytes, cx_bn_set_u32, cx_bn_shl, cx_bn_tst_bit, cx_bn_xor) are all
+# already provided by lib/bolos/cx_bn.c, and API_LEVEL is defined nowhere in
+# this repository, so defining TARGET_NANOS is all it takes to select the
+# variant on host. The definition compiled into each target below takes
+# precedence over the one libtestutils.so exports, which is what puts the
+# local implementation on the call path.
+#
+# Two consequences drive the shape of these targets:
+#
+#  - the sources have to be compiled into the target rather than linked from
+#    the shared `sss`/`sskr` libraries, which are built without the flag;
+#  - SSS_MAX_SHARE_COUNT is 10 under TARGET_NANOS and 16 otherwise
+#    (sss-constants.h), so the flag has to reach *every* translation unit of a
+#    target, test file included. A target mixing the two would size arrays
+#    differently on the two sides of a call -- a defect built by the test
+#    setup rather than found by it. target_compile_definitions() below applies
+#    to all of a target's sources, which is exactly what is wanted here.
+#
+# Only tests that actually interpolate are replayed; the four below cover
+# splitting and recovery, 128- and 256-bit secrets, thresholds of 2 and 3, and
+# use at most 5 shares, so none of them needs more than the 10 shares this
+# configuration allows. Tests that only exercise input guards would run the
+# same code either way and are left out.
+set(SSS_NANOS_SOURCES ../../src/common/sskr/sss/sss.c ../../src/common/sskr/sss/interpolate.c)
+set(SSKR_NANOS_SOURCES ../../src/common/sskr/sskr.c ${SSS_NANOS_SOURCES})
+set(SSS_NANOS_INCLUDES ${CMAKE_CURRENT_SOURCE_DIR}/../../src/common/sskr/sss)
+set(SSKR_NANOS_INCLUDES ${SSS_NANOS_INCLUDES} ${CMAKE_CURRENT_SOURCE_DIR}/../../src/common/sskr)
+
+# Blockchain Commons vectors at raw Shamir math level, the ideal oracle here:
+# they compare against values published outside this repository, so they hold
+# the variant against the specification rather than against the other
+# implementation.
+add_executable(test_sss_nanos tests/sss.c ${SSS_NANOS_SOURCES})
+target_include_directories(test_sss_nanos PUBLIC ${SSS_NANOS_INCLUDES})
+target_compile_definitions(test_sss_nanos PRIVATE TARGET_NANOS)
+target_link_libraries(test_sss_nanos PUBLIC cmocka gcov testutils)
+
+# Unlike its counterpart above, this one needs no -Wl,--no-as-needed: sskr.c
+# and sss.c are compiled into the target, so their references to cx_bn_*/
+# cx_hmac_sha256 are the executable's own undefined symbols and libtestutils.so
+# is kept for them.
+add_executable(test_sskr_interop_bc128_nanos tests/sskr_interop_bc128.c ${SSKR_NANOS_SOURCES})
+target_include_directories(test_sskr_interop_bc128_nanos PUBLIC ${SSKR_NANOS_INCLUDES})
+target_compile_definitions(test_sskr_interop_bc128_nanos PRIVATE TARGET_NANOS)
+target_link_libraries(test_sskr_interop_bc128_nanos PUBLIC cmocka gcov testutils)
+
+# Generation and recombination of the 256-bit vector, 2-of-3.
+add_executable(test_sskr_nanos tests/sskr.c ${SSKR_NANOS_SOURCES})
+target_include_directories(test_sskr_nanos PUBLIC ${SSKR_NANOS_INCLUDES})
+target_compile_definitions(test_sskr_nanos PRIVATE TARGET_NANOS)
+target_link_libraries(test_sskr_nanos PUBLIC cmocka gcov testutils)
+
+# 3-of-5: the only case that makes the interpolation loop run over more than
+# two shares, and the only one that exercises a threshold above 2.
+add_executable(test_sskr_threshold_three_roundtrip_nanos tests/sskr_threshold_three_roundtrip.c ${SSKR_NANOS_SOURCES})
+target_include_directories(test_sskr_threshold_three_roundtrip_nanos PUBLIC ${SSKR_NANOS_INCLUDES})
+target_compile_definitions(test_sskr_threshold_three_roundtrip_nanos PRIVATE TARGET_NANOS)
+target_link_libraries(test_sskr_threshold_three_roundtrip_nanos PUBLIC cmocka gcov testutils)
+# ---------------------------------------------------------------------------
+
 # Built with AddressSanitizer. Both buffer guards this file covers --
 # the "word too long for current_word[]" bail-out in decode() and the
 # "output buffer too small" bail-out in encode() -- are guards whose whole


### PR DESCRIPTION
`src/common/sskr/sss/interpolate.c` carries **two different implementations** of the GF(2^8) multiplication that every SSKR share is built from. Under `#if defined(TARGET_NANOS) && !defined API_LEVEL` it defines its own `cx_bn_gf2_n_mul()` -- a shift-and-XOR loop written by hand on top of elementary BN primitives. Outside that guard, the SDK's `cx_bn_gf2_n_mul()` is called instead.

The unit suite only ever built the second one. This is not an untested guard: it is the arithmetic core of the secret sharing, on the nominal path, held by nothing. Had the two implementations disagreed on a single input, shares produced on one device would not have recombined anywhere else -- silently, and with no recourse for the user.

## The variant really does ship

Verified at object level rather than assumed, by cross-compiling the app for the three Nano targets and looking at `cx_bn_gf2_n_mul` in `interpolate.o`:

| build | symbol in `interpolate.o` |
|---|---|
| `nanos` | **`T` -- defined locally, 0x13a = 314 bytes** |
| `nanos2` | `U` -- undefined, resolved from the SDK |
| `nanox` | `U` -- undefined, resolved from the SDK |

The reason is on the SDK side: `nanos-secure-sdk/Makefile.defines` does not define `API_LEVEL`, while `nanosplus-secure-sdk/Makefile.defines` sets `API_LEVEL := 26`. So on `nanos`, which `ledger_app.toml` still lists, the hand-written implementation is what runs.

## The fix is build configuration, not code

**No file under `src/` is modified.** The nine BN primitives the local implementation uses (`cx_bn_alloc`, `cx_bn_cnt_bits`, `cx_bn_copy`, `cx_bn_destroy`, `cx_bn_nbytes`, `cx_bn_set_u32`, `cx_bn_shl`, `cx_bn_tst_bit`, `cx_bn_xor`) are all already provided by `tests/unit/lib/bolos/cx_bn.c`, and `API_LEVEL` is defined nowhere in this repository -- so defining `TARGET_NANOS` on a test target is the whole change. No cross-compilation is needed to review this PR.

Four targets are added, each compiling `sss.c`, `interpolate.c` and (where the test needs it) `sskr.c` with `-DTARGET_NANOS`, and replaying against that variant the tests that actually interpolate:

| target | what it adds |
|---|---|
| `test_sss_nanos` | Blockchain Commons vectors at raw Shamir math level; split 2-of-3 and recovery |
| `test_sskr_interop_bc128_nanos` | the 128-bit Blockchain Commons vector |
| `test_sskr_nanos` | generation and recombination of the 256-bit vector, 2-of-3 |
| `test_sskr_threshold_three_roundtrip_nanos` | 3-of-5, the only case interpolating over more than two shares |

Tests that only exercise input guards are left out: they would run the same code either way and would only inflate the matrix.

The flag is set with `target_compile_definitions()`, so it reaches **every** translation unit of each target, test file included. That matters beyond `interpolate.c`: `SSS_MAX_SHARE_COUNT` is 10 under `TARGET_NANOS` and 16 otherwise (`sss-constants.h`), and a target mixing the two would size arrays differently on the two sides of a call -- a defect built by the test setup rather than found by it. Checked with the preprocessor rather than assumed: the new targets see 10, exactly like the real `nanos` device build; the pre-existing targets still see 16, and their generated `C_DEFINES` carry no `-DTARGET_NANOS`.

**No test is excluded for that reason.** All four use at most 5 shares, so none of them needs more than the 10 shares this configuration allows.

## Proof that the variant is really exercised

Without this, the PR would demonstrate nothing -- a target can define a flag and still run the other code. Both available angles were taken.

**By coverage.** `interpolate.c` in lines:

| | instrumented lines | covered |
|---|---|---|
| before | 64 (`DA:` range 128-250) | 64 (100%) |
| after | 98 (`DA:` range 60-250) | 94 (95.9%) |
| of which the `#if defined(TARGET_NANOS)` block, lines 36-126 | **0 -> 34** | **0 -> 30** |

Before, that block was *absent from the lcov report altogether* -- never compiled, therefore never reported, which is exactly why the gap was easy to miss while the file showed 100%. The four lines that remain uncovered are the two `CX_INVALID_PARAMETER` bail-outs (lines 68-69 and 81-82), which `interpolate()` cannot trigger: it always passes distinct BN indices and in-field operands.

**By mutation, twice.** In the local `cx_bn_gf2_n_mul()` -- there is no literal `^` in it, the function goes through `cx_bn_xor`:

1. modular reduction skipped: `nbits_a++ == degree` becomes `> degree`
2. accumulation dropped: `cx_bn_xor(bn_r, bn_temp, bn_copy)` becomes `cx_bn_copy(bn_r, bn_temp)`

Each turns **exactly the four new targets red and leaves all 43 pre-existing ones green**. That second half is the part that matters: it proves the new targets exercise this variant and not the other one. Both mutations reverted, `md5sum` of `interpolate.c` back to its original value.

## Result

**The two implementations produce the same values on every known vector**, including the Blockchain Commons ones, which are published outside this repository and therefore hold the variant against the specification rather than against the other implementation. No divergence was found.

`ctest -N` goes from 43 targets to 47, 47/47 green. The only compiler warnings are pre-existing `no previous prototype for 'sss_create_digest'` instances (3 -> 7, one per target compiling `sss.c` directly); no new warning class. No `.c`/`.h` file is touched, so there is nothing for `clang-format` to check.

BIP-85 is unaffected: it has no path to `sss`/`interpolate` at all, and the only callers of `sss_split_secret()`/`sss_recover_secret()` anywhere in `src/` are in `sskr.c`.

## What this does not cover

The test validates the **algorithm** of the local implementation against published vectors, assuming correct BN primitives. It does not validate the primitives themselves: on device `cx_bn_shl()`, `cx_bn_xor()` and the rest are BOLOS syscalls, while on host they are the OpenSSL-backed emulations in `tests/unit/lib/bolos/cx_bn.c`. A defect in those syscalls would stay invisible here -- but that is SDK code, not this application's.
