### PR TITLE
fix: return sskr_generate_shards()'s error code instead of 0

### DIFF
--- a/src/common/sskr/sskr.c
+++ b/src/common/sskr/sskr.c
@@ -348,6 +348,13 @@ int16_t sskr_generate_shards(uint8_t group_threshold,
                              uint8_t* output, uint16_t buffer_size,
                              unsigned char* (*random_generator)(uint8_t*,
                                                                 size_t)) {
+    // shard_len is an output parameter, and the function has several early
+    // rejections that never reach the assignment at the bottom. Define it
+    // once, here, so that no failure path can hand back the value the caller
+    // happened to leave in it; the success path overwrites it with the real
+    // shard length.
+    *shard_len = 0;
+
     int16_t error = sskr_check_secret_length(master_secret_len);
     if (error) {
         return error;
@@ -398,7 +405,12 @@ int16_t sskr_generate_shards(uint8_t group_threshold,
     memzero(shards, sizeof(shards));
     if (error) {
         memzero(output, buffer_size);
-        return 0;
+        // sskr.h promises a negative error code on failure. Returning 0 here
+        // reported every late failure as "no shards generated", made it
+        // indistinguishable from every other one, and matched no documented
+        // code; propagate the one that says what actually went wrong, the
+        // way the early rejections above already do.
+        return error;
     }
 
     *shard_len = byte_count;

--- a/src/common/sskr/sskr.h
+++ b/src/common/sskr/sskr.h
@@ -34,7 +34,7 @@ int16_t sskr_count_shards(uint8_t group_threshold,
  *                                  and even).
  * @param[in]  master_secret_length Length of the `master_secret` array in bytes.
  * @param[out] shard_len            Pointer to a variable that will be filled with the length of
- *                                  each shard.
+ *                                  each shard, or with 0 on failure.
  * @param[out] output               Pointer to a buffer where the generated shards will be stored.
  * @param[in]  buffer_size          Maximum size of the `output` buffer in bytes.
  * @param[in]  random_generator     Pointer to a function that generates random data (same as in SSS

--- a/tests/unit/CMakeLists.txt
+++ b/tests/unit/CMakeLists.txt
@@ -296,6 +296,9 @@ target_link_libraries(test_sskr_count_shards_invariants PUBLIC cmocka gcov sskr 
 add_executable(test_sskr_generate_erase_on_split_failure tests/sskr_generate_erase_on_split_failure.c)
 target_link_libraries(test_sskr_generate_erase_on_split_failure PUBLIC cmocka gcov sskr sss testutils)
 
+add_executable(test_sskr_generate_error_contract tests/sskr_generate_error_contract.c)
+target_link_libraries(test_sskr_generate_error_contract PUBLIC cmocka gcov sskr sss testutils)
+
 # Built with AddressSanitizer: without the bound under test, the overflow of
 # group_shares happens inside sss_split_secret()/interpolate() through plain
 # loads and stores, which ASan does instrument -- so it is the assertion for

--- a/tests/unit/tests/sskr_combine_erase_on_failure.c
+++ b/tests/unit/tests/sskr_combine_erase_on_failure.c
@@ -3,7 +3,7 @@
  * sskr_combine_shards_internal() (src/common/sskr/sskr.c).
  *
  * The generation side already gets this right: sskr_generate_shards() does
- * `memzero(output, buffer_size); return 0;` before returning on any error.
+ * `memzero(output, buffer_size);` before returning on any error.
  * The combination side's internal function cleans up its own working
  * buffers (group_shares/gx/gy/groups) on every failure, but never the
  * caller's `buffer` -- the very thing a failed combine is supposed to leave

--- a/tests/unit/tests/sskr_generate_erase_on_split_failure.c
+++ b/tests/unit/tests/sskr_generate_erase_on_split_failure.c
@@ -9,7 +9,13 @@
  *         return split_error;
  *     }
  *     ...
- *     if (error) { memzero(output, buffer_size); return 0; }
+ *     if (error) { memzero(output, buffer_size); *shard_len = 0;
+ *                  return error; }
+ *
+ * Both tests below also pin the code that comes back out, which is the
+ * point of reaching this cleanup through two genuinely different failures:
+ * the two triggers are told apart by SSS_ERROR_INTERPOLATION_FAILURE versus
+ * SSS_ERROR_INVALID_THRESHOLD.
  *
  * test_sskr_generate_split_error.c already covers this for a
  * SSS_ERROR_TOO_MANY_SHARES failure (member-level split, an oversized
@@ -62,7 +68,7 @@ static void test_generate_erases_output_on_member_level_interpolation_failure(
     const uint8_t master_secret[SECRET_LEN] = {0};
     const sskr_group_descriptor_t groups[] = {{.threshold = 2, .count = 2}};
     uint8_t share_buffer[BUFFER_LEN];
-    uint8_t share_len;
+    uint8_t share_len = 0xFF;
 
     memset(share_buffer, 0xFF, sizeof(share_buffer));
 
@@ -72,7 +78,8 @@ static void test_generate_erases_output_on_member_level_interpolation_failure(
                                           SECRET_LEN, &share_len, share_buffer,
                                           sizeof(share_buffer), cx_rng);
 
-    assert_int_equal(result, 0);
+    assert_int_equal(result, SSS_ERROR_INTERPOLATION_FAILURE);
+    assert_int_equal(share_len, 0);
 
     uint8_t expected[BUFFER_LEN];
     memset(expected, 0x00, sizeof(expected));
@@ -86,7 +93,7 @@ static void test_generate_erases_output_on_group_level_split_failure(
     const uint8_t master_secret[SECRET_LEN] = {0};
     const sskr_group_descriptor_t groups[] = {{.threshold = 1, .count = 1}};
     uint8_t share_buffer[BUFFER_LEN];
-    uint8_t share_len;
+    uint8_t share_len = 0xFF;
 
     memset(share_buffer, 0xFF, sizeof(share_buffer));
 
@@ -94,7 +101,8 @@ static void test_generate_erases_output_on_group_level_split_failure(
                                           SECRET_LEN, &share_len, share_buffer,
                                           sizeof(share_buffer), cx_rng);
 
-    assert_int_equal(result, 0);
+    assert_int_equal(result, SSS_ERROR_INVALID_THRESHOLD);
+    assert_int_equal(share_len, 0);
 
     uint8_t expected[BUFFER_LEN];
     memset(expected, 0x00, sizeof(expected));

--- a/tests/unit/tests/sskr_generate_error_contract.c
+++ b/tests/unit/tests/sskr_generate_error_contract.c
@@ -1,0 +1,275 @@
+/*
+ * Coverage for what sskr.h says sskr_generate_shards() returns:
+ *
+ *     @return Number of shards generated on success, or a negative error
+ *             code on failure.
+ *
+ * The other test files reach this function to cover a particular guard, a
+ * particular buffer erasure or a particular round trip, and each asserts the
+ * one code its own case produces. Nothing held the shape of the contract
+ * itself: that a caller can tell *why* a generation failed, and that both
+ * outputs -- the return value and *shard_len -- are defined on every path
+ * out.
+ *
+ * That is what this file pins, in three parts:
+ *
+ *   - one representative per error family, each with the exact code it must
+ *     produce, gathered in a single table so the families are read side by
+ *     side rather than one per file;
+ *   - the codes are all distinct, checked pairwise rather than asserted in
+ *     prose -- a table whose entries silently collapsed onto one value would
+ *     otherwise still pass every individual assertion above;
+ *   - *shard_len is 0 after every one of them, and the real shard length
+ *     after a successful call.
+ *
+ * The two families at the bottom of the table are the ones that used to be
+ * unreachable through the return value: they surface from sss_split_secret()
+ * inside sskr_generate_shards_internal(), and were collapsed into a plain 0
+ * on the way out. SSS_* and SSKR_* codes come from two disjoint ranges
+ * (-101.. and -1..), so propagating one through an int16_t neither truncates
+ * it nor makes it collide with the other family's meanings.
+ */
+
+#include <cmocka.h>
+#include <cx.h>
+#include <lcx_rng.h>
+#include <setjmp.h>
+#include <stdarg.h>
+#include <stdbool.h>
+#include <stddef.h>
+#include <stdint.h>
+#include <string.h>
+
+#include "sskr-constants.h"
+#include "sskr.h"
+#include "sss-constants.h"
+#include "testutils.h"
+
+#define SECRET_LEN (SSKR_MIN_STRENGTH_BYTES)
+#define SHARD_LEN (SSKR_METADATA_LENGTH_BYTES + SECRET_LEN)
+
+/* One shard more than sss_split_secret() can produce, so that the
+ * too-many-shares case clears the insufficient-space check and fails in the
+ * split instead. Sized symbolically: SSS_MAX_SHARE_COUNT is smaller on
+ * TARGET_NANOS. */
+#define OVERSIZED_COUNT (SSS_MAX_SHARE_COUNT + 1)
+#define BUFFER_LEN (SHARD_LEN * OVERSIZED_COUNT)
+
+/* A value no successful call could leave behind, so that "shard_len is 0"
+ * means it was written rather than merely never touched. */
+#define SHARD_LEN_SENTINEL (0xFF)
+
+/* One descriptor is enough for every row: the only one that passes a
+ * groups_len above 1 is the group-threshold rejection, and sskr_count_shards()
+ * returns on that before it reads any element. */
+typedef struct {
+    const char* name;
+    uint8_t group_threshold;
+    uint8_t groups_len;
+    sskr_group_descriptor_t group;
+    uint16_t master_secret_len;
+    uint16_t buffer_size;
+    /* Locks the BN context before the call, which makes interpolate() fail
+     * on its own cx_bn_lock(). */
+    bool lock_bn;
+    int16_t expected;
+} error_case_t;
+
+static const error_case_t error_cases[] = {
+    {"secret shorter than the minimum",
+     1,
+     1,
+     {.threshold = 2, .count = 3},
+     SSKR_MIN_STRENGTH_BYTES - 2,
+     BUFFER_LEN,
+     false,
+     SSKR_ERROR_SECRET_TOO_SHORT},
+    {"secret longer than the maximum",
+     1,
+     1,
+     {.threshold = 2, .count = 3},
+     SSKR_MAX_STRENGTH_BYTES + 2,
+     BUFFER_LEN,
+     false,
+     SSKR_ERROR_SECRET_TOO_LONG},
+    {"secret of odd length",
+     1,
+     1,
+     {.threshold = 2, .count = 3},
+     SSKR_MIN_STRENGTH_BYTES + 1,
+     BUFFER_LEN,
+     false,
+     SSKR_ERROR_SECRET_LENGTH_NOT_EVEN},
+    {"no group at all",
+     1,
+     0,
+     {.threshold = 2, .count = 3},
+     SECRET_LEN,
+     BUFFER_LEN,
+     false,
+     SSKR_ERROR_INVALID_GROUP_LENGTH},
+    {"group threshold above the group count",
+     SSKR_MAX_GROUP_COUNT + 1,
+     SSKR_MAX_GROUP_COUNT,
+     {.threshold = 2, .count = 3},
+     SECRET_LEN,
+     BUFFER_LEN,
+     false,
+     SSKR_ERROR_INVALID_GROUP_THRESHOLD},
+    {"empty group",
+     1,
+     1,
+     {.threshold = 1, .count = 0},
+     SECRET_LEN,
+     BUFFER_LEN,
+     false,
+     SSKR_ERROR_INVALID_GROUP_COUNT},
+    {"member threshold above the member count",
+     1,
+     1,
+     {.threshold = 3, .count = 2},
+     SECRET_LEN,
+     BUFFER_LEN,
+     false,
+     SSKR_ERROR_INVALID_MEMBER_THRESHOLD},
+    {"1-of-n group",
+     1,
+     1,
+     {.threshold = 1, .count = 2},
+     SECRET_LEN,
+     BUFFER_LEN,
+     false,
+     SSKR_ERROR_INVALID_SINGLETON_MEMBER},
+    {"output buffer one byte short",
+     1,
+     1,
+     {.threshold = 2, .count = 3},
+     SECRET_LEN,
+     (SHARD_LEN * 3) - 1,
+     false,
+     SSKR_ERROR_INSUFFICIENT_SPACE},
+    {"more members than the split can produce",
+     1,
+     1,
+     {.threshold = 2, .count = OVERSIZED_COUNT},
+     SECRET_LEN,
+     BUFFER_LEN,
+     false,
+     SSS_ERROR_TOO_MANY_SHARES},
+    {"group threshold of zero",
+     0,
+     1,
+     {.threshold = 1, .count = 1},
+     SECRET_LEN,
+     BUFFER_LEN,
+     false,
+     SSS_ERROR_INVALID_THRESHOLD},
+    {"member split that cannot interpolate",
+     1,
+     1,
+     {.threshold = 2, .count = 2},
+     SECRET_LEN,
+     BUFFER_LEN,
+     true,
+     SSS_ERROR_INTERPOLATION_FAILURE},
+};
+
+#define ERROR_CASE_COUNT (sizeof(error_cases) / sizeof(error_cases[0]))
+
+/* Runs one row of the table and returns what came back, so the two tests
+ * below can assert different things about the same call. */
+static int16_t run_error_case(const error_case_t* c, uint8_t* shard_len_out) {
+    uint8_t master_secret[SSKR_MAX_STRENGTH_BYTES + 2];
+    uint8_t output[BUFFER_LEN];
+    uint8_t shard_len = SHARD_LEN_SENTINEL;
+
+    memset(master_secret, 0x5A, sizeof(master_secret));
+    memset(output, 0xFF, sizeof(output));
+
+    if (c->lock_bn) {
+        assert_int_equal(cx_bn_lock(1, 0), CX_OK);
+    }
+
+    int16_t result = sskr_generate_shards(
+        c->group_threshold, &c->group, c->groups_len, master_secret,
+        c->master_secret_len, &shard_len, output, c->buffer_size, cx_rng);
+
+    if (c->lock_bn) {
+        cx_bn_unlock();
+    }
+
+    *shard_len_out = shard_len;
+    return result;
+}
+
+static void test_every_family_returns_its_own_error_code(void** state) {
+    (void)state;
+
+    for (size_t i = 0; i < ERROR_CASE_COUNT; ++i) {
+        uint8_t shard_len = SHARD_LEN_SENTINEL;
+        int16_t result = run_error_case(&error_cases[i], &shard_len);
+
+        /* Names the failing row, so a red run says which family broke. */
+        if (result != error_cases[i].expected) {
+            fail_msg("%s: expected %d, got %d", error_cases[i].name,
+                     error_cases[i].expected, result);
+        }
+        assert_true(result < 0);
+    }
+}
+
+static void test_error_codes_are_distinct(void** state) {
+    (void)state;
+
+    for (size_t i = 0; i < ERROR_CASE_COUNT; ++i) {
+        for (size_t j = i + 1; j < ERROR_CASE_COUNT; ++j) {
+            if (error_cases[i].expected == error_cases[j].expected) {
+                fail_msg("%s and %s both expect %d", error_cases[i].name,
+                         error_cases[j].name, error_cases[i].expected);
+            }
+        }
+    }
+}
+
+static void test_shard_len_is_zeroed_on_every_error(void** state) {
+    (void)state;
+
+    for (size_t i = 0; i < ERROR_CASE_COUNT; ++i) {
+        uint8_t shard_len = SHARD_LEN_SENTINEL;
+        (void)run_error_case(&error_cases[i], &shard_len);
+
+        if (shard_len != 0) {
+            fail_msg("%s: shard_len left at %u", error_cases[i].name,
+                     shard_len);
+        }
+    }
+}
+
+static void test_success_returns_the_shard_count_and_length(void** state) {
+    (void)state;
+
+    const sskr_group_descriptor_t groups[] = {{.threshold = 2, .count = 3}};
+    uint8_t master_secret[SECRET_LEN];
+    uint8_t output[SHARD_LEN * 3];
+    uint8_t shard_len = SHARD_LEN_SENTINEL;
+
+    memset(master_secret, 0x5A, sizeof(master_secret));
+    memset(output, 0x00, sizeof(output));
+
+    int16_t result =
+        sskr_generate_shards(1, groups, 1, master_secret, sizeof(master_secret),
+                             &shard_len, output, sizeof(output), cx_rng);
+
+    assert_int_equal(result, 3);
+    assert_int_equal(shard_len, SHARD_LEN);
+}
+
+int main(void) {
+    const struct CMUnitTest tests[] = {
+        cmocka_unit_test(test_every_family_returns_its_own_error_code),
+        cmocka_unit_test(test_error_codes_are_distinct),
+        cmocka_unit_test(test_shard_len_is_zeroed_on_every_error),
+        cmocka_unit_test(test_success_returns_the_shard_count_and_length),
+    };
+    return cmocka_run_group_tests(tests, NULL, NULL);
+}

--- a/tests/unit/tests/sskr_generate_split_error.c
+++ b/tests/unit/tests/sskr_generate_split_error.c
@@ -13,13 +13,12 @@
  * (verified: SIGSEGV, cmocka reports it as a failed test).
  *
  * sskr_generate_shards() -- the public entry point this test calls, since
- * sskr_generate_shards_internal() is static -- collapses any error surfacing
- * from the internal call into a plain 0 rather than propagating the SSS_*
- * code (`if (error) { memzero(output, buffer_size); return 0; }`). That
- * collapse is pre-existing and out of scope here (nothing about this fix
- * changes it, only which failures reach it); this test asserts the 0 that
- * contract already promises, and that output was actually cleared rather
- * than left holding shards built from whatever was on the stack.
+ * sskr_generate_shards_internal() is static -- propagates the SSS_* code
+ * surfacing from the internal call, so what this test asserts is the
+ * SSS_ERROR_TOO_MANY_SHARES the failed split produced, that shard_len was
+ * zeroed rather than left as the caller wrote it, and that output was
+ * actually cleared rather than left holding shards built from whatever was
+ * on the stack.
  *
  * Not reachable from the UI today (the menu options that set group/member
  * counts cannot exceed the arrays either), but a public library entry point,
@@ -58,7 +57,7 @@ static void test_generate_reports_the_split_error_instead_of_succeeding(void **s
         (SECRET_LEN + SSKR_METADATA_LENGTH_BYTES) * (SHARDS_CAPACITY + 1);
     uint8_t share_buffer[share_buffer_len];
     uint8_t expected_buffer[share_buffer_len];
-    uint8_t share_len;
+    uint8_t share_len = 0xFF;
 
     memset(share_buffer, 0xFF, share_buffer_len);
     memset(expected_buffer, 0, share_buffer_len);
@@ -67,7 +66,8 @@ static void test_generate_reports_the_split_error_instead_of_succeeding(void **s
                                           SECRET_LEN, &share_len, share_buffer,
                                           share_buffer_len, cx_rng);
 
-    assert_int_equal(result, 0);
+    assert_int_equal(result, SSS_ERROR_TOO_MANY_SHARES);
+    assert_int_equal(share_len, 0);
     assert_memory_equal(share_buffer, expected_buffer, share_buffer_len);
 }
 


### PR DESCRIPTION
## What this changes

`sskr.h` documents `sskr_generate_shards()` as returning

> Number of shards generated on success, or **a negative error code on failure**.

The exit at the bottom of the function returned `0` instead:

```c
    memzero(shards, sizeof(shards));
    if (error) {
        memzero(output, buffer_size);
        return 0;          /* the code that got here is dropped */
    }

    *shard_len = byte_count;   /* never reached on failure */
```

So every late failure — the ones surfacing from `sss_split_secret()` inside
`sskr_generate_shards_internal()`, and a serialization failure — came back as
`0`: indistinguishable from one another, and matching none of the documented
codes. The early rejections a few lines above already return theirs; only this
exit did not.

The second output was undefined on the same path. `shard_len` is declared
`[out]`, but it is only assigned after the failure check, so a failing call
left the caller's variable holding whatever was already in it.

This propagates the code that reached the exit, and assigns `shard_len` once at
the top of the function so that **every** rejection — early or late — hands back
a defined length, with the success path overwriting it with the real one. The
output erasure, the shards erasure and the nominal path are untouched.

`SSS_*` codes (`-101` and below) and `SSKR_*` codes (`-1` and below) come from
two disjoint ranges, so propagating one through the `int16_t` return value
neither truncates it nor collides with the other family's meanings.

## Existing tests described the old behaviour and are updated here

This is the part worth looking at first. Three assertions in two files pinned
the `0`:

- `tests/unit/tests/sskr_generate_split_error.c`
- `tests/unit/tests/sskr_generate_erase_on_split_failure.c` (two of them)

**Those tests were not wrong.** They described the behaviour as it stood, and
the first of them says so explicitly in its header comment ("that collapse is
pre-existing and out of scope here"). They change because the behaviour
changes, not because their assertions were false.

They also get more precise in the process. Each now pins the code its own
trigger actually produces, which tells apart three failures the suite could not
distinguish before:

| Trigger | Was | Now |
|---|---|---|
| group larger than the split can produce | `0` | `SSS_ERROR_TOO_MANY_SHARES` |
| member split that cannot interpolate | `0` | `SSS_ERROR_INTERPOLATION_FAILURE` |
| group threshold of zero | `0` | `SSS_ERROR_INVALID_THRESHOLD` |

Each also checks that `shard_len` came back as `0` rather than as the sentinel
it was handed.

## The application behaves exactly as before

`bolos_ux_sskr_generate()` (`src/common/sskr/seed_sskr.c`) is the only caller in
the app. It already stores the result in an `int16_t` and already tests
`share_count < 0` before anything else, so a failed generation erases the share
buffer and returns `0` exactly as it did — previously because `0` never equalled
the expected count, now because the count is negative. Its own caller,
`bolos_ux_bip39_to_sskr_convert()`, initialises `share_len` to `0` before the
call, so the new assignment writes the value that was already there.

That is not just an argument from reading the code: the six device builds come
out at identical sizes, and the `nanos` binary is byte-identical to the base
(`objdump -d` reports zero differing lines).

## New coverage of the contract itself

Nine files in the suite reach `sskr_generate_shards()`, each covering a
particular guard, buffer erasure or round trip, and each asserting the single
code its own case produces. Nothing held the shape of the contract itself.

`tests/unit/tests/sskr_generate_error_contract.c` adds a table of twelve rows,
one per error family reachable through the public entry point — the three
secret-length rejections, the five group-descriptor ones, insufficient space,
and the three failures that surface from `sss_split_secret()` — and asserts:

- the exact code of each row;
- that the twelve codes are pairwise distinct, checked rather than asserted in
  prose, so a table whose entries silently collapsed onto one value would still
  be caught;
- that `shard_len` is `0` after every one of them, starting from a `0xFF`
  sentinel so that "zero" means written rather than merely untouched;
- and, on a nominal call, the shard count and the real shard length.

Sizes and counts come from `SSS_MAX_SHARE_COUNT` and `SSKR_MAX_GROUP_COUNT`
rather than literals, so the file stays correct on a target where they differ.

## Verification

Verified by mutation, both ways:

| Mutation | Result |
|---|---|
| `return error;` → `return 0;` | `test_sskr_generate_split_error`, `test_sskr_generate_erase_on_split_failure` and `test_sskr_generate_error_contract` fail |
| drop `*shard_len = 0;` | the same three fail |
| restored | 51/51 green, source checksum back to its original value |

- `ctest`: **50 → 51** targets, all green. The new one runs in under 0.01 s, so
  the suite time is unchanged at about 2.3 s.
- The four `TARGET_NANOS` targets (`test_sss_nanos`, `test_sskr_nanos`,
  `test_sskr_interop_bc128_nanos`, `test_sskr_threshold_three_roundtrip_nanos`)
  are green: they consume `sskr.c` through `libsskr`, so they were checked
  explicitly even though none of the files they replay is modified.
- All six devices in `ledger_app.toml` build, `nanos` included (built by hand,
  since CI does not build it), with unchanged sizes:

  | device | code | BSS |
  |---|---|---|
  | nanos | 32 008 | 3 708 |
  | nanox | 46 136 | 28 672 |
  | nanos+ | 46 152 | 40 960 |
  | stax | 72 305 | 36 864 |
  | flex | 72 845 | 36 864 |
  | apex_p | 69 233 | 40 960 |

  The only symbol whose size changes at all is `sskr_generate_shards` itself
  (+6 bytes where it is linked); `.text` totals are identical.
- `clang-format --dry-run -Werror` is clean on every file touched, except
  `sskr_generate_split_error.c`, which was already non-conformant before this
  change (12 violations both before and after — none added, and it is not
  reformatted here so as not to bury the diff).
- No Speculos script is affected.
