### PR TITLE
fix: run the work Nano S defers, so its seed check can finish

### DIFF
--- a/src/bagl/nanos_enter_phrase.c
+++ b/src/bagl/nanos_enter_phrase.c
@@ -19,6 +19,10 @@
 #include <os_io_seproxyhal.h>
 
 #include "constants.h"
+// For app_ticker_event_callback()'s declaration: defining it below without one
+// would leave nothing to check the definition against, since the SDK calls it
+// through its own declaration.
+#include "io.h"
 #include "ui.h"
 
 #ifdef TARGET_NANOS
@@ -90,6 +94,41 @@ UX_STEP_NOCB_POSTINIT(processing_step, pb,
 UX_FLOW(processing_flow, &processing_step);
 
 void screen_processing_init(void) { ux_flow_init(0, processing_flow, NULL); }
+
+// Runs whatever the entry screens deferred once the "Processing" screen above
+// is up. Nano S is the only target that defers: comparing an entered phrase
+// against the device seed, and generating SSKR shares, both block for seconds,
+// and the other BAGL targets simply call them inline (see
+// nanox_enter_phrase.c) because their screens are driven differently. Here the
+// work has to wait until the screen the user is looking at has been painted,
+// or they would stare at the previous one throughout.
+//
+// The ticker is the hook the SDK offers an application for this
+// (app_ticker_event_callback() is WEAK in lib_standard_app/io.c, called on
+// SEPROXYHAL_TAG_TICKER_EVENT before UX_TICKER_EVENT). The event this used to
+// hang off, SEPROXYHAL_TAG_DISPLAY_PROCESSED_EVENT, is handled inside the
+// SDK's io_event() with no callback of its own, and taking it back would mean
+// the application re-implementing that whole function.
+//
+// `processing` is cleared before the work runs, not after: these calls block
+// for long enough that further ticker events are queued behind them, and a
+// second pass would compare the phrase, or generate the shares, twice.
+void app_ticker_event_callback(void) {
+    const uint8_t deferred = G_bolos_ux_context.processing;
+
+    G_bolos_ux_context.processing = PROCESSING_COMPLETE;
+
+    switch (deferred) {
+        case PROCESSING_COMPARE_RECOVERY_PHRASE:
+            compare_recovery_phrase_and_display_result();
+            break;
+        case PROCESSING_GENERATE_SSKR:
+            generate_sskr();
+            break;
+        default:
+            break;
+    }
+}
 
 unsigned int screen_onboarding_restore_word_select_button(
     unsigned int button_mask, unsigned int button_mask_counter);


### PR DESCRIPTION
On Nano S, entering a recovery phrase or a set of SSKR shares leaves the user on the "Processing" screen for good. The comparison against the device seed never runs, and neither does SSKR share generation.

## What happens

The end of entry does not do the work. It shows the screen and records what to do next:

```c
screen_processing_init();
G_bolos_ux_context.processing = PROCESSING_COMPARE_RECOVERY_PHRASE;
```

**Nothing reads that field.** "Refactor app_main.c" replaced this application's event loop with the SDK's standard one, and the block that consumed it went with the old loop:

```c
-  if (G_bolos_ux_context.processing == PROCESSING_COMPARE_RECOVERY_PHRASE) {
-      UX_DISPLAYED_EVENT(compare_recovery_phrase_and_display_result(););
-  } else if (G_bolos_ux_context.processing == PROCESSING_GENERATE_SSKR) {
-      UX_DISPLAYED_EVENT(generate_sskr(););
```

Both deferred actions lost their only trigger. `G_bolos_ux_context` is this application's own global (`bagl/ux_nano.c`), so nothing else can read the field, and it is still set from three places that all run: BIP-39 and SSKR entry (`bagl/nanos_enter_phrase.c`, in `screen_onboarding_restore_word_validate()`) and SSKR generation (`bagl/ux_sskr.c`, whose direct `generate_sskr()` call sits in the `#else` branch and so is not taken here).

The linker says the same thing more plainly. With no caller, the whole chain is stripped from the binary:

```
build/nanos/bin/app.elf, before:
  screen_processing_init                        PRESENT
  compare_recovery_phrase                       ABSENT
  compare_recovery_phrase_finish                ABSENT
  bolos_ux_bip39_mnemonic_to_seed               ABSENT
  bolos_ux_sskr_combine / sskr_combine_shards   ABSENT
  sss_recover_secret                            ABSENT
  interpolate / cx_bn_gf2_n_mul                 ABSENT
  generate_sskr                                 ABSENT
```

That is **8576 bytes of code, a quarter of the target's text**, missing from a build that still links the "Processing" screen promising it.

## Where the trigger belongs

Why this work is deferred on Nano S and called inline on the other BAGL targets (`nanox_enter_phrase.c`) decides where to put the trigger back, so it is worth being exact.

It is **not** about getting the screen painted. `HAVE_SE_SCREEN` is defined on Nano S, so `ux_flow_init()` paints synchronously and the screen is already up by the time `screen_processing_init()` returns.

It is about **stack**. Nano S has 4K+512 of SRAM in total, and the map leaves **1924 bytes** of it for the stack. Measured with `-fstack-usage`, the deferred work alone peaks at about **1072 bytes** on the shallowest path:

| frame | bytes |
|---|---|
| `io_event` | 120 |
| this callback | 24 |
| `compare_recovery_phrase_and_display_result` | 24 |
| `compare_recovery_phrase` | 552 |
| `bolos_ux_bip39_mnemonic_to_seed` | 328 |
| its pbkdf2 helper | 24 |

More than half the budget, before any SDK syscall frame underneath — which is also why that pbkdf2 helper exists as a separate out-of-line function in the first place. Running the work from the entry screens instead would stack the button and keyboard dispatch on top of that.

## The fix

`lib_standard_app` offers an application one hook that unwinds the entry chain first: `app_ticker_event_callback()`, `WEAK` in `io.c` and called on `SEPROXYHAL_TAG_TICKER_EVENT` before `UX_TICKER_EVENT`. This defines it, for `TARGET_NANOS` only, and dispatches on the field the entry screens already set.

Two alternatives were considered and rejected:

- **`SEPROXYHAL_TAG_DISPLAY_PROCESSED_EVENT`**, which the removed code hung off, is handled inside the SDK's `io_event()` with no callback of its own. Reclaiming it means this application re-implementing that whole function — which is what the refactor removed.
- **`G_ux.stack[].displayed_callback`**, which `ux_stack.c` invokes exactly when every element of a screen has been painted, is the closest match to the old semantics, and `ux_flow_engine.c` leaves the field free. But under `HAVE_SE_SCREEN` it fires synchronously inside `screen_processing_init()`, still nested in the button and keyboard call chain, so it would buy back none of the stack that is the reason for deferring at all.

The resulting depth is close to what it was before the regression: the old trigger ran from the application's own `io_event`, this one from the SDK's, one frame deeper.

`processing` is cleared before the work runs, not after: these calls block long enough that further ticker events queue behind them, and a second pass would compare the phrase, or generate the shares, twice. At boot the field is zero — it lives in BSS and `PROCESSING_COMPLETE` is 0 — so the tickers that arrive before any entry fall through to `default`.

`lib_standard_app/io.h` is included for the declaration of the callback being defined. Neither `os_io_seproxyhal.h` nor this application's `ui.h` reaches it, so without that include there would be nothing to check the definition against while the SDK calls it through its own declaration — the one arrangement this repository has just finished removing everywhere else under `src/`.

## Verification

Against the binary rather than by reading, because nothing else is available: **speculos dropped Nano S** (its `--model` takes `nanox`, `nanosp`, `stax`, `flex`, `apex_p`) and nanos was removed from the CI workflow. Those two together are how this survived.

All six targets of `ledger_app.toml` build. `nanos` goes from **32008 to 40584** bytes of text, BSS unchanged at 3708, and every symbol listed above comes back. The other five binaries are byte-for-byte the same size: nanox 46136/28672, nanos+ 46152/40960, stax 72305/36864, flex 72845/36864, apex_p 69233/40960.

The map confirms the `WEAK` override resolves the intended way: the SDK's empty two-byte `app_ticker_event_callback` (`obj/sdk/lib_standard_app/io.o`) is in the discarded sections, and the surviving definition comes from `obj/app/src/bagl/nanos_enter_phrase.o`.

**Verified by mutation, twice.** Emptying the dispatch takes `nanos` straight back to 32008 bytes with the whole chain stripped again — the same before-and-after the defect itself produced. Declaring the callback as returning `int` now fails the build:

```
src/bagl/nanos_enter_phrase.c:116:5: error: conflicting types for 'app_ticker_event_callback'
```

which is what the `io.h` include buys, and what nothing would have caught without it.

The unit suite does not reach any of this — no target compiles `src/bagl` — and stays at 52 targets, all green. `clang-format --dry-run -Werror` is clean on the touched file.

## What is not verified

The behaviour on a device. There is no emulator for this target, so the end-to-end flow is not exercised anywhere; everything above is binary, map and `-fstack-usage` evidence plus reading.

The stack figures are static frame sums along the paths traced, and exclude the SDK syscall frames below `cx_pbkdf2_sha512`, so the true peak is higher than 1072 and the headroom smaller than the difference suggests. That budget is not made worse by this change — it is the same work on a path of the same depth as before the regression — but it is worth knowing how little of it there is.
