### PR TITLE
refactor: read a share's CBOR header in one place while it is entered

### DIFF
--- a/src/bagl/nanos_enter_phrase.c
+++ b/src/bagl/nanos_enter_phrase.c
@@ -414,77 +414,14 @@ void screen_onboarding_restore_word_validate(void) {
             .sskr_words_buffer[G_bolos_ux_context.sskr_words_buffer_length] =
             G_bolos_ux_context.onboarding_index +
             G_bolos_ux_context.hslider3_current;
-        switch (G_bolos_ux_context.onboarding_step) {
-            // 4th byte of CBOR header contains number of data bytes to follow
-            case 3:
-                if ((G_bolos_ux_context.sskr_words_buffer
-                         [G_bolos_ux_context.sskr_words_buffer_length] &
-                     0x1F) <= 24) {
-                    // SSKR bytes = 4 bytes CBOR + n bytes share + 4 bytes CRC
-                    // checksum. This is only a literal length for 0-23; 24
-                    // (one length byte follows) is corrected below once that
-                    // byte is read.
-                    G_bolos_ux_context.bip39_type =
-                        4 +
-                        (G_bolos_ux_context.sskr_words_buffer
-                             [G_bolos_ux_context.sskr_words_buffer_length] &
-                         0x1F) +
-                        sizeof(uint32_t);
-                } else {
-                    // 25-31 are reserved CBOR additional-info values
-                    // (two/four/eight-byte length, reserved, or indefinite
-                    // length) with no literal length of their own -- there is
-                    // nothing valid to compute here. Force the same maximum
-                    // bound used below for an out-of-range declared length,
-                    // so entry can still complete and
-                    // bolos_ux_sskr_hex_check() rejects it, instead of
-                    // treating the reserved value as if it encoded a
-                    // 25-to-31-byte payload.
-                    G_bolos_ux_context.bip39_type = SSKR_SHARE_MAX_WIRE_LENGTH;
-                }
-                break;
-            case 4:
-                if ((G_bolos_ux_context.sskr_words_buffer[3] & 0x1F) == 24) {
-                    // Read the declared length as the unsigned wire byte it is.
-                    G_bolos_ux_context.bip39_type =
-                        4 + 1 +
-                        (uint8_t)G_bolos_ux_context.sskr_words_buffer
-                            [G_bolos_ux_context.sskr_words_buffer_length] +
-                        sizeof(uint32_t);
-                    // A serialized shard is SSKR_METADATA_LENGTH_BYTES plus a
-                    // value of at most SSKR_MAX_STRENGTH_BYTES, so no share
-                    // can be longer than this on the wire.
-                    if (G_bolos_ux_context.bip39_type >
-                        SSKR_SHARE_MAX_WIRE_LENGTH) {
-                        G_bolos_ux_context.bip39_type =
-                            SSKR_SHARE_MAX_WIRE_LENGTH;
-                    }
-                }
-                PRINTF("SSKR number of words: %d\n",
-                       G_bolos_ux_context.bip39_type);
-                break;
-            // 8th byte of SSKR phrase contains member-threshold
-            case 7:
-                if ((G_bolos_ux_context.sskr_words_buffer[3] & 0x1F) < 24) {
-                    G_bolos_ux_context.sskr_share_count =
-                        (G_bolos_ux_context.sskr_words_buffer
-                             [G_bolos_ux_context.sskr_words_buffer_length] &
-                         0x0F) +
-                        1;
-                }
-                break;
-            case 8:
-                if ((G_bolos_ux_context.sskr_words_buffer[3] & 0x1F) == 24) {
-                    G_bolos_ux_context.sskr_share_count =
-                        (G_bolos_ux_context.sskr_words_buffer
-                             [G_bolos_ux_context.sskr_words_buffer_length] &
-                         0x0F) +
-                        1;
-                }
-                PRINTF("SSKR member threshold: %d\n",
-                       G_bolos_ux_context.sskr_share_count);
-                break;
-        }
+        size_t final_size = G_bolos_ux_context.bip39_type;
+        bolos_ux_sskr_entry_header_update(
+            (const uint8_t*)G_bolos_ux_context.sskr_words_buffer,
+            G_bolos_ux_context.sskr_words_buffer_length,
+            G_bolos_ux_context.onboarding_step, &final_size,
+            &G_bolos_ux_context.sskr_share_count);
+        G_bolos_ux_context.bip39_type = (unsigned int)final_size;
+
         G_bolos_ux_context.sskr_words_buffer_length++;
     }
 

--- a/src/bagl/nanox_enter_phrase.c
+++ b/src/bagl/nanox_enter_phrase.c
@@ -387,77 +387,14 @@ void screen_onboarding_restore_word_validate(void) {
             .sskr_words_buffer[G_bolos_ux_context.sskr_words_buffer_length] =
             G_bolos_ux_context.onboarding_index +
             G_bolos_ux_context.hslider3_current;
-        switch (G_bolos_ux_context.onboarding_step) {
-            // 4th byte of CBOR header contains number of data bytes to follow
-            case 3:
-                if ((G_bolos_ux_context.sskr_words_buffer
-                         [G_bolos_ux_context.sskr_words_buffer_length] &
-                     0x1F) <= 24) {
-                    // SSKR bytes = 4 bytes CBOR + n bytes share + 4 bytes CRC
-                    // checksum. This is only a literal length for 0-23; 24
-                    // (one length byte follows) is corrected below once that
-                    // byte is read.
-                    G_bolos_ux_context.bip39_type =
-                        4 +
-                        (G_bolos_ux_context.sskr_words_buffer
-                             [G_bolos_ux_context.sskr_words_buffer_length] &
-                         0x1F) +
-                        sizeof(uint32_t);
-                } else {
-                    // 25-31 are reserved CBOR additional-info values
-                    // (two/four/eight-byte length, reserved, or indefinite
-                    // length) with no literal length of their own -- there is
-                    // nothing valid to compute here. Force the same maximum
-                    // bound used below for an out-of-range declared length,
-                    // so entry can still complete and
-                    // bolos_ux_sskr_hex_check() rejects it, instead of
-                    // treating the reserved value as if it encoded a
-                    // 25-to-31-byte payload.
-                    G_bolos_ux_context.bip39_type = SSKR_SHARE_MAX_WIRE_LENGTH;
-                }
-                break;
-            case 4:
-                if ((G_bolos_ux_context.sskr_words_buffer[3] & 0x1F) == 24) {
-                    // Read the declared length as the unsigned wire byte it is.
-                    G_bolos_ux_context.bip39_type =
-                        4 + 1 +
-                        (uint8_t)G_bolos_ux_context.sskr_words_buffer
-                            [G_bolos_ux_context.sskr_words_buffer_length] +
-                        sizeof(uint32_t);
-                    // A serialized shard is SSKR_METADATA_LENGTH_BYTES plus a
-                    // value of at most SSKR_MAX_STRENGTH_BYTES, so no share
-                    // can be longer than this on the wire.
-                    if (G_bolos_ux_context.bip39_type >
-                        SSKR_SHARE_MAX_WIRE_LENGTH) {
-                        G_bolos_ux_context.bip39_type =
-                            SSKR_SHARE_MAX_WIRE_LENGTH;
-                    }
-                }
-                PRINTF("SSKR number of words: %d\n",
-                       G_bolos_ux_context.bip39_type);
-                break;
-            // 8th byte of SSKR phrase contains member-threshold
-            case 7:
-                if ((G_bolos_ux_context.sskr_words_buffer[3] & 0x1F) < 24) {
-                    G_bolos_ux_context.sskr_share_count =
-                        (G_bolos_ux_context.sskr_words_buffer
-                             [G_bolos_ux_context.sskr_words_buffer_length] &
-                         0x0F) +
-                        1;
-                }
-                break;
-            case 8:
-                if ((G_bolos_ux_context.sskr_words_buffer[3] & 0x1F) == 24) {
-                    G_bolos_ux_context.sskr_share_count =
-                        (G_bolos_ux_context.sskr_words_buffer
-                             [G_bolos_ux_context.sskr_words_buffer_length] &
-                         0x0F) +
-                        1;
-                }
-                PRINTF("SSKR member threshold: %d\n",
-                       G_bolos_ux_context.sskr_share_count);
-                break;
-        }
+        size_t final_size = G_bolos_ux_context.bip39_type;
+        bolos_ux_sskr_entry_header_update(
+            (const uint8_t*)G_bolos_ux_context.sskr_words_buffer,
+            G_bolos_ux_context.sskr_words_buffer_length,
+            G_bolos_ux_context.onboarding_step, &final_size,
+            &G_bolos_ux_context.sskr_share_count);
+        G_bolos_ux_context.bip39_type = (unsigned int)final_size;
+
         G_bolos_ux_context.sskr_words_buffer_length++;
     }
 

--- a/src/common/sskr/common_sskr.h
+++ b/src/common/sskr/common_sskr.h
@@ -27,6 +27,42 @@
 // and the CRC32. Nothing longer can be a share, whatever its header declares.
 #define SSKR_SHARE_MAX_WIRE_LENGTH (5 + SSKR_METADATA_LENGTH_BYTES + SSKR_MAX_STRENGTH_BYTES + 4)
 
+// Read what the CBOR header of a share being entered says about that share,
+// one entered byte at a time.
+//
+// The UI layers append one byte per ByteWord to a buffer and, at four fixed
+// positions in the share, take the expected total length and the share count
+// out of the bytes just entered. This is that arithmetic, in one place: the
+// three entry paths (nbgl/sskr_shares.c, bagl/nanox_enter_phrase.c and
+// bagl/nanos_enter_phrase.c) all called it, in three copies of the same
+// switch, none of which a unit test could reach except the first.
+//
+// `buffer` holds the bytes entered since the buffer was last reset, `index` is
+// the position of the byte this ByteWord just wrote, and `word_number` is how
+// many words of the *current* share had already been entered before it -- so 3
+// for the fourth byte of the share, which is where the byte-string header
+// sits. The two are only equal while the first share is being entered: for
+// later shares `word_number` restarts at 0 and `index` keeps counting, which
+// is also why the byte-string header this reads at `buffer[3]` is the one of
+// the *first* share entered. Every share in a set has the same shape, so the
+// two agree; this preserves what the three copies did rather than changing it.
+//
+// The bytes are read through a `const uint8_t *` because the callers hold them
+// in a `char` buffer, and `char` is signed on the host that builds the unit
+// tests and unsigned on the device.
+//
+// `*final_size` and `*count` are left as they are wherever the entered header
+// says nothing about them: at any `word_number` other than the four below, and
+// at the positions whose form of length is not the one the header declared.
+// Callers rely on that -- reserved additional-info values deliberately leave
+// the share count at whatever it was, which is what makes the completed share
+// fail bolos_ux_sskr_hex_check().
+void bolos_ux_sskr_entry_header_update(const uint8_t *buffer,
+                                       size_t index,
+                                       size_t word_number,
+                                       size_t *final_size,
+                                       uint8_t *count);
+
 // Encode SSKR ByteWord as hex. Returns false, without writing to *value, if
 // the ByteWord is not in the wordlist.
 bool bolos_ux_sskr_byteword_to_hex(const unsigned char *byteword, uint8_t *value);

--- a/src/common/sskr/sskr_entry_header.c
+++ b/src/common/sskr/sskr_entry_header.c
@@ -1,0 +1,78 @@
+/*******************************************************************************
+ *   Ledger Seed Tool application
+ *   (c) 2016-2026 Ledger SAS
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ ********************************************************************************/
+
+#include <os.h>
+
+#include "./common_sskr.h"
+
+// See common_sskr.h for the contract. This is the arithmetic the three word
+// entry paths -- nbgl/sskr_shares.c, bagl/nanox_enter_phrase.c and
+// bagl/nanos_enter_phrase.c -- each used to carry a copy of.
+void bolos_ux_sskr_entry_header_update(const uint8_t* buffer, size_t index,
+                                       size_t word_number, size_t* final_size,
+                                       uint8_t* count) {
+    switch (word_number) {
+        // 4th byte of CBOR header contains number of data bytes to follow
+        case 3:
+            if ((buffer[index] & 0x1F) <= 24) {
+                // SSKR bytes = 4 bytes CBOR + n bytes share + 4 bytes CRC
+                // checksum. This is only a literal length for 0-23; 24 (one
+                // length byte follows) is corrected below once that byte is
+                // read.
+                *final_size = 4 + (buffer[index] & 0x1F) + sizeof(uint32_t);
+            } else {
+                // 25-31 are reserved CBOR additional-info values (two/four/
+                // eight-byte length, reserved, or indefinite length) with no
+                // literal length of their own -- there is nothing valid to
+                // compute here. Force the same maximum bound used below for an
+                // out-of-range declared length, so entry can still complete
+                // and bolos_ux_sskr_hex_check() rejects it, instead of
+                // treating the reserved value as if it encoded a
+                // 25-to-31-byte payload.
+                *final_size = SSKR_SHARE_MAX_WIRE_LENGTH;
+            }
+            break;
+        case 4:
+            if ((buffer[3] & 0x1F) == 24) {
+                // The declared length is read as the unsigned wire byte it is:
+                // callers hold the entered bytes in a `char` buffer, and
+                // `char` is signed on the host that builds the unit tests and
+                // unsigned on the device.
+                *final_size = 4 + 1 + buffer[index] + sizeof(uint32_t);
+                // A serialized shard is SSKR_METADATA_LENGTH_BYTES plus a
+                // value of at most SSKR_MAX_STRENGTH_BYTES, so no share can be
+                // longer than this on the wire.
+                if (*final_size > SSKR_SHARE_MAX_WIRE_LENGTH) {
+                    *final_size = SSKR_SHARE_MAX_WIRE_LENGTH;
+                }
+            }
+            PRINTF("SSKR number of words: %u\n", (unsigned int)*final_size);
+            break;
+        // 8th byte of SSKR phrase contains member-threshold
+        case 7:
+            if ((buffer[3] & 0x1F) < 24) {
+                *count = (buffer[index] & 0x0F) + 1;
+            }
+            break;
+        case 8:
+            if ((buffer[3] & 0x1F) == 24) {
+                *count = (buffer[index] & 0x0F) + 1;
+            }
+            PRINTF("SSKR member threshold: %u\n", (unsigned int)*count);
+            break;
+    }
+}

--- a/src/nbgl/sskr_shares.c
+++ b/src/nbgl/sskr_shares.c
@@ -90,58 +90,10 @@ size_t sskr_shares_word_add(const char* const byteword) {
         return sskr_shares_current_word_number_get();
     }
     shares.buffer[shares.length] = (char)value;
-    switch (sskr_shares_current_word_number_get()) {
-        // 4th byte of CBOR header contains number of data bytes to follow
-        case 3:
-            if ((shares.buffer[shares.length] & 0x1F) <= 24) {
-                // SSKR bytes = 4 bytes CBOR + n bytes share + 4 bytes CRC
-                // checksum. This is only a literal length for 0-23; 24 (one
-                // length byte follows) is corrected below once that byte is
-                // read.
-                shares.final_size = 4 + (shares.buffer[shares.length] & 0x1F) +
-                                    sizeof(uint32_t);
-            } else {
-                // 25-31 are reserved CBOR additional-info values (two/four/
-                // eight-byte length, reserved, or indefinite length) with no
-                // literal length of their own -- there is nothing valid to
-                // compute here. Force the same maximum bound used below for
-                // an out-of-range declared length, so entry can still
-                // complete and bolos_ux_sskr_hex_check() rejects it, instead
-                // of treating the reserved value as if it encoded a
-                // 25-to-31-byte payload.
-                shares.final_size = SSKR_SHARE_MAX_WIRE_LENGTH;
-            }
-            break;
-        case 4:
-            if ((shares.buffer[3] & 0x1F) == 24) {
-                // Read the declared length as the unsigned wire byte it is:
-                // `char` is signed on the host that builds the unit tests and
-                // unsigned on the device.
-                shares.final_size = 4 + 1 +
-                                    (uint8_t)shares.buffer[shares.length] +
-                                    sizeof(uint32_t);
-                // A serialized shard is SSKR_METADATA_LENGTH_BYTES plus a
-                // value of at most SSKR_MAX_STRENGTH_BYTES, so no share can be
-                // longer than this on the wire.
-                if (shares.final_size > SSKR_SHARE_MAX_WIRE_LENGTH) {
-                    shares.final_size = SSKR_SHARE_MAX_WIRE_LENGTH;
-                }
-            }
-            PRINTF("SSKR final number of words in this share: %d\n",
-                   shares.final_size);
-            break;
-        // 8th byte of SSKR phrase contains member-threshold
-        case 7:
-            if ((shares.buffer[3] & 0x1F) < 24) {
-                shares.count = (shares.buffer[shares.length] & 0x0F) + 1;
-            }
-            break;
-        case 8:
-            if ((shares.buffer[3] & 0x1F) == 24) {
-                shares.count = (shares.buffer[shares.length] & 0x0F) + 1;
-            }
-            break;
-    }
+    bolos_ux_sskr_entry_header_update((const uint8_t*)shares.buffer,
+                                      shares.length,
+                                      sskr_shares_current_word_number_get(),
+                                      &shares.final_size, &shares.count);
     shares.length++;
     shares.current_word_index++;
 

--- a/tests/unit/CMakeLists.txt
+++ b/tests/unit/CMakeLists.txt
@@ -532,7 +532,7 @@ add_executable(test_roundtrip ./tests/roundtrip.c ../../src/common/bip39/seed_ro
 target_include_directories(test_roundtrip PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/../../src ${CMAKE_CURRENT_SOURCE_DIR}/../../src/common)
 target_link_libraries(test_roundtrip PUBLIC cmocka gcov testutils sskr sss)
 
-add_executable(test_sskr_entry_bounds ./tests/sskr_entry_bounds.c ../../src/common/bip39/seed_rom_variables.c ../../src/common/bip39/seed_bip39.c ../../src/common/sskr/seed_rom_variables.c ../../src/common/sskr/seed_sskr.c ../../src/nbgl/sskr_shares.c)
+add_executable(test_sskr_entry_bounds ./tests/sskr_entry_bounds.c ../../src/common/bip39/seed_rom_variables.c ../../src/common/bip39/seed_bip39.c ../../src/common/sskr/seed_rom_variables.c ../../src/common/sskr/seed_sskr.c ../../src/nbgl/sskr_shares.c ../../src/common/sskr/sskr_entry_header.c)
 target_compile_definitions(test_sskr_entry_bounds PRIVATE SCREEN_SIZE_WALLET)
 target_include_directories(test_sskr_entry_bounds PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/../../src/common ${CMAKE_CURRENT_SOURCE_DIR}/../../src)
 target_link_libraries(test_sskr_entry_bounds PUBLIC cmocka gcov sskr sss testutils)
@@ -544,7 +544,7 @@ target_link_libraries(test_sskr_entry_bounds PUBLIC cmocka gcov sskr sss testuti
 # it, and the two files reference each other's accessors; the only symbol left
 # unresolved after that is compare_recovery_phrase(), which the test file stubs
 # out rather than dragging common_seed.c and the BIP32 syscall in behind it.
-add_executable(test_bip39_entry_bounds ./tests/bip39_entry_bounds.c ../../src/common/bip39/seed_rom_variables.c ../../src/common/bip39/seed_bip39.c ../../src/common/sskr/seed_rom_variables.c ../../src/common/sskr/seed_sskr.c ../../src/nbgl/bip39_mnemonic.c ../../src/nbgl/sskr_shares.c)
+add_executable(test_bip39_entry_bounds ./tests/bip39_entry_bounds.c ../../src/common/bip39/seed_rom_variables.c ../../src/common/bip39/seed_bip39.c ../../src/common/sskr/seed_rom_variables.c ../../src/common/sskr/seed_sskr.c ../../src/nbgl/bip39_mnemonic.c ../../src/nbgl/sskr_shares.c ../../src/common/sskr/sskr_entry_header.c)
 target_compile_definitions(test_bip39_entry_bounds PRIVATE SCREEN_SIZE_WALLET)
 target_include_directories(test_bip39_entry_bounds PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/../../src/common ${CMAKE_CURRENT_SOURCE_DIR}/../../src)
 target_link_libraries(test_bip39_entry_bounds PUBLIC cmocka gcov sskr sss testutils)
@@ -554,7 +554,7 @@ target_link_libraries(test_bip39_entry_bounds PUBLIC cmocka gcov sskr sss testut
 # buffer's life: sskr_shares_word_remove() and the reach of the erasure it
 # triggers. Kept in its own target rather than appended to the bounds test so
 # that a failure names which of the two it is.
-add_executable(test_sskr_entry_lifecycle ./tests/sskr_entry_lifecycle.c ../../src/common/bip39/seed_rom_variables.c ../../src/common/bip39/seed_bip39.c ../../src/common/sskr/seed_rom_variables.c ../../src/common/sskr/seed_sskr.c ../../src/nbgl/sskr_shares.c)
+add_executable(test_sskr_entry_lifecycle ./tests/sskr_entry_lifecycle.c ../../src/common/bip39/seed_rom_variables.c ../../src/common/bip39/seed_bip39.c ../../src/common/sskr/seed_rom_variables.c ../../src/common/sskr/seed_sskr.c ../../src/nbgl/sskr_shares.c ../../src/common/sskr/sskr_entry_header.c)
 target_compile_definitions(test_sskr_entry_lifecycle PRIVATE SCREEN_SIZE_WALLET)
 target_include_directories(test_sskr_entry_lifecycle PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/../../src/common ${CMAKE_CURRENT_SOURCE_DIR}/../../src)
 target_link_libraries(test_sskr_entry_lifecycle PUBLIC cmocka gcov sskr sss testutils)
@@ -562,17 +562,17 @@ target_link_libraries(test_sskr_entry_lifecycle PUBLIC cmocka gcov sskr sss test
 # Same sources as test_sskr_entry_bounds above, for the one part of the entry
 # state machine that only shows up when a secret takes more than one share:
 # sskr_shares_complete_check() reopening entry for the next share.
-add_executable(test_sskr_multi_share_entry ./tests/sskr_multi_share_entry.c ../../src/common/bip39/seed_rom_variables.c ../../src/common/bip39/seed_bip39.c ../../src/common/sskr/seed_rom_variables.c ../../src/common/sskr/seed_sskr.c ../../src/nbgl/sskr_shares.c)
+add_executable(test_sskr_multi_share_entry ./tests/sskr_multi_share_entry.c ../../src/common/bip39/seed_rom_variables.c ../../src/common/bip39/seed_bip39.c ../../src/common/sskr/seed_rom_variables.c ../../src/common/sskr/seed_sskr.c ../../src/nbgl/sskr_shares.c ../../src/common/sskr/sskr_entry_header.c)
 target_compile_definitions(test_sskr_multi_share_entry PRIVATE SCREEN_SIZE_WALLET)
 target_include_directories(test_sskr_multi_share_entry PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/../../src/common ${CMAKE_CURRENT_SOURCE_DIR}/../../src)
 target_link_libraries(test_sskr_multi_share_entry PUBLIC cmocka gcov sskr sss testutils)
 
-add_executable(test_sskr_byteword_sentinel ./tests/sskr_byteword_sentinel.c ../../src/common/bip39/seed_rom_variables.c ../../src/common/bip39/seed_bip39.c ../../src/common/sskr/seed_rom_variables.c ../../src/common/sskr/seed_sskr.c ../../src/nbgl/sskr_shares.c)
+add_executable(test_sskr_byteword_sentinel ./tests/sskr_byteword_sentinel.c ../../src/common/bip39/seed_rom_variables.c ../../src/common/bip39/seed_bip39.c ../../src/common/sskr/seed_rom_variables.c ../../src/common/sskr/seed_sskr.c ../../src/nbgl/sskr_shares.c ../../src/common/sskr/sskr_entry_header.c)
 target_compile_definitions(test_sskr_byteword_sentinel PRIVATE SCREEN_SIZE_WALLET)
 target_include_directories(test_sskr_byteword_sentinel PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/../../src/common ${CMAKE_CURRENT_SOURCE_DIR}/../../src)
 target_link_libraries(test_sskr_byteword_sentinel PUBLIC cmocka gcov sskr sss testutils)
 
-add_executable(test_sskr_cbor_additional_info ./tests/sskr_cbor_additional_info.c ../../src/common/bip39/seed_rom_variables.c ../../src/common/bip39/seed_bip39.c ../../src/common/sskr/seed_rom_variables.c ../../src/common/sskr/seed_sskr.c ../../src/nbgl/sskr_shares.c)
+add_executable(test_sskr_cbor_additional_info ./tests/sskr_cbor_additional_info.c ../../src/common/bip39/seed_rom_variables.c ../../src/common/bip39/seed_bip39.c ../../src/common/sskr/seed_rom_variables.c ../../src/common/sskr/seed_sskr.c ../../src/nbgl/sskr_shares.c ../../src/common/sskr/sskr_entry_header.c)
 target_compile_definitions(test_sskr_cbor_additional_info PRIVATE SCREEN_SIZE_WALLET)
 target_include_directories(test_sskr_cbor_additional_info PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/../../src/common ${CMAKE_CURRENT_SOURCE_DIR}/../../src)
 target_link_libraries(test_sskr_cbor_additional_info PUBLIC cmocka gcov sskr sss testutils)

--- a/tests/unit/CMakeLists.txt
+++ b/tests/unit/CMakeLists.txt
@@ -577,6 +577,14 @@ target_compile_definitions(test_sskr_cbor_additional_info PRIVATE SCREEN_SIZE_WA
 target_include_directories(test_sskr_cbor_additional_info PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/../../src/common ${CMAKE_CURRENT_SOURCE_DIR}/../../src)
 target_link_libraries(test_sskr_cbor_additional_info PUBLIC cmocka gcov sskr sss testutils)
 
+# The header arithmetic on its own. It holds no state and reaches into no UI
+# storage, so unlike every target above it needs nothing but its own source --
+# and unlike every target above, what it covers is the code all three entry
+# paths run, not the one path a host build can link.
+add_executable(test_sskr_entry_header ./tests/sskr_entry_header.c ../../src/common/sskr/sskr_entry_header.c)
+target_include_directories(test_sskr_entry_header PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/../../src/common)
+target_link_libraries(test_sskr_entry_header PUBLIC cmocka gcov testutils)
+
 add_executable(test_words ./tests/words.c ../../src/common/bip39/seed_rom_variables.c ../../src/common/bip39/seed_bip39.c ../../src/common/sskr/seed_rom_variables.c ../../src/common/sskr/seed_sskr.c)
 target_include_directories(test_words PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/../../src/common)
 target_link_libraries(test_words PUBLIC cmocka gcov testutils sskr sss)

--- a/tests/unit/tests/sskr_entry_header.c
+++ b/tests/unit/tests/sskr_entry_header.c
@@ -1,0 +1,336 @@
+/*
+ * bolos_ux_sskr_entry_header_update(): what a share's CBOR header says about
+ * that share, read one entered byte at a time.
+ *
+ * The three word entry paths -- src/nbgl/sskr_shares.c,
+ * src/bagl/nanox_enter_phrase.c and src/bagl/nanos_enter_phrase.c -- each held
+ * a copy of this switch, on three different pieces of storage. Only the first
+ * is compiled by any test target, and the third (Nano S) is not even built by
+ * the CI matrix, so a defect in the arithmetic had two places to sit unseen:
+ * the reserved additional-info values leaving the share count at zero was
+ * exactly that, present in all three at once.
+ *
+ * These tests hold the extracted function to the behaviour those three copies
+ * had, position by position. Per RFC 8949 the 4th byte of the share is a
+ * byte-string header: major type 2, plus a 5-bit additional-info field
+ * (buffer[3] & 0x1F) meaning
+ *
+ *   0-23    literal length, 0 to 23 bytes                  (short form)
+ *   24      one length byte follows (0x58)                 (long form)
+ *   25-31   two/four/eight-byte length, reserved, or indefinite length
+ *
+ * and only the first two forms have a length this code can compute. What the
+ * function leaves *unwritten* matters as much as what it writes: the share
+ * count is deliberately not established for a reserved form, which is what
+ * makes the completed share fail bolos_ux_sskr_hex_check() downstream.
+ */
+
+#include <stdarg.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include <stddef.h>
+#include <setjmp.h>
+#include <cmocka.h>
+#include <string.h>
+
+#include "testutils.h"
+#include "sskr/common_sskr.h"
+
+/* Values no call below can legitimately produce, so "left alone" is
+ * distinguishable from "written". */
+#define FINAL_SIZE_UNTOUCHED ((size_t) 0xA5A5A5)
+#define COUNT_UNTOUCHED      ((uint8_t) 0xA5)
+
+/* Where each quantity is read from, and where the header itself sits. */
+#define HEADER_POSITION      3
+#define LONG_LENGTH_POSITION 4
+#define COUNT_POSITION_SHORT 7
+#define COUNT_POSITION_LONG  8
+
+/* A buffer long enough to hold two shares' worth of positions. */
+#define BUFFER_LENGTH 64
+
+/* CBOR tag 309 (crypto-sskr), the three bytes every share starts with. */
+static void put_tag(uint8_t *buffer)
+{
+    buffer[0] = 0xD9;
+    buffer[1] = 0x9D;
+    buffer[2] = 0x75;
+}
+
+/* Byte-string header with `additional_info` in its low five bits. */
+static uint8_t byte_string_header(uint8_t additional_info)
+{
+    return (uint8_t) (0x40 | (additional_info & 0x1F));
+}
+
+/*
+ * Short form: the additional-info field is the payload length itself, and the
+ * share is that many bytes plus the 4-byte CBOR header and the 4-byte CRC32.
+ * Nothing else is established at this position -- in particular not the share
+ * count, which comes later out of the shard's own metadata.
+ */
+static void test_short_form_length_is_read_from_the_header(void **state)
+{
+    (void) state;
+
+    for (uint8_t additional_info = 0; additional_info <= 23; additional_info++) {
+        uint8_t buffer[BUFFER_LENGTH] = {0};
+        put_tag(buffer);
+        buffer[HEADER_POSITION] = byte_string_header(additional_info);
+
+        size_t final_size = FINAL_SIZE_UNTOUCHED;
+        uint8_t count = COUNT_UNTOUCHED;
+        bolos_ux_sskr_entry_header_update(buffer, HEADER_POSITION, HEADER_POSITION,
+                                          &final_size, &count);
+
+        assert_int_equal(final_size, 4 + additional_info + 4);
+        assert_int_equal(count, COUNT_UNTOUCHED);
+    }
+}
+
+/*
+ * Long form: additional-info 24 says one length byte follows, so the length
+ * taken at the header position is provisional and the byte after it carries
+ * the real one. The share is that many bytes plus the 5-byte header and the
+ * 4-byte CRC32.
+ */
+static void test_long_form_length_is_read_from_the_byte_after_the_header(void **state)
+{
+    (void) state;
+
+    uint8_t buffer[BUFFER_LENGTH] = {0};
+    put_tag(buffer);
+    buffer[HEADER_POSITION] = byte_string_header(24);
+
+    size_t final_size = FINAL_SIZE_UNTOUCHED;
+    uint8_t count = COUNT_UNTOUCHED;
+    bolos_ux_sskr_entry_header_update(buffer, HEADER_POSITION, HEADER_POSITION,
+                                      &final_size, &count);
+    /* The provisional value the short-form formula gives for 24. */
+    assert_int_equal(final_size, 4 + 24 + 4);
+
+    for (unsigned int declared = 0; declared <= 0xFF; declared++) {
+        buffer[LONG_LENGTH_POSITION] = (uint8_t) declared;
+        final_size = FINAL_SIZE_UNTOUCHED;
+        bolos_ux_sskr_entry_header_update(buffer, LONG_LENGTH_POSITION, LONG_LENGTH_POSITION,
+                                          &final_size, &count);
+
+        size_t expected = 4 + 1 + declared + 4;
+        if (expected > SSKR_SHARE_MAX_WIRE_LENGTH) {
+            expected = SSKR_SHARE_MAX_WIRE_LENGTH;
+        }
+        assert_int_equal(final_size, expected);
+        assert_true(final_size <= SSKR_SHARE_MAX_WIRE_LENGTH);
+    }
+
+    assert_int_equal(count, COUNT_UNTOUCHED);
+}
+
+/*
+ * The clamp is what keeps a declared length from setting an expected share
+ * length no share can have: a shard is SSKR_METADATA_LENGTH_BYTES plus at most
+ * SSKR_MAX_STRENGTH_BYTES, and the wire form adds the 5-byte header and the
+ * CRC32 on top. Either side of the largest length that fits.
+ */
+static void test_declared_length_is_clamped_to_the_maximum_wire_length(void **state)
+{
+    (void) state;
+
+    const unsigned int largest_unclamped = SSKR_SHARE_MAX_WIRE_LENGTH - 4 - 1 - 4;
+    uint8_t buffer[BUFFER_LENGTH] = {0};
+    put_tag(buffer);
+    buffer[HEADER_POSITION] = byte_string_header(24);
+
+    size_t final_size = FINAL_SIZE_UNTOUCHED;
+    uint8_t count = COUNT_UNTOUCHED;
+
+    buffer[LONG_LENGTH_POSITION] = (uint8_t) largest_unclamped;
+    bolos_ux_sskr_entry_header_update(buffer, LONG_LENGTH_POSITION, LONG_LENGTH_POSITION,
+                                      &final_size, &count);
+    assert_int_equal(final_size, SSKR_SHARE_MAX_WIRE_LENGTH);
+
+    buffer[LONG_LENGTH_POSITION] = (uint8_t) (largest_unclamped - 1);
+    bolos_ux_sskr_entry_header_update(buffer, LONG_LENGTH_POSITION, LONG_LENGTH_POSITION,
+                                      &final_size, &count);
+    assert_int_equal(final_size, SSKR_SHARE_MAX_WIRE_LENGTH - 1);
+
+    buffer[LONG_LENGTH_POSITION] = 0xFF;
+    bolos_ux_sskr_entry_header_update(buffer, LONG_LENGTH_POSITION, LONG_LENGTH_POSITION,
+                                      &final_size, &count);
+    assert_int_equal(final_size, SSKR_SHARE_MAX_WIRE_LENGTH);
+}
+
+/*
+ * Reserved additional-info values (25-31) have no literal length of their own.
+ * There is nothing valid to compute, so the expected length is pinned to the
+ * same maximum a too-long declared length is clamped to -- far enough out that
+ * entry cannot be considered complete at a plausible-looking word count -- and
+ * the share count is left exactly as it was at every position that could
+ * otherwise establish it. That last part is the point: the count stays at
+ * whatever the caller had (zero, for a fresh entry), and a share count of zero
+ * is what bolos_ux_sskr_hex_check() refuses.
+ */
+static void test_reserved_additional_info_pins_the_length_and_sets_no_count(void **state)
+{
+    (void) state;
+
+    for (uint8_t additional_info = 25; additional_info <= 31; additional_info++) {
+        uint8_t buffer[BUFFER_LENGTH] = {0};
+        put_tag(buffer);
+        buffer[HEADER_POSITION] = byte_string_header(additional_info);
+        buffer[LONG_LENGTH_POSITION] = 0x01;
+        buffer[COUNT_POSITION_SHORT] = 0x22;
+        buffer[COUNT_POSITION_LONG] = 0x33;
+
+        size_t final_size = FINAL_SIZE_UNTOUCHED;
+        uint8_t count = COUNT_UNTOUCHED;
+        bolos_ux_sskr_entry_header_update(buffer, HEADER_POSITION, HEADER_POSITION,
+                                          &final_size, &count);
+        assert_int_equal(final_size, SSKR_SHARE_MAX_WIRE_LENGTH);
+        assert_int_equal(count, COUNT_UNTOUCHED);
+
+        /* Neither the long-form length byte nor either count position says
+         * anything once the header is a reserved form. */
+        bolos_ux_sskr_entry_header_update(buffer, LONG_LENGTH_POSITION, LONG_LENGTH_POSITION,
+                                          &final_size, &count);
+        bolos_ux_sskr_entry_header_update(buffer, COUNT_POSITION_SHORT, COUNT_POSITION_SHORT,
+                                          &final_size, &count);
+        bolos_ux_sskr_entry_header_update(buffer, COUNT_POSITION_LONG, COUNT_POSITION_LONG,
+                                          &final_size, &count);
+        assert_int_equal(final_size, SSKR_SHARE_MAX_WIRE_LENGTH);
+        assert_int_equal(count, COUNT_UNTOUCHED);
+    }
+}
+
+/*
+ * The share count is the member threshold nibble plus one, read out of the
+ * shard's metadata -- at the 8th byte of the share for a short-form header,
+ * one byte later for a long-form one, since that form spends a byte more on
+ * its length. Each position speaks only for its own form.
+ */
+static void test_share_count_is_read_at_the_position_the_length_form_dictates(void **state)
+{
+    (void) state;
+
+    for (unsigned int metadata = 0; metadata <= 0xFF; metadata++) {
+        const uint8_t expected = (uint8_t) ((metadata & 0x0F) + 1);
+
+        uint8_t short_form[BUFFER_LENGTH] = {0};
+        put_tag(short_form);
+        short_form[HEADER_POSITION] = byte_string_header(23);
+        short_form[COUNT_POSITION_SHORT] = (uint8_t) metadata;
+        short_form[COUNT_POSITION_LONG] = (uint8_t) ~metadata;
+
+        size_t final_size = FINAL_SIZE_UNTOUCHED;
+        uint8_t count = COUNT_UNTOUCHED;
+        bolos_ux_sskr_entry_header_update(short_form, COUNT_POSITION_SHORT, COUNT_POSITION_SHORT,
+                                          &final_size, &count);
+        assert_int_equal(count, expected);
+        assert_int_equal(final_size, FINAL_SIZE_UNTOUCHED);
+
+        /* The long-form position says nothing about a short-form share. */
+        count = COUNT_UNTOUCHED;
+        bolos_ux_sskr_entry_header_update(short_form, COUNT_POSITION_LONG, COUNT_POSITION_LONG,
+                                          &final_size, &count);
+        assert_int_equal(count, COUNT_UNTOUCHED);
+
+        uint8_t long_form[BUFFER_LENGTH] = {0};
+        put_tag(long_form);
+        long_form[HEADER_POSITION] = byte_string_header(24);
+        long_form[COUNT_POSITION_SHORT] = (uint8_t) ~metadata;
+        long_form[COUNT_POSITION_LONG] = (uint8_t) metadata;
+
+        count = COUNT_UNTOUCHED;
+        bolos_ux_sskr_entry_header_update(long_form, COUNT_POSITION_SHORT, COUNT_POSITION_SHORT,
+                                          &final_size, &count);
+        assert_int_equal(count, COUNT_UNTOUCHED);
+
+        bolos_ux_sskr_entry_header_update(long_form, COUNT_POSITION_LONG, COUNT_POSITION_LONG,
+                                          &final_size, &count);
+        assert_int_equal(count, expected);
+        assert_int_equal(final_size, FINAL_SIZE_UNTOUCHED);
+    }
+}
+
+/*
+ * Every other position in a share carries payload, and payload says nothing
+ * about the share's shape. A byte that would look like a header or a metadata
+ * byte elsewhere must not be read as one here.
+ */
+static void test_other_positions_establish_nothing(void **state)
+{
+    (void) state;
+
+    uint8_t buffer[BUFFER_LENGTH];
+    memset(buffer, 0xFF, sizeof(buffer));
+    put_tag(buffer);
+    buffer[HEADER_POSITION] = byte_string_header(23);
+
+    for (size_t word_number = 0; word_number < BUFFER_LENGTH; word_number++) {
+        if (word_number == HEADER_POSITION || word_number == LONG_LENGTH_POSITION ||
+            word_number == COUNT_POSITION_SHORT || word_number == COUNT_POSITION_LONG) {
+            continue;
+        }
+
+        size_t final_size = FINAL_SIZE_UNTOUCHED;
+        uint8_t count = COUNT_UNTOUCHED;
+        bolos_ux_sskr_entry_header_update(buffer, word_number, word_number, &final_size, &count);
+        assert_int_equal(final_size, FINAL_SIZE_UNTOUCHED);
+        assert_int_equal(count, COUNT_UNTOUCHED);
+    }
+}
+
+/*
+ * Position in the buffer and position in the share are two different things.
+ * They only coincide while the first share of a set is being entered: for
+ * every share after it the word number restarts and the buffer index keeps
+ * counting, and the entry paths read the *first* share's byte-string header to
+ * decide which form the set uses. Every share in a set has the same shape, so
+ * this holds; it is checked here because the extraction has to keep taking the
+ * two apart the same way.
+ */
+static void test_word_number_and_buffer_index_are_independent(void **state)
+{
+    (void) state;
+
+    const size_t second_share = 32;
+    uint8_t buffer[BUFFER_LENGTH] = {0};
+    put_tag(buffer);
+    buffer[HEADER_POSITION] = byte_string_header(20);
+    put_tag(buffer + second_share);
+    /* A byte that would be read as a long-form header, were the second share's
+     * own header the one consulted. */
+    buffer[second_share + HEADER_POSITION] = byte_string_header(24);
+    buffer[second_share + COUNT_POSITION_SHORT] = 0x04;
+
+    size_t final_size = FINAL_SIZE_UNTOUCHED;
+    uint8_t count = COUNT_UNTOUCHED;
+
+    /* Fourth word of the second share: the length comes from the byte just
+     * entered, wherever in the buffer it landed. */
+    bolos_ux_sskr_entry_header_update(buffer, second_share + HEADER_POSITION, HEADER_POSITION,
+                                      &final_size, &count);
+    assert_int_equal(final_size, 4 + 24 + 4);
+
+    /* Eighth word of the second share: the form comes from the first share's
+     * header, which is the short form, so this position does establish the
+     * count. */
+    bolos_ux_sskr_entry_header_update(buffer, second_share + COUNT_POSITION_SHORT,
+                                      COUNT_POSITION_SHORT, &final_size, &count);
+    assert_int_equal(count, 5);
+}
+
+int main(void)
+{
+    const struct CMUnitTest tests[] = {
+        cmocka_unit_test(test_short_form_length_is_read_from_the_header),
+        cmocka_unit_test(test_long_form_length_is_read_from_the_byte_after_the_header),
+        cmocka_unit_test(test_declared_length_is_clamped_to_the_maximum_wire_length),
+        cmocka_unit_test(test_reserved_additional_info_pins_the_length_and_sets_no_count),
+        cmocka_unit_test(test_share_count_is_read_at_the_position_the_length_form_dictates),
+        cmocka_unit_test(test_other_positions_establish_nothing),
+        cmocka_unit_test(test_word_number_and_buffer_index_are_independent),
+    };
+    return cmocka_run_group_tests(tests, NULL, NULL);
+}


### PR DESCRIPTION
The arithmetic that reads a share's CBOR header while it is being entered
existed in **three copies**, one per entry path:

| File | Serves | Built by CI | Compiled by the test suite |
|---|---|---|---|
| `src/nbgl/sskr_shares.c` | stax, flex, apex_p | yes | yes |
| `src/bagl/nanox_enter_phrase.c` | nanox, nanos+ | yes | no |
| `src/bagl/nanos_enter_phrase.c` | nanos | **no** | no |

The same switch over the position of the ByteWord just entered: the
expected total length of the share out of the CBOR additional-info field,
corrected at the next byte for the long form, then the share count out of
the member-threshold nibble. Identical logic in all three, only the storage
differing — `shares.buffer` / `final_size` / `count` on one side,
`G_bolos_ux_context.sskr_words_buffer` / `bip39_type` / `sskr_share_count`
on the other.

**A defect has already lodged itself in all three at once.** The reserved
CBOR additional-info values 25-31 were read as if they encoded a literal
length, which left the share count at zero; the fix had to be applied three
times, and nothing but review would have caught it in two of the three
places.

## What this changes

The computation moves into `bolos_ux_sskr_entry_header_update()`, in
`src/common/sskr/` — it is shared by both UI stacks and belongs to neither.
It is a pure function: the bytes entered so far, the index of the byte just
written, that word's position in the share, and two out parameters. No UI
structure, no global state, no syscall.

**No behaviour changes.** This is a mechanical extraction: the three stacks
produce the same values they did before, position by position, including
what the old code deliberately left alone — a reserved additional-info value
pins the expected length to `SSKR_SHARE_MAX_WIRE_LENGTH` and establishes no
share count at all, which is what leaves the completed share to be rejected
by `bolos_ux_sskr_hex_check()`. `buffer[3]` still refers to the byte-string
header of the first share entered rather than the current one; every share
in a set has the same shape, so the two agree, and changing it is not this
PR's business.

The one difference outside the arithmetic is in the debug traces, compiled
out of every built target (`DEBUG = 0`): the two `PRINTF` lines now sit in
the shared function, so an NBGL debug build logs the two messages the BAGL
builds already logged instead of its own wording for one of them.

## Scope

**Only the header arithmetic is shared.** The UI layers keep their own
storage, their own entry state and their own navigation; the layering is
untouched, no file is merged, nothing about display or navigation moves.
That is deliberate — it is what makes this reviewable without an
architecture discussion.

## Tests

The calculation is now **tested once for all three paths**, which was
possible for none of them before: two of the three copies are compiled into
no test target at all, and what did get tested went through the NBGL entry
state machine rather than the arithmetic itself.

The new test covers the short form over every additional-info value, the
long form over all 256 declared lengths with the clamp to
`SSKR_SHARE_MAX_WIRE_LENGTH`, that clamp on its own either side of the
largest length that fits, the reserved values 25-31 (pinned length, and no
share count established at either position that could establish one), the
share count at both positions and both length forms over all 256 metadata
bytes, every other position establishing nothing, and the word's position in
the share being independent of the byte's index in the buffer — what
entering a second share does.

Four mutants of the extracted constants (the 4-byte header count, the
short/long threshold 24, the clamp, the member-threshold nibble mask) each
turn it red.

`ctest` goes from 56 to 57 targets, all green. Line coverage of the new
function is 22/22; `src/nbgl/sskr_shares.c` goes from 62/93 lines to 43/74,
the 19 lines that left being the arithmetic, now covered where it lives.

The two BAGL entry files remain compiled into no test target — this PR does
not change that, and what is left in them is UI plumbing a host build cannot
link.

## Builds

**All six targets of `ledger_app.toml` build, with no warning**, `nanos`
included and checked by hand since CI does not build it:

| Target | text | bss |
|---|---|---|
| nanos | 40648 (+64) | 3708 (=) |
| nanox | 46136 (=) | 28672 (=) |
| nanos+ | 46152 (=) | 40960 (=) |
| stax | 72305 (=) | 36864 (=) |
| flex | 72845 (=) | 36864 (=) |
| apex_p | 69233 (=) | 40960 (=) |

Five are unchanged to the byte. On `nanos`, comparing every defined symbol
in the two ELFs, exactly two differ:
`screen_onboarding_restore_word_validate()` drops from 352 bytes to 264 and
the new function is 94 — 6 bytes of code, the rest of the +64 being the
relayout around an extra function section. Nothing is inlined across
translation units in this build, so the switch that used to be inline in its
one caller is now a real call.

The Speculos check on SSKR share entry (share buffer erased on cancel) was
re-run against the flex build of this branch, since this PR touches that
path.
