### PR TITLE
build: take src/ to zero missing prototypes, and hold it there

### DIFF
--- a/src/common/bip39/common_bip39.h
+++ b/src/common/bip39/common_bip39.h
@@ -17,6 +17,14 @@
 
 #pragma once
 
+// Hashes an over-long mnemonic down to 64 bytes in its own frame, so that the
+// pbkdf2 call in bolos_ux_bip39_mnemonic_to_seed() does not carry this one's
+// locals. Kept out of line and with external linkage for that reason -- static
+// would let the compiler undo it -- which is an argument against `static`, not
+// against a prototype.
+unsigned int bolos_ux_bip39_mnemonic_to_seed_hash_length128(unsigned char *mnemonic,
+                                                            unsigned int mnemonic_length);
+
 // BIP39 helpers
 #include "./seed_rom_variables.h"
 

--- a/src/common/bip85/base64.c
+++ b/src/common/bip85/base64.c
@@ -17,6 +17,7 @@
 
 #include <os.h>
 
+#include "./bip85_internal.h"
 #include "./seed_rom_variables.h"
 
 /**

--- a/src/common/bip85/base85.c
+++ b/src/common/bip85/base85.c
@@ -17,6 +17,7 @@
 
 #include <os.h>
 
+#include "./bip85_internal.h"
 #include "./seed_rom_variables.h"
 
 /**

--- a/src/common/bip85/bip85_internal.h
+++ b/src/common/bip85/bip85_internal.h
@@ -17,17 +17,18 @@
 
 #pragma once
 
-// Internals of seed_bip85.c: helpers that no other file in src/ calls, but
-// that keep external linkage so the unit suite can reach them. That intent is
-// already written on bip85_dice_bits_per_roll() -- "with external linkage,
-// purely so it can be linked into a unit test" -- so making them static is
-// not the answer; giving them a prototype is.
+// Internals of this directory: helpers that the application reaches only from
+// within it, but that keep external linkage so the unit suite can reach them
+// too. That intent is already written on bip85_dice_bits_per_roll() -- "with
+// external linkage, purely so it can be linked into a unit test" -- so making
+// them static is not the answer; giving them a prototype is.
 //
 // Before this header, each of them was declared by hand, with `extern`, in
 // whichever test file needed it, and nothing checked those declarations
 // against the definitions: no translation unit saw both. This header is the
-// single place they are declared, included by seed_bip85.c so the compiler
-// checks the definitions, and by the tests so it checks their use.
+// single place they are declared, included by the file that defines them so
+// the compiler checks the definitions, and by the tests so it checks their
+// use.
 //
 // Nothing here is part of the application's BIP-85 interface. That is
 // common_bip85.h, and it is what callers outside this directory should use.
@@ -76,3 +77,10 @@ int32_t bip85_dice_roll(uint32_t *out,
                         uint32_t sides,
                         uint32_t rolls,
                         const uint8_t seed[BIP85_ENTROPY_LENGTH]);
+
+// The password encoders, defined in base64.c and base85.c. Each consumes
+// exactly 64 bytes from `src` and writes BASE64_ENCODE_LENGTH /
+// BASE85_ENCODE_LENGTH characters to `dst`, unterminated, returning that count.
+// bip85_finalize_pwd() above is what truncates and terminates the result.
+uint8_t base64_encode_64bytes(const uint8_t *src, char *dst);
+uint8_t base85_encode_64bytes(const uint8_t *src, char *dst);

--- a/src/common/bip85/seed_bip85.c
+++ b/src/common/bip85/seed_bip85.c
@@ -504,9 +504,6 @@ bool bip85_dice_rolls_valid(uint32_t rolls) {
 #include "common.h"
 #include "constants.h"
 
-extern uint8_t base64_encode_64bytes(const uint8_t* src, char* dst);
-extern uint8_t base85_encode_64bytes(const uint8_t* src, char* dst);
-
 /**
  * @brief Generates BIP85 entropy from a device's seed using a specified BIP32
  * path.

--- a/src/common/common.h
+++ b/src/common/common.h
@@ -36,3 +36,15 @@
  * one. It is always true for the BIP39 tool, which has nothing to reconstruct.
  */
 bool compare_recovery_phrase(bool *reconstructed);
+
+/*
+ * The tail of compare_recovery_phrase(): everything that happens once
+ * os_derive_bip32_no_throw() has returned. Split out because that syscall is
+ * not available on host while the comparison and the two erasures around it are
+ * pure logic. Not for callers outside common_seed.c -- it is here so that the
+ * file that defines it, and the unit suite that drives it, are checked against
+ * one declaration.
+ */
+bool compare_recovery_phrase_finish(cx_err_t derivation_status,
+                                    uint8_t buffer[64],
+                                    uint8_t buffer_device[64]);

--- a/src/common/sskr/sss/sss.h
+++ b/src/common/sskr/sss/sss.h
@@ -44,6 +44,15 @@
  *                              - Other negative values may be returned by the `random_generator`
  *                                function.
  */
+// Upstream bc-sskr defines this in sss.c without declaring it anywhere. It is
+// declared here rather than in sss.c so that file stays diffable against
+// upstream: the only change on this side of the port is these four lines.
+uint8_t *sss_create_digest(const uint8_t *random_data,
+                           uint32_t rdlen,
+                           const uint8_t *shared_secret,
+                           uint32_t sslen,
+                           uint8_t *result);
+
 int16_t sss_split_secret(uint8_t threshold,
                          uint8_t share_count,
                          const uint8_t *secret,

--- a/src/nbgl/bip39_mnemonic.h
+++ b/src/nbgl/bip39_mnemonic.h
@@ -84,4 +84,13 @@ char *bip39_mnemonic_get(void);
  */
 size_t bip39_mnemonic_length_get(void);
 
+/*
+ * Drops the last `size` bytes of the mnemonic and erases everything from the
+ * new end to the end of the buffer, returning the new length. A `size` of 0, or
+ * one larger than the current length, drops everything. word_remove() is its
+ * only caller in the application; it is declared here so that the compiler
+ * checks that caller, the definition and the unit suite against one another.
+ */
+size_t bip39_mnemonic_shrink(const size_t size);
+
 #endif  // SCREEN_SIZE_WALLET

--- a/src/nbgl/sskr_shares.h
+++ b/src/nbgl/sskr_shares.h
@@ -100,4 +100,12 @@ char *sskr_shares_get(void);
  */
 size_t sskr_shares_length_get(void);
 
+/*
+ * The twin of bip39_mnemonic_shrink(), for the shares buffer: drops the last
+ * `size` bytes, erases everything from the new end to the end of the buffer,
+ * and returns the new length. A `size` of 0, or one larger than the current
+ * length, drops everything.
+ */
+size_t sskr_shares_shrink(const size_t size);
+
 #endif  // SCREEN_SIZE_WALLET

--- a/tests/unit/CMakeLists.txt
+++ b/tests/unit/CMakeLists.txt
@@ -31,25 +31,33 @@ set(CMAKE_C_STANDARD_REQUIRED True)
 # problem, a function with external linkage and no prototype at all, where
 # there is nothing for the compiler to compare a definition against.
 #
-# It is not at zero. Measured over a full build of this directory and
-# deduplicated by (file, function), it reports 21 as of this commit, 7 of them
-# in src/: one each in bip39/seed_bip39.c, common_seed.c, bip85/base64.c,
-# bip85/base85.c, sskr/sss/sss.c, nbgl/bip39_mnemonic.c and
-# nbgl/sskr_shares.c. It was 23 and 9 immediately before, the two extra being
-# bolos_ux_sskr_size_get() and bolos_ux_sskr_generate() in sskr/seed_sskr.c;
-# they now come from sskr/seed_sskr_internal.h, as the seventeen this comment
-# once listed in bip85/seed_bip85.c come from bip85/bip85_internal.h. That is
-# the pattern the rest should follow.
+# src/ is at zero, and the block below keeps it there. Measured over a full
+# build of this directory and deduplicated by (file, function), the flag
+# reported 23 two commits ago and 21 as of this one; every one of the
+# remaining 21 is in tests/, and none in src/.
 #
-# Making the remainder static is not the automatic answer: four of the seven
-# are reached by declarations written by hand in tests/unit/tests/
-# (compare_recovery_phrase_finish, base64_encode_64bytes,
-# base85_encode_64bytes, bip39_mnemonic_shrink), sss.c is kept diffable
-# against upstream bc-sskr, and
-# bolos_ux_bip39_mnemonic_to_seed_hash_length128() exists precisely to keep
-# the pbkdf2 frame off its caller's stack, which static would let the
-# compiler undo. They are left as warnings deliberately; the point of the
-# flag is that a *new* one shows up.
+# Getting there was not a matter of making anything static -- the flag asks
+# for a prototype, not for internal linkage, and every one of these functions
+# has a reason to keep external linkage. Each declaration went into the header
+# its own directory already had, which the defining file already included:
+#
+#   base64_encode_64bytes, base85_encode_64bytes  bip85/bip85_internal.h
+#   bolos_ux_bip39_..._hash_length128             bip39/common_bip39.h
+#   compare_recovery_phrase_finish                common.h
+#   sss_create_digest                             sskr/sss/sss.h
+#   bip39_mnemonic_shrink, sskr_shares_shrink     nbgl/*.h
+#
+# Five hand-written declarations went away with them -- three in tests, and
+# two in src/common/bip85/seed_bip85.c, which declared the two encoders with
+# `extern` for its own use. Those two were the point: a caller in the
+# application, a definition in another file, and nothing comparing them.
+#
+# tests/ is deliberately not held to this. Several test files define stubs
+# with external linkage that stand in for functions the target does not link
+# (bip39_mnemonic_get(), compare_recovery_phrase() and friends), and
+# testutils.c defines os_secure_memcmp() the same way. Giving those prototypes
+# would mean a header per set of stubs for no gain: nothing calls them across
+# translation units.
 #
 # -Wstrict-prototypes is already clean everywhere and is here as a ratchet.
 #
@@ -60,6 +68,21 @@ set(CMAKE_C_STANDARD_REQUIRED True)
 # overridden here, so they would not break that build -- they would just bury
 # the app's own diagnostics.
 set(CMAKE_C_FLAGS_DEBUG "${CMAKE_C_FLAGS_DEBUG} -Wall -Wmissing-prototypes -Wstrict-prototypes -pedantic -g -O0 --coverage")
+
+# Hold src/ at zero, rather than trusting the comment above to be re-read.
+# Promoting -Wmissing-prototypes to an error globally is not an option: the
+# tests deliberately define stubs with external linkage, and the SDK sources
+# pulled into some targets add their own. Scoping the error to the application
+# sources is what turns "the point of the flag is that a *new* one shows up"
+# into something the build enforces.
+#
+# The glob is read at build time, not just at configure time, so a new file
+# under src/ is covered without anyone remembering this block exists -- the
+# same reason the ctest registration at the end of this file reads the targets
+# rather than a list kept by hand.
+file(GLOB_RECURSE APP_SOURCES CONFIGURE_DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/../../src/*.c)
+set_source_files_properties(${APP_SOURCES} DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
+                            PROPERTIES COMPILE_OPTIONS "-Werror=missing-prototypes")
 
 set(GCC_COVERAGE_LINK_FLAGS "--coverage -lgcov")
 set(CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS} ${GCC_COVERAGE_LINK_FLAGS}")
@@ -521,6 +544,7 @@ target_include_directories(test_words PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/../../s
 target_link_libraries(test_words PUBLIC cmocka gcov testutils sskr sss)
 
 add_executable(test_base64 tests/base64.c ../../src/common/bip85/seed_rom_variables.c ../../src/common/bip85/base64.c)
+target_include_directories(test_base64 PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/../../src/common)
 target_link_libraries(test_base64 PUBLIC cmocka gcov)
 
 # Built with UndefinedBehaviorSanitizer, in abort mode: base85_encode_64bytes()
@@ -528,6 +552,7 @@ target_link_libraries(test_base64 PUBLIC cmocka gcov)
 # its top bit set. Nothing about the result is visibly wrong, so a value
 # assertion cannot see it -- the sanitizer is the assertion.
 add_executable(test_base85 tests/base85.c ../../src/common/bip85/seed_rom_variables.c ../../src/common/bip85/base85.c)
+target_include_directories(test_base85 PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/../../src/common)
 target_compile_options(test_base85 PRIVATE -fsanitize=undefined -fno-sanitize-recover=all)
 target_link_options(test_base85 PRIVATE -fsanitize=undefined)
 target_link_libraries(test_base85 PUBLIC cmocka gcov)

--- a/tests/unit/tests/base64.c
+++ b/tests/unit/tests/base64.c
@@ -4,7 +4,7 @@
 #include <setjmp.h>
 #include <cmocka.h>
 
-extern uint8_t base64_encode_64bytes(const uint8_t* src, char* dst);
+#include "bip85/bip85_internal.h"
 
 const uint8_t base64_input[] = {
     0x74, 0xa2, 0xe8, 0x7a, 0x9b, 0xa0, 0xcd, 0xd5, 

--- a/tests/unit/tests/base85.c
+++ b/tests/unit/tests/base85.c
@@ -4,7 +4,7 @@
 #include <setjmp.h>
 #include <cmocka.h>
 
-extern uint8_t base85_encode_64bytes(const uint8_t* src, char* dst);
+#include "bip85/bip85_internal.h"
 
 const uint8_t base85_input[] = {
     0xf7, 0xcf, 0xe5, 0x6f, 0x63, 0xdc, 0xa2, 0x49, 

--- a/tests/unit/tests/bip39_entry_bounds.c
+++ b/tests/unit/tests/bip39_entry_bounds.c
@@ -56,13 +56,6 @@ bool compare_recovery_phrase(bool* reconstructed) {
     fail_msg("not on the entry path");
 }
 
-/*
- * bip39_mnemonic_shrink() is external but not declared in bip39_mnemonic.h --
- * word_remove() is its only caller today. Declared here rather than added to
- * the header, which would mean touching src/ for a test's sake.
- */
-size_t bip39_mnemonic_shrink(const size_t size);
-
 #define BIP39_WORDLIST_SIZE (BIP39_WORDLIST_OFFSETS_LENGTH - 1)
 
 /*

--- a/tests/unit/tests/compare_recovery_phrase_finish.c
+++ b/tests/unit/tests/compare_recovery_phrase_finish.c
@@ -17,9 +17,7 @@
 #include <stdint.h>
 #include <string.h>
 
-extern bool compare_recovery_phrase_finish(cx_err_t derivation_status,
-                                           uint8_t buffer[64],
-                                           uint8_t buffer_device[64]);
+#include "common.h"
 
 static void assert_all_zero(const uint8_t* data, size_t len) {
     for (size_t i = 0; i < len; i++) {

--- a/tests/unit/tests/sskr_entry_bounds.c
+++ b/tests/unit/tests/sskr_entry_bounds.c
@@ -122,10 +122,59 @@ static void test_entry_counter_never_folds_back(void **state)
     }
 }
 
+/* Nothing from `from` to the end of the shares buffer may survive a shrink. */
+static void assert_erased_from(size_t from) {
+    const char* buffer = sskr_shares_get();
+
+    for (size_t i = from; i < SSKR_SHARES_MAX_LENGTH; i++) {
+        assert_int_equal(buffer[i], 0);
+    }
+}
+
+/*
+ * sskr_shares_shrink() is the exact twin of bip39_mnemonic_shrink(), which
+ * bip39_entry_bounds.c already covers with these three cases; the shares half
+ * had none. It is what erases entered data when the user backs out of a word,
+ * so each of the three ways of asking for it -- part of the buffer, all of it
+ * via a size of 0, all of it via an over-large size -- has to leave the tail
+ * zeroed and the length consistent with what was kept.
+ *
+ * Unlike the BIP39 buffer, which holds the words as text, this one holds one
+ * decoded byte per ByteWord, so a word is one byte here and there is no
+ * separator.
+ */
+static void test_shrink_erases_what_it_drops(void** state) {
+    (void)state;
+
+    /* Partial removal: the tail goes, the head stays. */
+    sskr_shares_reset();
+    sskr_shares_word_add(word_for(0x11));
+    sskr_shares_word_add(word_for(0x42));
+    assert_int_equal(sskr_shares_length_get(), 2);
+
+    assert_int_equal(sskr_shares_shrink(1), 1);
+    assert_int_equal(sskr_shares_length_get(), 1);
+    assert_int_equal((uint8_t)sskr_shares_get()[0], 0x11);
+    assert_erased_from(1);
+
+    /* size == 0: erase all. */
+    assert_int_equal(sskr_shares_shrink(0), 0);
+    assert_int_equal(sskr_shares_length_get(), 0);
+    assert_erased_from(0);
+
+    /* size > length: erase all, without wrapping the length around. */
+    sskr_shares_reset();
+    sskr_shares_word_add(word_for(0x42));
+    assert_int_equal(sskr_shares_shrink(sskr_shares_length_get() + 1), 0);
+    assert_int_equal(sskr_shares_length_get(), 0);
+    assert_erased_from(0);
+}
+
 int main(void)
 {
     const struct CMUnitTest tests[] = {
         cmocka_unit_test(test_entry_counter_never_folds_back),
+        cmocka_unit_test(test_shrink_erases_what_it_drops),
     };
     return cmocka_run_group_tests(tests, NULL, NULL);
 }


### PR DESCRIPTION
`-Wmissing-prototypes` went into `tests/unit/CMakeLists.txt` for a defect the suite could not otherwise see: a function whose definition contradicts the declaration its callers use, in a file that never includes a header declaring it. The comment there has said since it went in that "the point of the flag is that a *new* one shows up" — while carrying a list of the ones already there, in `src/`, left as warnings.

This takes `src/` to zero and makes the build keep it there.

## The one that was not hygiene

`src/common/bip85/seed_bip85.c` reached the two BIP-85 password encoders through declarations written by hand:

```c
extern uint8_t base64_encode_64bytes(const uint8_t* src, char* dst);
extern uint8_t base85_encode_64bytes(const uint8_t* src, char* dst);
```

The definitions are in `base64.c` and `base85.c`, neither of which included a header declaring them. No translation unit saw both, so nothing compared the two — and this is not a test's convenience: it is how the application itself calls the functions that turn BIP-85 entropy into a password. `tests/base64.c` and `tests/base85.c` each carried a third unchecked copy.

`bip85_internal.h` already existed for exactly this, and `seed_bip85.c` already included it, so the declarations move there and all four hand-written copies go. `base64.c` and `base85.c` gain the include, which is what puts a compiler in a position to check them.

**Mutation.** Declaring `base64_encode_64bytes()` as returning `uint16_t` in the header now stops the build:

```
src/common/bip85/base64.c:31:9: error: conflicting types for 'base64_encode_64bytes';
  have 'uint8_t(const uint8_t *, char *)'
```

Before, the same disagreement between `seed_bip85.c` and `base64.c` compiled without a word.

## The other five

A prototype each, in the header their own directory already had — and which the file defining them already included, so five of the six changes are one line in a header and nothing else:

| function | header |
|---|---|
| `base64_encode_64bytes`, `base85_encode_64bytes` | `bip85/bip85_internal.h` |
| `bolos_ux_bip39_mnemonic_to_seed_hash_length128` | `bip39/common_bip39.h` |
| `compare_recovery_phrase_finish` | `common.h` |
| `sss_create_digest` | `sskr/sss/sss.h` |
| `bip39_mnemonic_shrink` | `nbgl/bip39_mnemonic.h` |
| `sskr_shares_shrink` | `nbgl/sskr_shares.h` |

Two more hand-written declarations in `tests/unit/tests/` go with them.

**Making any of these `static` was never what the flag was asking for.** It asks for a prototype; each of the six has a reason to keep external linkage, and a declaration takes nothing away from that. `bolos_ux_bip39_mnemonic_to_seed_hash_length128()` is out of line precisely so its locals stay off the pbkdf2 caller's frame — an argument against `static`, not against a prototype.

Two notes on the ones that looked expensive and were not:

- `sss.c` is kept diffable against upstream bc-sskr, which is why `sss_create_digest()` had been left alone. It already includes `sss.h`, so the declaration lands in the header and **that file is not touched at all**.
- `bip39_entry_bounds.c` declared `bip39_mnemonic_shrink()` by hand rather than adding it to the header, on the grounds that doing so "would mean touching `src/` for a test's sake". Fair at the time; the reason to add it now is not the test, it is that nothing was checking the definition against the declaration.

## A missing test, found on the way

`sskr_shares_shrink()` is the exact twin of `bip39_mnemonic_shrink()` — same body, same role, one per entry buffer — and it is what erases entered data when the user backs out of a word. Only the BIP-39 half was covered.

`test_sskr_entry_bounds` gains the mirror of the three cases `bip39_entry_bounds.c` already had: a partial shrink, a shrink of 0, and a shrink larger than the buffer holds, each checked for a zeroed tail and a length consistent with what was kept. That target already compiles `sskr_shares.c`, so it needs no new target — `ctest` stays at 52.

The shares buffer holds one decoded byte per ByteWord rather than the words as text, so the arithmetic differs from its twin even though the function does not.

**Mutation.** Removing the `memzero()` from `sskr_shares_shrink()` turns the new test red, and nothing else in the suite.

## Holding it there

A comment that has to be re-read is not a ratchet. With `src/` at zero, the flag is promoted to an error for the application sources only:

```cmake
file(GLOB_RECURSE APP_SOURCES CONFIGURE_DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/../../src/*.c)
set_source_files_properties(${APP_SOURCES} DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
                            PROPERTIES COMPILE_OPTIONS "-Werror=missing-prototypes")
```

Globally is not an option: several test files define stubs with external linkage on purpose (`bip39_mnemonic_get()`, `compare_recovery_phrase()` and friends), `testutils.c` defines `os_secure_memcmp()` the same way, and the SDK sources compiled into some targets add their own. `tests/` is deliberately left as warnings, all 21 of them, and the comment now says why rather than listing them.

The glob is read at build time, so a new file under `src/` is covered without anyone remembering the block exists — the same reason the `ctest` registration at the end of that file reads the targets rather than a list kept by hand.

**Mutation.** A function with external linkage and no prototype, added to `base64.c`:

```
src/common/bip85/base64.c:57:9: error: no previous prototype for
  'ratchet_probe_no_prototype' [-Werror=missing-prototypes]
make[2]: *** [CMakeFiles/test_base64.dir/.../base64.c.o] Error 1
```

That is the only thing that distinguishes an armed ratchet from a configured one.

## Verification

Figures measured over a full build of `tests/unit`, deduplicated by (file, function), not derived: **23 before the previous change, 21 now**, none of the 21 in `src/`.

`ctest`: **52 targets, 52 green.** No new target.

All six targets of `ledger_app.toml` build, and every binary is byte-for-byte the same size as before — no code changed, only declarations it already satisfied:

| target | text | bss | delta |
|---|---|---|---|
| nanos | 32008 | 3708 | 0 |
| nanox | 46136 | 28672 | 0 |
| nanos+ | 46152 | 40960 | 0 |
| stax | 72305 | 36864 | 0 |
| flex | 72845 | 36864 | 0 |
| apex_p | 69233 | 40960 | 0 |

`clang-format --dry-run -Werror` is clean on every touched file except `tests/base64.c`, `tests/base85.c` and `tests/sskr_entry_bounds.c`, which are already non-conformant on the base: **18 violations each before, 18 after, none added**. The new test block follows `clang-format` rather than the local style of the file it sits in; those three files are not reformatted here, to keep this diff readable.

The Speculos scripts are not involved.
