### PR TITLE
refactor: read the SSKR group descriptor in one place

### DIFF
--- a/src/common/sskr/seed_sskr.c
+++ b/src/common/sskr/seed_sskr.c
@@ -23,6 +23,7 @@
 #include "../common.h"
 #include "./common_sskr.h"
 #include "./seed_rom_variables.h"
+#include "./seed_sskr_internal.h"
 #include "./sskr.h"
 
 // Return the CRC-32 checksum of the input buffer in network byte order (big
@@ -43,18 +44,34 @@
     (SSKR_MAX_GROUP_COUNT * SSS_MAX_SHARE_COUNT * \
      (SSKR_MAX_STRENGTH_BYTES + SSKR_METADATA_LENGTH_BYTES))
 
+// See seed_sskr_internal.h. Both entry points below need this, and used to do
+// it inline with two different index expressions -- the same array read two
+// ways. One expression per descriptor layout is the point of this function;
+// having it take the destination's capacity rather than assume
+// SSKR_MAX_GROUP_COUNT is what lets a test reach a group past the first.
+bool bolos_ux_sskr_groups_from_descriptor(const unsigned int* group_descriptor,
+                                          uint8_t groups_len,
+                                          sskr_group_descriptor_t* groups,
+                                          size_t groups_capacity) {
+    if ((size_t)groups_len > groups_capacity) {
+        return false;
+    }
+
+    for (uint8_t i = 0; i < groups_len; i++) {
+        groups[i].threshold = (uint8_t)group_descriptor[i * 2];
+        groups[i].count = (uint8_t)group_descriptor[i * 2 + 1];
+    }
+
+    return true;
+}
+
 int16_t bolos_ux_sskr_size_get(uint8_t bip39_type, uint8_t groups_threshold,
                                unsigned int* group_descriptor,
                                uint8_t groups_len, uint8_t* share_len) {
-    if (groups_len > SSKR_MAX_GROUP_COUNT) {
-        return SSKR_ERROR_INVALID_GROUP_LENGTH;
-    }
     sskr_group_descriptor_t groups[SSKR_MAX_GROUP_COUNT];
-    for (uint8_t i = 0; i < groups_len; i++) {
-        groups[i].threshold =
-            *(group_descriptor + i * sizeof(*(group_descriptor)) / groups_len);
-        groups[i].count = *(group_descriptor + 1 +
-                            i * sizeof(*(group_descriptor)) / groups_len);
+    if (!bolos_ux_sskr_groups_from_descriptor(group_descriptor, groups_len,
+                                              groups, SSKR_MAX_GROUP_COUNT)) {
+        return SSKR_ERROR_INVALID_GROUP_LENGTH;
     }
 
     int16_t share_count_expected =
@@ -140,7 +157,9 @@ unsigned int bolos_ux_sskr_generate(uint8_t groups_threshold,
                                     unsigned int share_buffer_len,
                                     uint8_t share_len_expected,
                                     int16_t share_count_expected) {
-    if (groups_len > SSKR_MAX_GROUP_COUNT) {
+    sskr_group_descriptor_t groups[SSKR_MAX_GROUP_COUNT];
+    if (!bolos_ux_sskr_groups_from_descriptor(group_descriptor, groups_len,
+                                              groups, SSKR_MAX_GROUP_COUNT)) {
         return 0;
     }
     // share_buffer_len is a write length, not just a capacity hint: the
@@ -149,12 +168,6 @@ unsigned int bolos_ux_sskr_generate(uint8_t groups_threshold,
     // longer rather than write past the end of one.
     if (share_buffer_len > SSKR_MAX_SHARE_BUFFER_LENGTH) {
         return 0;
-    }
-    sskr_group_descriptor_t groups[SSKR_MAX_GROUP_COUNT];
-
-    for (uint8_t i = 0; i < (uint8_t)groups_len; i++) {
-        groups[i].threshold = *(group_descriptor + i * 2);
-        groups[i].count = *(group_descriptor + 1 + i * 2);
     }
 
     if (!(SSKR_MIN_STRENGTH_BYTES <= seed_len &&

--- a/src/common/sskr/seed_sskr_internal.h
+++ b/src/common/sskr/seed_sskr_internal.h
@@ -20,8 +20,14 @@
 // Internals of seed_sskr.c: helpers that no other file in src/ calls, but that
 // keep external linkage so the unit suite can reach them. Same pattern, and for
 // the same reason, as bip85/bip85_internal.h: the single place they are
-// declared, included by seed_sskr.c so the compiler checks the definition, and
+// declared, included by seed_sskr.c so the compiler checks the definitions, and
 // by the tests so it checks their use.
+//
+// Before this header, the two entry points below were declared by hand, with
+// `extern`, in each of the three test files that needed them, and nothing
+// checked those declarations against the definitions: no translation unit saw
+// both. They happened to agree, which is not the same as being kept in
+// agreement.
 //
 // Nothing here is part of the application's SSKR interface. That is
 // common_sskr.h, and it is what callers outside this directory should use.
@@ -48,3 +54,33 @@ bool bolos_ux_sskr_groups_from_descriptor(const unsigned int *group_descriptor,
                                           uint8_t groups_len,
                                           sskr_group_descriptor_t *groups,
                                           size_t groups_capacity);
+
+// The two SSKR generation entry points. Both are reached only from
+// bolos_ux_bip39_to_sskr_convert() in the same file, which is why neither is in
+// common_sskr.h; the unit suite calls them directly.
+//
+// bolos_ux_sskr_size_get() returns the number of shares the descriptor calls
+// for, or one of sskr_count_shards()'s negative error codes, and writes the
+// serialized length of one share to *share_len. bolos_ux_sskr_generate()
+// returns the number of shares written to share_buffer, or 0 on any failure,
+// having first erased the whole of share_buffer -- so share_buffer_len is a
+// write length and not merely a capacity. The share_len_expected and
+// share_count_expected it is given are the figures bolos_ux_sskr_size_get()
+// produced for the same descriptor, and it refuses to report success unless
+// what it generated matches them.
+int16_t bolos_ux_sskr_size_get(uint8_t bip39_type,
+                               uint8_t groups_threshold,
+                               unsigned int *group_descriptor,
+                               uint8_t groups_len,
+                               uint8_t *share_len);
+
+unsigned int bolos_ux_sskr_generate(uint8_t groups_threshold,
+                                    unsigned int *group_descriptor,
+                                    uint8_t groups_len,
+                                    unsigned char *seed,
+                                    unsigned int seed_len,
+                                    uint8_t *share_len,
+                                    unsigned char *share_buffer,
+                                    unsigned int share_buffer_len,
+                                    uint8_t share_len_expected,
+                                    int16_t share_count_expected);

--- a/src/common/sskr/seed_sskr_internal.h
+++ b/src/common/sskr/seed_sskr_internal.h
@@ -1,0 +1,50 @@
+/*******************************************************************************
+ *   Ledger Seed Tool application
+ *   (c) 2016-2026 Ledger SAS
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ ********************************************************************************/
+
+#pragma once
+
+// Internals of seed_sskr.c: helpers that no other file in src/ calls, but that
+// keep external linkage so the unit suite can reach them. Same pattern, and for
+// the same reason, as bip85/bip85_internal.h: the single place they are
+// declared, included by seed_sskr.c so the compiler checks the definition, and
+// by the tests so it checks their use.
+//
+// Nothing here is part of the application's SSKR interface. That is
+// common_sskr.h, and it is what callers outside this directory should use.
+
+#include <stdbool.h>
+#include <stddef.h>
+#include <stdint.h>
+
+#include "./group.h"
+
+// Expand the flat group descriptor the UI layers hold into the array of
+// sskr_group_descriptor_t that sskr_count_shards() and sskr_generate_shards()
+// take.
+//
+// `group_descriptor` points at the first element of an `unsigned int[N][2]` --
+// nbgl/sskr_shares.c and bagl/ux_nano.h both declare it that way and pass
+// `[0]` -- so group `i` holds its threshold at `[i * 2]` and its member count
+// at `[i * 2 + 1]`.
+//
+// Returns false, having written nothing, when `groups_len` exceeds
+// `groups_capacity`: `groups` is a fixed-size array in both callers, while the
+// length reaching them comes from outside.
+bool bolos_ux_sskr_groups_from_descriptor(const unsigned int *group_descriptor,
+                                          uint8_t groups_len,
+                                          sskr_group_descriptor_t *groups,
+                                          size_t groups_capacity);

--- a/tests/unit/CMakeLists.txt
+++ b/tests/unit/CMakeLists.txt
@@ -31,16 +31,21 @@ set(CMAKE_C_STANDARD_REQUIRED True)
 # problem, a function with external linkage and no prototype at all, where
 # there is nothing for the compiler to compare a definition against.
 #
-# It is not at zero. As of this commit it reports 25 functions, 9 of them in
-# src/: 2 in sskr/seed_sskr.c, and one each in bip39/seed_bip39.c,
-# common_seed.c, bip85/base64.c, bip85/base85.c, sskr/sss/sss.c,
-# nbgl/bip39_mnemonic.c and nbgl/sskr_shares.c. The seventeen this comment
-# used to list in bip85/seed_bip85.c are gone: they now come from
-# bip85/bip85_internal.h, which is the pattern the rest should follow.
+# It is not at zero. Measured over a full build of this directory and
+# deduplicated by (file, function), it reports 21 as of this commit, 7 of them
+# in src/: one each in bip39/seed_bip39.c, common_seed.c, bip85/base64.c,
+# bip85/base85.c, sskr/sss/sss.c, nbgl/bip39_mnemonic.c and
+# nbgl/sskr_shares.c. It was 23 and 9 immediately before, the two extra being
+# bolos_ux_sskr_size_get() and bolos_ux_sskr_generate() in sskr/seed_sskr.c;
+# they now come from sskr/seed_sskr_internal.h, as the seventeen this comment
+# once listed in bip85/seed_bip85.c come from bip85/bip85_internal.h. That is
+# the pattern the rest should follow.
 #
-# Making the remainder static is not the automatic answer: six of the nine
-# are reached by extern declarations in tests/unit/tests/, sss.c is kept
-# diffable against upstream bc-sskr, and
+# Making the remainder static is not the automatic answer: four of the seven
+# are reached by declarations written by hand in tests/unit/tests/
+# (compare_recovery_phrase_finish, base64_encode_64bytes,
+# base85_encode_64bytes, bip39_mnemonic_shrink), sss.c is kept diffable
+# against upstream bc-sskr, and
 # bolos_ux_bip39_mnemonic_to_seed_hash_length128() exists precisely to keep
 # the pbkdf2 frame off its caller's stack, which static would let the
 # compiler undo. They are left as warnings deliberately; the point of the

--- a/tests/unit/CMakeLists.txt
+++ b/tests/unit/CMakeLists.txt
@@ -356,6 +356,20 @@ target_compile_options(test_sskr_generate_seed_len_bounds PRIVATE -fsanitize=add
 target_link_options(test_sskr_generate_seed_len_bounds PRIVATE -fsanitize=address)
 target_link_libraries(test_sskr_generate_seed_len_bounds PUBLIC cmocka gcov testutils sskr sss)
 
+# The group-descriptor expansion both of the above and bolos_ux_sskr_size_get()
+# share, on group counts above the one SSKR_MAX_GROUP_COUNT allows their own
+# fixed-size arrays -- which is why the function under test takes the
+# destination's capacity from its caller, and why this target can reach a case
+# neither entry point could. Same source list and same sanitizer setup as
+# test_sskr_generate_bound_groups above, for the same reason: the capacity bound
+# is about a write, so seed_sskr.c is compiled in rather than linked so its
+# frames are instrumented.
+add_executable(test_sskr_group_descriptor ./tests/sskr_group_descriptor.c ../../src/common/bip39/seed_rom_variables.c ../../src/common/bip39/seed_bip39.c ../../src/common/sskr/seed_rom_variables.c ../../src/common/sskr/seed_sskr.c)
+target_include_directories(test_sskr_group_descriptor PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/../../src ${CMAKE_CURRENT_SOURCE_DIR}/../../src/common ${CMAKE_CURRENT_SOURCE_DIR}/../../src/common/sskr/sss)
+target_compile_options(test_sskr_group_descriptor PRIVATE -fsanitize=address -fno-omit-frame-pointer)
+target_link_options(test_sskr_group_descriptor PRIVATE -fsanitize=address)
+target_link_libraries(test_sskr_group_descriptor PUBLIC cmocka gcov testutils sskr sss)
+
 # Blockchain Commons 128-bit vector, raw Shamir math level (no CBOR/CRC).
 add_executable(test_sskr_interop_bc128 tests/sskr_interop_bc128.c)
 target_link_libraries(test_sskr_interop_bc128 PUBLIC cmocka gcov testutils sskr sss)

--- a/tests/unit/tests/sskr_generate_bound_groups.c
+++ b/tests/unit/tests/sskr_generate_bound_groups.c
@@ -43,25 +43,11 @@
 #include <string.h>
 
 #include "constants.h"
+#include "sskr/seed_sskr_internal.h"
 #include "sskr/sskr-constants.h"
 #include "testutils.h"
 
 #define SECRET_LEN (SSKR_MIN_STRENGTH_BYTES)
-
-/* bolos_ux_sskr_generate() and bolos_ux_sskr_size_get() are public entry
- * points (external linkage) but only ever called from within seed_sskr.c
- * itself, so neither is declared in common_sskr.h. */
-extern int16_t bolos_ux_sskr_size_get(uint8_t bip39_type,
-                                      uint8_t groups_threshold,
-                                      unsigned int* group_descriptor,
-                                      uint8_t groups_len, uint8_t* share_len);
-
-extern unsigned int bolos_ux_sskr_generate(
-    uint8_t groups_threshold, unsigned int* group_descriptor,
-    uint8_t groups_len, unsigned char* seed, unsigned int seed_len,
-    uint8_t* share_len, unsigned char* share_buffer,
-    unsigned int share_buffer_len, uint8_t share_len_expected,
-    int16_t share_count_expected);
 
 /*
  * One more group than `groups[SSKR_MAX_GROUP_COUNT]` (and hence

--- a/tests/unit/tests/sskr_generate_seed_len_bounds.c
+++ b/tests/unit/tests/sskr_generate_seed_len_bounds.c
@@ -53,6 +53,7 @@
 #include <stdint.h>
 #include <string.h>
 
+#include "sskr/seed_sskr_internal.h"
 #include "sskr/sskr-constants.h"
 #include "testutils.h"
 
@@ -67,16 +68,6 @@
 #define SEED_BUFFER_LENGTH (SSKR_MAX_STRENGTH_BYTES + 2)
 
 #define SENTINEL 0xa5
-
-/* bolos_ux_sskr_generate() is a public entry point (external linkage) but is
- * only ever called from within seed_sskr.c itself, so it is not declared in
- * common_sskr.h. */
-extern unsigned int bolos_ux_sskr_generate(
-    uint8_t groups_threshold, unsigned int* group_descriptor,
-    uint8_t groups_len, unsigned char* seed, unsigned int seed_len,
-    uint8_t* share_len, unsigned char* share_buffer,
-    unsigned int share_buffer_len, uint8_t share_len_expected,
-    int16_t share_count_expected);
 
 /*
  * Call bolos_ux_sskr_generate() varying nothing but seed_len. Everything

--- a/tests/unit/tests/sskr_group_descriptor.c
+++ b/tests/unit/tests/sskr_group_descriptor.c
@@ -1,0 +1,196 @@
+/*
+ * bolos_ux_sskr_groups_from_descriptor() (seed_sskr.c): the single place the
+ * flat group descriptor the UI layers hold is turned into the
+ * sskr_group_descriptor_t array the SSKR core takes.
+ *
+ * Until that function existed, bolos_ux_sskr_size_get() and
+ * bolos_ux_sskr_generate() each did it themselves, reading the same array with
+ * two different index expressions:
+ *
+ *     groups[i].threshold =
+ *         *(group_descriptor + i * sizeof(*(group_descriptor)) / groups_len);
+ *     groups[i].threshold = *(group_descriptor + i * 2);
+ *
+ * The descriptor is an `unsigned int[N][2]` passed as a pointer to its first
+ * element (nbgl/sskr_shares.c, bagl/ux_nano.h), so the second is the right one:
+ * group i holds its threshold at [i * 2] and its member count at [i * 2 + 1].
+ * The first is `i * sizeof(unsigned int) / groups_len`, that is `i * 4 /
+ * groups_len` -- a size in bytes divided into an index in elements -- and
+ * coincides with the second only for the two smallest group counts:
+ *
+ *     groups_len | i * 4 / groups_len | i * 2      | agree
+ *     1          | 0                  | 0          | yes
+ *     2          | 0, 2               | 0, 2       | yes, by coincidence
+ *     3          | 0, 1, 2            | 0, 2, 4    | no
+ *     4          | 0, 1, 2, 3         | 0, 2, 4, 6 | no
+ *
+ * Neither entry point could be held to that table. Both size their local
+ * `groups[SSKR_MAX_GROUP_COUNT]` from a constant that is 1 in this port, and
+ * both reject a groups_len above it, so i never left 0 and the two expressions
+ * never disagreed on a call that could happen. Taking the destination and its
+ * capacity as parameters, rather than assuming SSKR_MAX_GROUP_COUNT, is what
+ * makes the last two rows reachable at all: the tests below supply a
+ * destination of their own.
+ *
+ * That the extraction left the two entry points behaving as before, for the
+ * single group this port allows, is what the rest of the suite already checks:
+ * every seed_sskr.c target goes through one or both of them.
+ *
+ * Built with AddressSanitizer for test_rejects_groups_len_above_capacity: the
+ * capacity bound exists to prevent a write, and the return value cannot tell a
+ * working bound from a missing one -- past the end of a
+ * sskr_group_descriptor_t[2] the stores are plain indexed writes, which ASan's
+ * stack-buffer-overflow instrumentation does report (unlike the
+ * memzero()/explicit_bzero() overruns elsewhere in this suite, which it does
+ * not intercept). seed_sskr.c is compiled directly into the target rather than
+ * linked from a library so its frames are instrumented too, matching
+ * test_sskr_generate_bound_groups.
+ */
+
+#include <cmocka.h>
+#include <setjmp.h>
+#include <stdarg.h>
+#include <stddef.h>
+#include <stdint.h>
+#include <string.h>
+
+#include "sskr/seed_sskr_internal.h"
+#include "sskr/sskr-constants.h"
+
+#define GROUPS_CAPACITY(array) (sizeof(array) / sizeof((array)[0]))
+
+/* Four groups' worth of (threshold, count) pairs, all distinct and none equal
+ * to its own index, so that reading the wrong element cannot pass by accident.
+ * Declared the way the UI layers declare it -- `unsigned int[N][2]` -- and
+ * passed as `descriptor[0]`, so what these tests exercise is the layout the
+ * application actually hands over and not a hand-flattened stand-in. */
+static const unsigned int descriptor[4][2] = {
+    {1, 1},
+    {2, 3},
+    {3, 5},
+    {4, 7},
+};
+
+/*
+ * The one configuration this port supports: a single group, into a destination
+ * sized exactly as both entry points size theirs.
+ */
+static void test_fills_one_group(void** state) {
+    (void)state;
+
+    sskr_group_descriptor_t groups[SSKR_MAX_GROUP_COUNT];
+
+    assert_true(bolos_ux_sskr_groups_from_descriptor(descriptor[0], 1, groups,
+                                                     SSKR_MAX_GROUP_COUNT));
+    assert_int_equal(groups[0].threshold, descriptor[0][0]);
+    assert_int_equal(groups[0].count, descriptor[0][1]);
+}
+
+/*
+ * Every group gets the pair at its own offset. One test per row of the table in
+ * the file header rather than a loop over the four counts, so that a run names
+ * the counts that disagree: cmocka stops a test at its first failed assertion,
+ * and "groups_len 3 and 4 are wrong while 1 and 2 are right" is the whole point
+ * here.
+ *
+ * With `i * 4 / groups_len` the groups_len 3 and 4 calls read [0, 1, 2] and
+ * [0, 1, 2, 3] instead of [0, 2, 4] and [0, 2, 4, 6], so group 1 comes out as
+ * (descriptor[0][1], descriptor[1][0]) -- the member count of the first group
+ * paired with the threshold of the second.
+ */
+static void assert_expansion(uint8_t groups_len) {
+    sskr_group_descriptor_t groups[4];
+    memset(groups, 0xAA, sizeof(groups));
+
+    assert_true(bolos_ux_sskr_groups_from_descriptor(
+        descriptor[0], groups_len, groups, GROUPS_CAPACITY(groups)));
+
+    for (uint8_t i = 0; i < groups_len; i++) {
+        assert_int_equal(groups[i].threshold, descriptor[i][0]);
+        assert_int_equal(groups[i].count, descriptor[i][1]);
+    }
+}
+
+static void test_fills_two_groups(void** state) {
+    (void)state;
+    assert_expansion(2);
+}
+
+static void test_fills_three_groups(void** state) {
+    (void)state;
+    assert_expansion(3);
+}
+
+static void test_fills_four_groups(void** state) {
+    (void)state;
+    assert_expansion(4);
+}
+
+/*
+ * A groups_len at exactly the capacity must still be accepted, so that the
+ * bound cannot be an off-by-one that turns away the largest configuration a
+ * caller legitimately asks for.
+ */
+static void test_accepts_groups_len_at_capacity(void** state) {
+    (void)state;
+
+    sskr_group_descriptor_t groups[2];
+
+    assert_true(bolos_ux_sskr_groups_from_descriptor(
+        descriptor[0], GROUPS_CAPACITY(groups), groups,
+        GROUPS_CAPACITY(groups)));
+    assert_int_equal(groups[1].threshold, descriptor[1][0]);
+    assert_int_equal(groups[1].count, descriptor[1][1]);
+}
+
+/*
+ * One group more than the destination holds. The function must refuse rather
+ * than write past the end of it, and must leave what is already there alone:
+ * the sentinel says "wrote nothing", the sanitizer says "wrote nothing past the
+ * end".
+ */
+static void test_rejects_groups_len_above_capacity(void** state) {
+    (void)state;
+
+    sskr_group_descriptor_t groups[2];
+    memset(groups, 0xAA, sizeof(groups));
+
+    assert_false(bolos_ux_sskr_groups_from_descriptor(
+        descriptor[0], GROUPS_CAPACITY(groups) + 1, groups,
+        GROUPS_CAPACITY(groups)));
+    for (size_t i = 0; i < GROUPS_CAPACITY(groups); i++) {
+        assert_int_equal(groups[i].threshold, 0xAA);
+        assert_int_equal(groups[i].count, 0xAA);
+    }
+}
+
+/*
+ * Zero groups is accepted and writes nothing, which is what both entry points
+ * did before the extraction: their loop simply did not run, and
+ * sskr_count_shards() is left to reject the count. Pinned here so the
+ * extraction cannot quietly turn it into a rejection.
+ */
+static void test_zero_groups_len_writes_nothing(void** state) {
+    (void)state;
+
+    sskr_group_descriptor_t groups[1];
+    memset(groups, 0xAA, sizeof(groups));
+
+    assert_true(bolos_ux_sskr_groups_from_descriptor(descriptor[0], 0, groups,
+                                                     GROUPS_CAPACITY(groups)));
+    assert_int_equal(groups[0].threshold, 0xAA);
+    assert_int_equal(groups[0].count, 0xAA);
+}
+
+int main(void) {
+    const struct CMUnitTest tests[] = {
+        cmocka_unit_test(test_fills_one_group),
+        cmocka_unit_test(test_fills_two_groups),
+        cmocka_unit_test(test_fills_three_groups),
+        cmocka_unit_test(test_fills_four_groups),
+        cmocka_unit_test(test_accepts_groups_len_at_capacity),
+        cmocka_unit_test(test_rejects_groups_len_above_capacity),
+        cmocka_unit_test(test_zero_groups_len_writes_nothing),
+    };
+    return cmocka_run_group_tests(tests, NULL, NULL);
+}

--- a/tests/unit/tests/sskr_invalid_group_descriptor.c
+++ b/tests/unit/tests/sskr_invalid_group_descriptor.c
@@ -63,6 +63,7 @@
 #include "bip39/common_bip39.h"
 #include "constants.h"
 #include "sskr/common_sskr.h"
+#include "sskr/seed_sskr_internal.h"
 #include "sskr/sskr-constants.h"
 #include "testutils.h"
 
@@ -89,21 +90,6 @@ static const unsigned char bip39_mnemonic[] =
 /* ...and as space-separated ByteWords: 4 letters per byte plus a
  * separator, minus the trailing separator of the last word. */
 #define BYTEWORDS_SHARE_24_LENGTH (SERIALIZED_SHARE_24_LENGTH * 5 - 1)
-
-/* bolos_ux_sskr_size_get() and bolos_ux_sskr_generate() are public entry
- * points (external linkage) but only ever called from within seed_sskr.c
- * itself, so neither is declared in common_sskr.h. */
-extern int16_t bolos_ux_sskr_size_get(uint8_t bip39_type,
-                                      uint8_t groups_threshold,
-                                      unsigned int* group_descriptor,
-                                      uint8_t groups_len, uint8_t* share_len);
-
-extern unsigned int bolos_ux_sskr_generate(
-    uint8_t groups_threshold, unsigned int* group_descriptor,
-    uint8_t groups_len, unsigned char* seed, unsigned int seed_len,
-    uint8_t* share_len, unsigned char* share_buffer,
-    unsigned int share_buffer_len, uint8_t share_len_expected,
-    int16_t share_count_expected);
 
 /*
  * Drive bolos_ux_bip39_to_sskr_convert() end to end with the given


### PR DESCRIPTION
## Two readings of the same array

`bolos_ux_sskr_size_get()` and `bolos_ux_sskr_generate()` (`src/common/sskr/seed_sskr.c`) both turned the same flat group descriptor into the same `sskr_group_descriptor_t` array. Each did it with its own index expression.

`bolos_ux_sskr_size_get()`:

```c
for (uint8_t i = 0; i < groups_len; i++) {
    groups[i].threshold =
        *(group_descriptor + i * sizeof(*(group_descriptor)) / groups_len);
    groups[i].count = *(group_descriptor + 1 +
                        i * sizeof(*(group_descriptor)) / groups_len);
}
```

`bolos_ux_sskr_generate()`:

```c
for (uint8_t i = 0; i < (uint8_t)groups_len; i++) {
    groups[i].threshold = *(group_descriptor + i * 2);
    groups[i].count = *(group_descriptor + 1 + i * 2);
}
```

The descriptor is an `unsigned int[N][2]` passed as a pointer to its first element — `src/nbgl/sskr_shares.c` declares `unsigned int group_descriptor[1][2]` and passes `shares.group_descriptor[0]`, `src/bagl/ux_nano.h` declares `unsigned int sskr_group_descriptor[1][2]` and passes `[0]` the same way. So group `i` holds its threshold at `[i * 2]` and its member count at `[i * 2 + 1]`, and the second expression is the correct one.

The first is `i * sizeof(unsigned int) / groups_len`, that is `i * 4 / groups_len`: a size in bytes divided into an index in elements. It lands on the right element only for the two smallest group counts, and then by coincidence.

| `groups_len` | `i * 4 / groups_len` | `i * 2` | agree |
|---|---|---|---|
| 1 | `[0]` | `[0]` | yes |
| 2 | `[0, 2]` | `[0, 2]` | yes, by coincidence |
| 3 | `[0, 1, 2]` | `[0, 2, 4]` | **no** |
| 4 | `[0, 1, 2, 3]` | `[0, 2, 4, 6]` | **no** |

## Nothing is wrong today

`SSKR_MAX_GROUP_COUNT` is 1 in this port, and both functions refuse a `groups_len` above it. `i` therefore never leaves 0, both expressions evaluate to 0, and every call that can actually happen reads the same two elements either way.

**This is not a user-visible defect and there is no behaviour to fix.** No share was ever generated from the wrong descriptor, and none could be.

## Why close it anyway

Because of what the two expressions would do the day the group count went above 1 — which the existence of `SSKR_MAX_GROUP_COUNT` suggests is a foreseen direction.

`bolos_ux_sskr_generate()` compares what `sskr_generate_shards()` returns against the `share_count_expected` that `bolos_ux_sskr_size_get()` computed:

```c
if ((share_count < 0) || (share_count != share_count_expected) ||
    (*share_len != share_len_expected)) {
    memzero(share_buffer, share_buffer_len);
    return 0;
}
```

A descriptor read one way on one side and another way on the other makes those two figures disagree. The symptom would be generation failing at the very last check, on valid input, with nothing pointing at the cause — and in a part of the file nobody would be reading at that moment, since the two loops look like they do the same thing.

## Deduplicating rather than fixing twice

Replacing the wrong expression with the right one would leave two copies of a piece of logic that has already drifted apart once, free to drift again. This extracts it into a single function instead:

```c
bool bolos_ux_sskr_groups_from_descriptor(const unsigned int *group_descriptor,
                                          uint8_t groups_len,
                                          sskr_group_descriptor_t *groups,
                                          size_t groups_capacity);
```

Both entry points call it. There is now one expression for one layout, and divergence is structurally impossible rather than merely fixed.

Two details worth flagging:

- **It takes the destination and its capacity from the caller** rather than assuming `SSKR_MAX_GROUP_COUNT`. That is what makes the last two rows of the table above reachable by a test at all: with the constant baked in, nothing could ever ask for a second group, which is exactly why the divergence survived unnoticed.
- **Its capacity bound subsumes the `groups_len > SSKR_MAX_GROUP_COUNT` check each function performed for itself**, in the same position and returning the same value (`SSKR_ERROR_INVALID_GROUP_LENGTH` on one side, `0` on the other). In `bolos_ux_sskr_generate()` the descriptor is now filled before the `share_buffer_len` check instead of after, but that fill only writes to the function's own local array, so no observable behaviour changes.

The function is declared in a new `src/common/sskr/seed_sskr_internal.h`, on the pattern `bip85_internal.h` already sets in this repository: external linkage so a unit test can reach it, and one place where it is declared, included by `seed_sskr.c` so the compiler checks the definition against it. That header is also what the last commit builds on, below.

## The divergent case is now tested

`tests/unit/tests/sskr_group_descriptor.c`, built with AddressSanitizer, seven cases:

- one group, into a destination sized exactly as both entry points size theirs — the configuration this port supports;
- **two, three and four groups, one test each rather than a loop**, because cmocka stops a test at its first failed assertion and "3 and 4 are wrong while 1 and 2 are right" is the finding worth reading;
- a `groups_len` at exactly the capacity, so the bound cannot be an off-by-one;
- a `groups_len` one past the capacity, which must be refused rather than written;
- a `groups_len` of zero, which writes nothing — what both callers' loops did, leaving `sskr_count_shards()` to reject the count.

The descriptor the tests pass is declared `unsigned int[4][2]` and passed as `descriptor[0]`, the way the UI layers declare and pass theirs, so what is pinned is the layout the application really hands over rather than a hand-flattened stand-in. Its four `(threshold, count)` pairs are all distinct and none equals its own index, so reading the wrong element cannot pass by accident.

The capacity case is why the target is built with ASan: that bound exists to prevent a write, so the return value alone cannot tell a working bound from a missing one. The stores past the end are plain indexed writes, which ASan does report — unlike the `memzero()`/`explicit_bzero()` overruns elsewhere in this suite, which this toolchain's ASan does not intercept. A `0xAA` sentinel covers the other half of the claim, that nothing inside the destination is touched either.

**None of this was testable before.** Both entry points size their local `groups[SSKR_MAX_GROUP_COUNT]` from a constant that is 1 and reject anything above it, so no test written against either of them could ever put `i` past 0.

## Verified by mutation

Twice, both restored afterwards.

**Putting the old formula back** into the extracted function:

```
[ RUN      ] test_fills_one_group
[       OK ] test_fills_one_group
[ RUN      ] test_fills_two_groups
[       OK ] test_fills_two_groups
[ RUN      ] test_fills_three_groups
[  ERROR   ] --- 1 != 2
[  FAILED  ] test_fills_three_groups
[ RUN      ] test_fills_four_groups
[  ERROR   ] --- 1 != 2
[  FAILED  ] test_fills_four_groups
```

Exactly the table: 1 and 2 agree, 3 and 4 do not. Across the whole suite only this one target goes red — the same fact from the other side, that nothing else can see this case.

**Making the capacity bound unconditionally false:**

```
==2597==ERROR: AddressSanitizer: stack-buffer-overflow on address 0x76791cd00164
WRITE of size 1 at 0x76791cd00164 thread T0
    #0 bolos_ux_sskr_groups_from_descriptor src/common/sskr/seed_sskr.c:61
    #1 test_rejects_groups_len_above_capacity tests/unit/tests/sskr_group_descriptor.c:158
  This frame has 1 object(s):
    [32, 36) 'groups' <== Memory access at offset 36 overflows this variable
```

With both restored, the suite is green again.

## Since the header is new: two entry points that had no prototype

`bolos_ux_sskr_size_get()` and `bolos_ux_sskr_generate()` have external linkage, are called only from `bolos_ux_bip39_to_sskr_convert()` in the same file, and had no prototype anywhere. The unit suite reached them by declaring them with `extern`, by hand, in each of the three test files that needed them — and nothing checked those declarations against the definitions, because no translation unit saw both.

They happened to agree. That is not the same as being kept in agreement, and it is the same class of problem this suite already acted on: six definitions in `seed_bip39.c` and `seed_sskr.c` once contradicted the declarations their callers used, which is why those files now include their own public headers and why `-Wmissing-prototypes` is on. That flag catches a function with no prototype at all; it cannot help when the declaration lives in another translation unit.

`seed_sskr_internal.h` now exists, so the last commit declares them there and deletes the three hand-written blocks. The header also writes down what each returns — including that `bolos_ux_sskr_generate()`'s `share_buffer_len` is a write length rather than a capacity, since its failure path erases the whole of it, which a caller could previously only learn by reading the body.

**Mutation, in both directions.** Changing the header's declaration to return `int32_t` stops the build, because `seed_sskr.c` now sees both:

```
src/common/sskr/seed_sskr.c:68:9: error: conflicting types for 'bolos_ux_sskr_size_get';
  have 'int16_t(uint8_t, uint8_t, unsigned int *, uint8_t, uint8_t *)'
```

Reproducing the old arrangement instead — the same wrong return type declared by hand in a test file, header not included there — builds with **zero errors** and the target still passes. That is the failure mode being removed.

The `-Wmissing-prototypes` figures in `tests/unit/CMakeLists.txt` are updated, re-measured rather than derived: over a full build of that directory, deduplicated by (file, function), **23 before and 21 after**, the difference being exactly these two. Its count of 9 in `src/` was right and becomes 7; the total it stated, 25, does not match what a build reports today, so the new figures say how they were obtained.

## Verification

Unit suite: **51 targets to 52**, 52/52 green, total 1.99 s to 2.28 s. The new target needs no registration — `add_executable()` is enough.

All **six** targets of `ledger_app.toml` build, and changes that alter no behaviour alter no code either — every binary is byte-for-byte the same size as before, measured after each of the two source-touching commits:

| target | text | bss | delta |
|---|---|---|---|
| nanos | 32008 | 3708 | 0 |
| nanox | 46136 | 28672 | 0 |
| nanos+ | 46152 | 40960 | 0 |
| stax | 72305 | 36864 | 0 |
| flex | 72845 | 36864 | 0 |
| apex_p | 69233 | 40960 | 0 |

The four `TARGET_NANOS` targets replay `sskr.c`/`sss.c`/`interpolate.c`, not `seed_sskr.c`, so this cannot affect them; they are green in the run above regardless.

`clang-format --dry-run -Werror` is clean on every touched file. The Speculos scripts are not involved.
