### PR TITLE
fix(tests): count no bits for a zero bignum in the cx_mpi stub

### DIFF
--- a/tests/unit/CMakeLists.txt
+++ b/tests/unit/CMakeLists.txt
@@ -511,6 +511,48 @@ add_executable(test_gf2_8_mul_nanos tests/gf2_8_mul.c ../../src/common/sskr/sss/
 target_include_directories(test_gf2_8_mul_nanos PUBLIC ${SSS_NANOS_INCLUDES})
 target_compile_definitions(test_gf2_8_mul_nanos PRIVATE TARGET_NANOS)
 target_link_libraries(test_gf2_8_mul_nanos PUBLIC cmocka gcov testutils)
+
+# The primitive underneath all of the above, on the one input the rest of this
+# directory never asks it about: zero.
+#
+# cx_mpi_cnt_bits() (lib/bolos/cx_mpi.c) is a host stub, and for a zero bignum
+# BN_bn2bin() writes nothing into its 2048-byte scratch buffer and returns 0 --
+# so the walk that follows read the buffer uninitialised and, the byte counter
+# being unsigned, ran off its end. Only the TARGET_NANOS build of
+# cx_bn_gf2_n_mul() ever reaches it, which is why the four targets above and
+# nothing else were affected.
+#
+# Both targets are built with AddressSanitizer: the value the stub returns is
+# only half of what is being held here, the other half being that producing it
+# reads nothing it should not, and that half has no observable form without a
+# sanitiser. Which is precisely how this survived every unsanitised run.
+#
+# The pair is the same one-file-two-targets shape as test_gf2_8_mul above, and
+# for the same reason: the multiplication by zero has to hold for both
+# implementations of cx_bn_gf2_n_mul(), not just the one that goes near the
+# stub.
+#
+#  - test_cx_bn_cnt_bits compiles lib/bolos/ into the target, so the stub's own
+#    stack frame is instrumented in every configuration this suite is built in,
+#    rather than only in the sanitised entry of the matrix workflow where the
+#    flags also reach libtestutils.so.
+#  - test_cx_bn_cnt_bits_nanos cannot do the same: cx_bn.c and the TARGET_NANOS
+#    part of interpolate.c both define cx_bn_gf2_n_mul(), and having the second
+#    one on the call path is the whole point of the target. It links lib/bolos/
+#    from libtestutils.so like the four targets above, and what it pins is the
+#    returned value -- zero times anything is zero -- which a wrong bit count
+#    breaks on its own, with no sanitiser needed.
+add_executable(test_cx_bn_cnt_bits tests/cx_bn_cnt_bits.c ${BOLOS_SOURCES})
+target_compile_options(test_cx_bn_cnt_bits PRIVATE -fsanitize=address -fno-omit-frame-pointer)
+target_link_options(test_cx_bn_cnt_bits PRIVATE -fsanitize=address)
+target_link_libraries(test_cx_bn_cnt_bits PUBLIC cmocka gcov testutils)
+
+add_executable(test_cx_bn_cnt_bits_nanos tests/cx_bn_cnt_bits.c ../../src/common/sskr/sss/interpolate.c)
+target_include_directories(test_cx_bn_cnt_bits_nanos PUBLIC ${SSS_NANOS_INCLUDES})
+target_compile_definitions(test_cx_bn_cnt_bits_nanos PRIVATE TARGET_NANOS)
+target_compile_options(test_cx_bn_cnt_bits_nanos PRIVATE -fsanitize=address -fno-omit-frame-pointer)
+target_link_options(test_cx_bn_cnt_bits_nanos PRIVATE -fsanitize=address)
+target_link_libraries(test_cx_bn_cnt_bits_nanos PUBLIC cmocka gcov testutils)
 # ---------------------------------------------------------------------------
 
 # Built with AddressSanitizer. Both buffer guards this file covers --

--- a/tests/unit/lib/bolos/cx_mpi.c
+++ b/tests/unit/lib/bolos/cx_mpi.c
@@ -615,6 +615,16 @@ uint32_t cx_mpi_cnt_bits(const cx_mpi_t *x)
   // Convert a cx_mpi_t into big-endian bytes form:
   len = BN_bn2bin(x, a);
 
+  // A zero bignum has no significant byte at all: BN_bn2bin() writes nothing
+  // and returns 0, leaving 'a' untouched. The scan below would then read it
+  // uninitialised and, since 'len' is unsigned, walk past the end of the
+  // buffer: 'len--' turns 0 into UINT32_MAX and the loop's only exit
+  // condition can no longer be met. Zero has no bits either way the count is
+  // read, so return early.
+  if (len == 0) {
+    return 0;
+  }
+
   p = a;
   while (*p == 0) {
     p++;

--- a/tests/unit/tests/cx_bn_cnt_bits.c
+++ b/tests/unit/tests/cx_bn_cnt_bits.c
@@ -1,0 +1,249 @@
+/*
+ * What the unit harness answers when asked how many bits a *zero* bignum has.
+ *
+ * cx_mpi_cnt_bits() (tests/unit/lib/bolos/cx_mpi.c) is a host stub standing in
+ * for an SDK primitive. It converts the bignum to big-endian bytes with
+ * BN_bn2bin(), into a 2048-byte buffer left uninitialised, then walks the
+ * result looking for the first significant bit. A zero bignum has no
+ * significant byte at all: BN_bn2bin() writes nothing and returns 0. The walk
+ * then reads a buffer nothing has written and, because the byte counter is a
+ * uint32_t, the `len--` meant to stop it turns 0 into 4294967295 -- the loop's
+ * only exit condition can no longer be met and the read runs off the end.
+ *
+ * Nothing in src/ is involved. The defect is in the code that stands in for
+ * the device, and it stayed invisible because the default build of
+ * src/common/sskr/sss/interpolate.c calls the SDK's cx_bn_gf2_n_mul(), which
+ * this harness stubs directly and which never counts bits. Under TARGET_NANOS
+ * that file multiplies by hand out of elementary BN primitives instead and
+ * asks cx_bn_cnt_bits() for the bit length of each operand -- where zero is an
+ * ordinary operand, and the answer for it has to be zero.
+ *
+ * Both targets built from this file compile with AddressSanitizer, and the
+ * first of the two compiles lib/bolos/ in rather than linking it from
+ * libtestutils.so so that the stub's own stack frame is instrumented whatever
+ * flags the rest of the build carries. Without a sanitiser the overrun reads
+ * whatever follows the buffer and reports nothing, which is exactly how this
+ * survived every unsanitised run of the suite. See CMakeLists.txt for why the
+ * TARGET_NANOS target cannot do the same.
+ */
+
+#include <cmocka.h>
+#include <cx_errors.h>
+#include <ox_bn.h>
+#include <setjmp.h>
+#include <stdarg.h>
+#include <stdbool.h>
+#include <stddef.h>
+#include <stdint.h>
+
+#include "testutils.h"
+
+/* The same three values interpolate.c passes cx_bn_gf2_n_mul(): N(x) = x^8 +
+ * x^4 + x^3 + x + 1 big-endian, the second Montgomery constant the Nano S
+ * implementation takes and ignores, and the BN width both use. */
+static const uint8_t POLYNOMIAL[2] = {0x01, 0x1B};
+static const uint8_t MONTGOMERY_R2[1] = {0x02};
+#define GF2_8_MPI_BYTES 16
+
+/*
+ * Whether the defect shows up at all depends on what the stub's uninitialised
+ * buffer happens to contain: a non-zero first byte stops the walk immediately
+ * and yields the right answer by accident. Leaving that to whatever ran before
+ * would make this test pass or fail for reasons that have nothing to do with
+ * the code under test, so the region the stub's frame is about to occupy is
+ * zeroed on purpose first.
+ *
+ * The array is volatile so that the writes survive -O2/-Os, and larger than
+ * the stub's own buffer so that it covers the whole of it whatever the frame
+ * layout turns out to be.
+ */
+#define STACK_PRIMING_BYTES 8192
+
+static void prime_the_stack_with_zeroes(void) {
+    volatile uint8_t scratch[STACK_PRIMING_BYTES];
+
+    for (size_t i = 0; i < sizeof(scratch) / sizeof(scratch[0]); i++) {
+        scratch[i] = 0;
+    }
+}
+
+/*
+ * A single bignum, and the field operands the multiplication needs. Set up and
+ * torn down by fixtures rather than by calls in the test bodies: cmocka leaves
+ * a failing test by longjmp, so a teardown written into the body is skipped
+ * exactly when it matters, and the BN context would stay locked and fail the
+ * next test's setup on CX_NOT_UNLOCKED -- a second failure that says nothing.
+ */
+typedef struct {
+    cx_bn_t x;
+    cx_bn_t a;
+    cx_bn_t b;
+    cx_bn_t r;
+    cx_bn_t n;
+    cx_bn_t h;
+} bn_operands_t;
+
+static int bn_open(void** state) {
+    bn_operands_t* ops = test_malloc(sizeof(*ops));
+
+    assert_non_null(ops);
+    *state = ops;
+
+    assert_int_equal(cx_bn_lock(GF2_8_MPI_BYTES, 0), CX_OK);
+    assert_int_equal(cx_bn_alloc(&ops->x, GF2_8_MPI_BYTES), CX_OK);
+    assert_int_equal(cx_bn_alloc(&ops->a, GF2_8_MPI_BYTES), CX_OK);
+    assert_int_equal(cx_bn_alloc(&ops->b, GF2_8_MPI_BYTES), CX_OK);
+    assert_int_equal(cx_bn_alloc(&ops->r, GF2_8_MPI_BYTES), CX_OK);
+    assert_int_equal(cx_bn_alloc_init(&ops->n, GF2_8_MPI_BYTES, POLYNOMIAL,
+                                      sizeof(POLYNOMIAL)),
+                     CX_OK);
+    assert_int_equal(cx_bn_alloc_init(&ops->h, GF2_8_MPI_BYTES, MONTGOMERY_R2,
+                                      sizeof(MONTGOMERY_R2)),
+                     CX_OK);
+
+    return 0;
+}
+
+static int bn_close(void** state) {
+    bn_operands_t* ops = *state;
+
+    assert_int_equal(cx_bn_destroy(&ops->x), CX_OK);
+    assert_int_equal(cx_bn_destroy(&ops->a), CX_OK);
+    assert_int_equal(cx_bn_destroy(&ops->b), CX_OK);
+    assert_int_equal(cx_bn_destroy(&ops->r), CX_OK);
+    assert_int_equal(cx_bn_destroy(&ops->n), CX_OK);
+    assert_int_equal(cx_bn_destroy(&ops->h), CX_OK);
+    assert_int_equal(cx_bn_unlock(), CX_OK);
+    test_free(ops);
+
+    return 0;
+}
+
+/*
+ * Zero, asked directly. Two things are being held here at once: the value --
+ * a bignum with no bits set has no bits, whichever way the count is read --
+ * and, under the sanitiser, that answering it reads nothing it should not.
+ *
+ * Without the guard in the stub this test is red either way: the walk stops at
+ * the first non-zero byte past the priming above and returns a bit length in
+ * the billions, or, when the whole buffer is zero, it leaves the buffer and
+ * AddressSanitizer reports the read. Which of the two happens depends on the
+ * frame layout; both are failures, and neither is the value asked for.
+ */
+static void test_zero_has_no_bits(void** state) {
+    bn_operands_t* ops = *state;
+    uint32_t nbits = UINT32_MAX;
+
+    assert_int_equal(cx_bn_set_u32(ops->x, 0), CX_OK);
+
+    prime_the_stack_with_zeroes();
+
+    assert_int_equal(cx_bn_cnt_bits(ops->x, &nbits), CX_OK);
+    assert_int_equal(nbits, 0);
+}
+
+/*
+ * The other half of the contract, and the reason the guard above returns 0
+ * rather than short-circuiting the whole function: what this primitive answers
+ * for a non-zero bignum must not change.
+ *
+ * Worth pinning for a second reason. The SDK header (ox_bn.h) documents
+ * cx_bn_cnt_bits() as the "number of bits set to 1"; this implementation
+ * returns the bit *length*, and interpolate.c depends on the bit length -- it
+ * takes cnt_bits(N) - 1 as the degree of the modulus polynomial, which is 8
+ * for 0x11B only under the second reading. The two readings agree on 0 and on
+ * nothing else here, so the table below is what says which one is in force.
+ */
+static void test_a_non_zero_bignum_counts_its_bit_length(void** state) {
+    bn_operands_t* ops = *state;
+    static const struct {
+        uint32_t value;
+        uint32_t nbits;
+    } cases[] = {
+        {1, 1},
+        {2, 2},
+        {3, 2},
+        {4, 3},
+        {5, 3},
+        {7, 3},
+        {0x7F, 7},
+        {0x80, 8},
+        {0xFF, 8},
+        {0x100, 9},
+        {0x11B, 9},
+        {0x8000, 16},
+        {0xFFFF, 16},
+        {0x10000, 17},
+        {0x800000, 24},
+        {0x1000000, 25},
+        {0x80000000u, 32},
+        {0xFFFFFFFFu, 32},
+    };
+
+    for (size_t i = 0; i < sizeof(cases) / sizeof(cases[0]); i++) {
+        uint32_t nbits = UINT32_MAX;
+
+        assert_int_equal(cx_bn_set_u32(ops->x, cases[i].value), CX_OK);
+        assert_int_equal(cx_bn_cnt_bits(ops->x, &nbits), CX_OK);
+
+        if (nbits != cases[i].nbits) {
+            fail_msg("cnt_bits(0x%X): got %u, expected %u", cases[i].value,
+                     nbits, cases[i].nbits);
+        }
+    }
+}
+
+/* One product through whichever cx_bn_gf2_n_mul() this target links. */
+static uint8_t gf_mul(bn_operands_t* ops, uint8_t a, uint8_t b) {
+    uint32_t product = UINT32_MAX;
+
+    assert_int_equal(cx_bn_set_u32(ops->a, a), CX_OK);
+    assert_int_equal(cx_bn_set_u32(ops->b, b), CX_OK);
+    assert_int_equal(cx_bn_gf2_n_mul(ops->r, ops->a, ops->b, ops->n, ops->h),
+                     CX_OK);
+    assert_int_equal(cx_bn_get_u32(ops->r, &product), CX_OK);
+
+    return (uint8_t)product;
+}
+
+/*
+ * The path the incident actually came down: multiplying by zero in GF(2^8).
+ *
+ * Legitimate arithmetic -- interpolate() multiplies by zero whenever a
+ * Lagrange coefficient vanishes -- and, under TARGET_NANOS, the only thing
+ * standing between it and the stub is cx_bn_cnt_bits() on a zero operand. A
+ * bit length in the billions there makes the implementation's "both operands
+ * are in the field" guard reject the pair with CX_INVALID_PARAMETER, which is
+ * how a Shamir round trip turns into SSS_ERROR_INTERPOLATION_FAILURE without
+ * a sanitiser ever being involved.
+ *
+ * Both zero positions and every second operand: 0 * b, a * 0 and 0 * 0 are 511
+ * products, cheap enough to take exhaustively rather than sample.
+ */
+static void test_multiplying_by_zero_gives_zero(void** state) {
+    bn_operands_t* ops = *state;
+
+    for (unsigned int other = 0; other <= UINT8_MAX; other++) {
+        const uint8_t left = gf_mul(ops, 0, (uint8_t)other);
+        const uint8_t right = gf_mul(ops, (uint8_t)other, 0);
+
+        if (left != 0) {
+            fail_msg("0 * %u is %u, not 0", other, left);
+        }
+        if (right != 0) {
+            fail_msg("%u * 0 is %u, not 0", other, right);
+        }
+    }
+}
+
+int main(void) {
+    const struct CMUnitTest tests[] = {
+        cmocka_unit_test_setup_teardown(test_zero_has_no_bits, bn_open,
+                                        bn_close),
+        cmocka_unit_test_setup_teardown(
+            test_a_non_zero_bignum_counts_its_bit_length, bn_open, bn_close),
+        cmocka_unit_test_setup_teardown(test_multiplying_by_zero_gives_zero,
+                                        bn_open, bn_close),
+    };
+    return cmocka_run_group_tests(tests, NULL, NULL);
+}


### PR DESCRIPTION
## The CI is red

The `Unit test configuration matrix` workflow has been failing on every push to
`bip85` since at least 2026-08-01 15:10 UTC -- five consecutive runs (the merges
of #110, #111, #112, #113 and #114). One of its six jobs falls over: **ASan**.
UBSan, `-O2`, `-Os`, `-fsigned-char` and `-funsigned-char` are all green.

Five tests fail in that job:

```
29 - test_sss_nanos                             -103 != 32  (SSS_ERROR_INTERPOLATION_FAILURE)
31 - test_sskr_nanos                            stack-buffer-overflow  cx_mpi.c:619
32 - test_sskr_threshold_three_roundtrip_nanos  -103 != ...
34 - test_gf2_8_mul_nanos                       stack-buffer-overflow  cx_mpi.c:619
35 - test_bip39                                 global-buffer-overflow testutils.c:37
```

This pull request fixes the first four. The fifth has a different, unrelated
cause and is described at the bottom -- **the ASan job will still be red on this
branch, at 58/59 instead of 54/59**. Nothing here is meant to hide that.

## The defect is in the test harness, not in the embedded code

`cx_mpi_cnt_bits()` (`tests/unit/lib/bolos/cx_mpi.c`) is a host stub standing in
for an SDK primitive. **No file under `src/` is modified by this pull request**,
and no cross build is affected -- the diff touches `tests/unit/` only.

## The cause

The stub converts the bignum into a 2048-byte stack buffer with `BN_bn2bin()`
and then walks that buffer for the first significant bit:

```c
uint8_t a[MAX_MPI_BYTE_SIZE];   /* 2048 bytes, uninitialised */
...
len = BN_bn2bin(x, a);          /* zero bignum: writes nothing, returns 0 */

p = a;
while (*p == 0) {               /* line 619: reads a[0], never written */
    p++;
    len--;                      /* 0 becomes 4294967295 */
    if (len == 0)               /* so this can never fire again */
        break;
}
```

**For a zero bignum `BN_bn2bin()` writes no byte at all and returns 0.** The
walk then reads a buffer nothing has written and, `len` being a `uint32_t`, the
`len--` meant to stop it turns 0 into 4294967295: the loop's only exit condition
can no longer be met and the read runs off the end of the buffer.

Checked directly rather than assumed -- a `0xAA` sentinel written into the
buffer before the call is still `0xAA` afterwards, with `BN_num_bytes()` and
`BN_bn2bin()` both returning 0.

The fix is a guard before the walk. Zero has no bits under either reading of the
count, so no other input goes through anything new.

## Why it surfaces now

The default build calls the SDK's `cx_bn_gf2_n_mul()`, which this harness stubs
directly and which never counts bits. **The `TARGET_NANOS` variant of
`src/common/sskr/sss/interpolate.c` implements the multiplication by hand** out
of elementary BN primitives and asks `cx_bn_cnt_bits()` for the bit length of
each operand -- and multiplying by zero is perfectly ordinary there.

Test targets exercising that variant were added recently, so the flaw in the
stub predates them; it was simply never reached.

## Verified by mutation, under AddressSanitizer

Two new targets, `test_cx_bn_cnt_bits` and `test_cx_bn_cnt_bits_nanos`, both
built with AddressSanitizer, three tests each: zero counted directly, the bit
length of eighteen non-zero values, and every GF(2^8) product with a zero
operand.

With the guard removed and the suite rebuilt under ASan, both targets fail:

```
ERROR: AddressSanitizer: stack-buffer-overflow
  #0 cx_mpi_cnt_bits       tests/unit/lib/bolos/cx_mpi.c:619
  #1 cx_bn_cnt_bits        tests/unit/lib/bolos/cx_bn.c:242
  #2 test_zero_has_no_bits tests/unit/tests/cx_bn_cnt_bits.c:139
```

and running the multiplication test alone separates the two implementations:
the `TARGET_NANOS` target fails at `interpolate.c:76`, the host one passes,
since the harness's OpenSSL-backed multiplication never counts bits. With the
guard restored, both are green.

One detail worth knowing if this test is ever touched: the flaw is only
observable when the first byte of the uninitialised buffer happens to be zero --
a non-zero one stops the walk immediately and yields the right answer by
accident. The first test zeroes that stack region on purpose before calling,
which is what makes it fail deterministically rather than depending on what ran
before it.

## Verification

All six entries of `unit-tests-matrix.yml` replayed locally in
`ledger-app-builder-lite:latest`, plus the default build used by
`unit_tests.yml`:

| Entry | Result |
|---|---|
| ASan | 58/59 -- `test_bip39` only, see below |
| UBSan | 59/59 |
| `-O2` | 59/59 |
| `-Os` | 59/59 |
| `-fsigned-char` | 59/59 |
| `-funsigned-char` | 59/59 |
| default (`unit_tests.yml`) | 59/59 |

`ctest` goes from 57 to 59 through the `add_executable()` calls alone; no list
is touched. No new compiler warning. **No file under `src/` is modified, so no
cross build is needed** and the Speculos scripts are unaffected.

`tests/unit/lib/bolos/` follows a different style from the rest of the
repository, and `clang-format --dry-run` reports 1098 pre-existing violations in
`cx_mpi.c` alone under the repository's `.clang-format`; the style workflow lints
`src` only. Nothing there is reformatted -- the added lines follow the local
style. The new test file is clean under `clang-format --dry-run -Werror`, like
its neighbours in `tests/unit/tests/`.

## Reported, not changed: what `cx_bn_cnt_bits()` is documented to return

The SDK header (`ox_bn.h`) documents `cx_bn_cnt_bits()` as returning the "number
of bits set to 1". This implementation returns the **bit length**, and callers
depend on the bit length: `interpolate.c` takes `cnt_bits(bn_n) - 1` as the
degree of the modulus polynomial, which is 8 for `0x11B` only under the second
reading. The two readings agree on zero, so this pull request does not have to
choose between them, and it does not change the existing semantics. The table of
eighteen values in the new test is what records which reading is in force.

## The other ASan failure, not addressed here

`test_bip39` fails for an unrelated reason, in `src/` rather than in the
harness, and this pull request deliberately leaves it alone:

```
ERROR: AddressSanitizer: global-buffer-overflow, READ of size 1
  #0 os_secure_memcmp                tests/unit/lib/testutils.c:37
  #1 bolos_ux_bip39_mnemonic_decode  src/common/bip39/seed_bip39.c:96
  #2 test_bip39_decode_unknown_word  tests/unit/tests/bip39.c:227
0 bytes after global variable 'BIP39_WORDLIST' (size 11068)
```

`seed_bip39.c:96` compares `current_word_size` bytes -- the length of the *word
being looked up* -- against a wordlist entry, and the check that the two lengths
match is the second operand of the `&&`, so it is evaluated after the read. For
a word longer than the entries at the tail of the list, the comparison reads
past the end of `BIP39_WORDLIST`.

That is a change to embedded code and a different discussion; it is mentioned
here so that the remaining red job is not mistaken for this one.
