### PR TITLE
fix: keep the BIP-39 wordlist lookup inside BIP39_WORDLIST

### DIFF
--- a/src/common/bip39/seed_bip39.c
+++ b/src/common/bip39/seed_bip39.c
@@ -93,13 +93,22 @@ unsigned int bolos_ux_bip39_mnemonic_decode(const unsigned char* mnemonic,
         }
         current_word_size++;
         for (k = 0; k < BIP39_WORDLIST_OFFSETS_LENGTH - 1; k++) {
-            if ((os_secure_memcmp(
+            // The lengths have to agree before the bytes are compared. The
+            // comparison reads current_word_size bytes from the entry, and
+            // os_secure_memcmp() is constant time, so it reads all of them
+            // whatever the entry actually holds: on the last entry ("zoo", 3
+            // bytes, at offset 11065 of an 11068-byte array) an 8-character
+            // word read 5 bytes past the end. && short-circuits, so testing
+            // the length first keeps the read inside the entry. A word still
+            // matches only when both length and content agree, so no result
+            // changes.
+            if (((unsigned int)(BIP39_WORDLIST_OFFSETS[k + 1] -
+                                BIP39_WORDLIST_OFFSETS[k]) ==
+                 current_word_size) &&
+                (os_secure_memcmp(
                      current_word,
                      (void*)(BIP39_WORDLIST + BIP39_WORDLIST_OFFSETS[k]),
-                     current_word_size) == 0) &&
-                ((unsigned int)(BIP39_WORDLIST_OFFSETS[k + 1] -
-                                BIP39_WORDLIST_OFFSETS[k]) ==
-                 current_word_size)) {
+                     current_word_size) == 0)) {
                 for (ki = 0; ki < 11; ki++) {
                     if (k & (1 << (10 - ki))) {
                         bits[bi / 8] |= 1 << (7 - (bi % 8));

--- a/tests/unit/tests/bip39.c
+++ b/tests/unit/tests/bip39.c
@@ -231,6 +231,79 @@ static void test_bip39_decode_unknown_word(void** state) {
     assert_int_equal(result, 0);
 }
 
+// Decodes the 12-word phrase above with its last word replaced, and asserts
+// the phrase is rejected. The word count is what it has to be for the lookup
+// to be reached at all, so the replacement has to keep it at 12.
+static void assert_last_word_rejected(const char* last_word) {
+    static const char prefix[] =
+        "girl mad pet galaxy egg matter matrix prison refuse sense ordinary ";
+    const size_t prefix_len = sizeof(prefix) - 1;
+    const size_t word_len = strlen(last_word);
+    unsigned char mnemonic[sizeof(prefix) + 16];
+    unsigned char bits[32 + 1];
+
+    assert_true(prefix_len + word_len <= sizeof(mnemonic));
+    memcpy(mnemonic, prefix, prefix_len);
+    memcpy(mnemonic + prefix_len, last_word, word_len);
+
+    unsigned int result = bolos_ux_bip39_mnemonic_decode(
+        mnemonic, (unsigned int)(prefix_len + word_len), bits, sizeof(bits));
+
+    assert_int_equal(result, 0);
+}
+
+// BIP39_WORDLIST stores the 2048 entries back to back with no separator and
+// BIP39_WORDLIST_OFFSETS says where each one starts: 11068 bytes in all, the
+// last entry ("zoo") at offset 11065 for 3 bytes. The lookup in
+// bolos_ux_bip39_mnemonic_decode() compares current_word_size bytes -- the
+// length of the *typed* word, not of the entry -- so a word longer than the
+// entry it is held against reads past that entry, and past the array itself
+// on the last ones. os_secure_memcmp() is constant time and never short
+// circuits, so it reads every one of those bytes rather than stopping at the
+// first difference.
+//
+// It takes two things at once to get there: a word absent from the list, so
+// that the scan is not stopped early by the break on a match, and a word
+// longer than 3 characters, so that the read runs off the end once the scan
+// reaches "zoo". A word that is in the list can do neither -- it stops the
+// scan at its own index, and no entry extends past the end of the array.
+//
+// The lengths below cover the whole range that can reach the lookup: 4 is
+// the shortest that reads past "zoo" (by 1 byte), 10 is the longest the
+// current_word[10] buffer accepts, and reads 7 bytes past the end of the
+// array -- the worst case. Under the sanitizer this target is built with,
+// each of those reads is a failure; without one they land in whatever the
+// linker put after the array, and the phrase is rejected all the same, so
+// the assertion holds in both builds and only the sanitizer tells them
+// apart.
+static void test_bip39_decode_word_longer_than_last_wordlist_entry(
+    void** state) {
+    (void)state;
+    static const char* const absent_words[] = {
+        "zzzz",     "zzzzz",     "zzzzzz",    "zzzzzzz",
+        "zzzzzzzz", "zzzzzzzzz", "zzzzzzzzzz"};
+
+    for (size_t i = 0; i < sizeof(absent_words) / sizeof(absent_words[0]);
+         i++) {
+        assert_last_word_rejected(absent_words[i]);
+    }
+}
+
+// The counterpart of the case above: words that are exactly as long as the
+// last entry of the wordlist and still absent from it. They reach the last
+// entry like the ones above but read nothing past it, so the length check
+// lets the comparison through and the comparison alone has to reject them.
+// Without this, a length check that rejected everything -- or a comparison
+// that no longer ran -- would look just as green as a correct one.
+static void test_bip39_decode_three_letter_word_absent_from_wordlist(
+    void** state) {
+    (void)state;
+
+    assert_last_word_rejected("zzz");
+    assert_last_word_rejected("aaa");
+    assert_last_word_rejected("qqq");
+}
+
 // bolos_ux_bip39_mnemonic_decode() rejects a phrase purely on word count
 // before looking at word content, so the content here does not matter --
 // only the number of space-separated words.
@@ -509,6 +582,25 @@ static void test_bip39_roundtrip_24_words(void** state) {
                   "volcano");
 }
 
+// Non-regression for the order the lookup evaluates its two conditions in:
+// the entries of the wordlist are still found, whatever their length and
+// wherever they sit. "abandon" is entry 0 and "zoo" entry 2047, the last one
+// -- looking "zoo" up walks the scan all the way to the entry the overread
+// was about -- and between them the phrase covers every length the list
+// holds, 3 to 8 characters. The checksum is what makes it a valid phrase, so
+// the roundtrip only passes if all twelve words are matched at their own
+// index.
+static void test_bip39_roundtrip_wordlist_bounds(void** state) {
+    (void)state;
+    static const uint8_t entropy[16] = {0x00, 0x1f, 0xff, 0xff, 0x00, 0x7f,
+                                        0xf5, 0xfe, 0x00, 0x17, 0xfc, 0xff,
+                                        0xbf, 0xec, 0x04, 0x00};
+
+    run_roundtrip(entropy, sizeof(entropy),
+                  "abandon zoo zone abstract young yellow able zebra zero "
+                  "youth absurd achieve");
+}
+
 int main(void) {
     const struct CMUnitTest tests[] = {
         cmocka_unit_test(test_bip39),
@@ -516,6 +608,10 @@ int main(void) {
         cmocka_unit_test(test_bip39_seed_length_boundary),
         cmocka_unit_test(test_bip39_decode_word_too_long_for_buffer),
         cmocka_unit_test(test_bip39_decode_unknown_word),
+        cmocka_unit_test(
+            test_bip39_decode_word_longer_than_last_wordlist_entry),
+        cmocka_unit_test(
+            test_bip39_decode_three_letter_word_absent_from_wordlist),
         cmocka_unit_test(test_bip39_decode_bad_checksum),
         cmocka_unit_test(test_bip39_decode_checksum_mask_covers_fourth_bit),
         cmocka_unit_test(test_bip39_decode_wrong_length),
@@ -527,6 +623,7 @@ int main(void) {
         cmocka_unit_test(test_bip39_roundtrip_12_words),
         cmocka_unit_test(test_bip39_roundtrip_18_words),
         cmocka_unit_test(test_bip39_roundtrip_24_words),
+        cmocka_unit_test(test_bip39_roundtrip_wordlist_bounds),
     };
     return cmocka_run_group_tests(tests, NULL, NULL);
 }


### PR DESCRIPTION
`bolos_ux_bip39_mnemonic_decode()` reads past the end of `BIP39_WORDLIST` when
it looks a word up. This restores the "Unit test configuration matrix" workflow
to green: ASan was its last red entry.

## The defect

The lookup walks the wordlist and compares `current_word_size` bytes -- the
length of the *typed* word, not of the entry -- against each entry in turn. That
the entry is actually that long was checked afterwards, as the **second**
operand of the `&&`:

```c
for (k = 0; k < BIP39_WORDLIST_OFFSETS_LENGTH - 1; k++) {
    if ((os_secure_memcmp(current_word,
                          (void*)(BIP39_WORDLIST + BIP39_WORDLIST_OFFSETS[k]),
                          current_word_size) == 0) &&
        ((unsigned int)(BIP39_WORDLIST_OFFSETS[k + 1] -
                        BIP39_WORDLIST_OFFSETS[k]) == current_word_size)) {
```

So the comparison ran first and read as many bytes as the typed word from
entries shorter than it. `os_secure_memcmp()` is a constant-time comparison: it
does not stop at the first difference and reads **every** byte it is asked for,
whatever it finds. That is deliberate, and it makes the overread systematic
rather than occasional.

The figures, taken from the array itself: `BIP39_WORDLIST` holds the 2048
entries back to back with no separator, **11 068 bytes** in all, the last one
(`"zoo"`) at offset **11 065** for **3** bytes. An 8-character word held against
that entry read **5 bytes past the end** of the array; the 10-character maximum
that the `current_word[10]` buffer accepts reads **7**.

AddressSanitizer, on `test_bip39_decode_unknown_word`:

```
ERROR: AddressSanitizer: global-buffer-overflow
READ of size 1
    #0 os_secure_memcmp tests/unit/lib/testutils.c:37
    #1 bolos_ux_bip39_mnemonic_decode src/common/bip39/seed_bip39.c:96
    #2 test_bip39_decode_unknown_word tests/unit/tests/bip39.c:227
0x... is located 0 bytes after global variable 'BIP39_WORDLIST'
    defined in 'src/common/bip39/seed_rom_variables.c:18:21' of size 11068
```

## Reachability

**Not reachable through the interface as the code stands**, and it is worth
being precise about why rather than leaving it implied.

A word that *is* in the list cannot get there. The scan `break`s on the entry it
matches and the list is sorted, so it never reaches an index beyond the word's
own; and no entry extends past the end of the array, since
`OFFSETS[k] + len(entry k) == OFFSETS[k+1] <= 11068` by construction.
Simulating the scan for all 2048 entries confirms it: none of them reads past
the array.

And every word the decoder is given is copied out of the list *by index*:
`bolos_ux_bip39_idx_strcpy()` directly on the BAGL entry screens,
`bolos_ux_bip39_fill_with_candidates()` behind the suggestion buttons on the
NBGL one, and `bolos_ux_bip39_mnemonic_encode()` on the
`bolos_ux_bip39_to_sskr_convert()` path. There is no other way in -- the
application takes no APDU carrying a mnemonic.

Reaching the overread takes a word that is **absent from the list**, so the scan
is not stopped early, **and longer than 3 characters**, so the read runs off the
end once the scan reaches the last entry. That makes this a bound the function
has to hold on its own rather than a way in from outside. It is still worth
holding: the "word not in the wordlist" rejection immediately below the loop
exists precisely because the function does not assume its input is clean, and
the read is real out-of-bounds access in code that ships to a device.

## The fix

Swap the two operands of the `&&`. C guarantees short-circuit evaluation, so the
comparison no longer runs on an entry whose length differs and the read stays
inside the entry. **This is a reordering, not added logic**, and no result
changes: a word matches only when length and content both agree, in either
order. The three existing roundtrip tests (12, 18 and 24 words) are green before
and after, as is the rest of the suite.

### Constant time

The first thing the change invites asking about, so: short-circuiting on the
length does not weaken what `os_secure_memcmp()` is there for.

How many entries the list holds of each length is a public property of the list.
The length of the word being typed is already plain to anyone in a position to
watch it entered. What has to stay hidden is *which* word it is, and the content
is still compared in constant time against every entry of that length.

The scan around the comparison was never constant time to begin with -- it
`break`s on the entry it matches, so its iteration count has always depended on
the index of the word. The reordering changes the per-iteration cost by length
only, which was already observable.

## Why it surfaces now

The defect predates the test that exposes it. The suite's unknown-word vector
used to be 17 characters long and stopped at the "word too long for the buffer"
guard above the loop, never reaching the wordlist at all. Since it was corrected
to an 8-character vector the test reaches the lookup, and AddressSanitizer
reports the read. Nothing about the lookup itself changed.

## Tests

Three added, to hold the bound explicitly rather than by accident:

- **a word longer than the last entry**, at every length that can get there --
  4 characters is the shortest that reads past `"zoo"` (by one byte), 10 is the
  longest the `current_word[10]` buffer accepts and reads 7 bytes past the end,
  the worst case the function admits. All seven are absent from the list, which
  is what drives the scan to the last entry;
- **the entries of the list are still found**, wherever they sit and whatever
  their length: one 12-word phrase covering `"abandon"` (entry 0), `"zoo"`
  (entry 2047, so the scan walks all the way to the entry the overread was
  about) and every length the list holds, 3 to 8 characters. It goes through the
  roundtrip helper, so the phrase must encode to exactly those words and decode
  back to the same entropy -- with the checksum, that only holds if all twelve
  are matched at their own index;
- **three-character words absent from the list**, which reach the last entry
  without reading past it, so the length check passes them through and the
  comparison alone has to reject them. A length check that rejected too much
  would look as green as a correct one without this.

Only the first fails without the fix, which is the point of it; the other two
are there so the fix cannot be over-applied, and both were checked green against
the unfixed code before the fix went back in, under the sanitizer, with the
failing test isolated by `CMOCKA_TEST_FILTER` so its abort would not hide them.

The read is only observable under a sanitizer -- without one those bytes land in
whatever the linker put after the array and the phrase is rejected all the same.
The assertions hold in every configuration; it is the ASan entry of the matrix
that tells the two apart.

## Verification

All six entries of `unit-tests-matrix.yml` were replayed locally on the
committed tree, in `ledger-app-builder-lite:latest`, each configured the way the
workflow configures it:

| ASan | UBSan | `-O2` | `-Os` | `-fsigned-char` | `-funsigned-char` |
|---|---|---|---|---|---|
| 59/59 | 59/59 | 59/59 | 59/59 | 59/59 | 59/59 |

**The ASan entry is entirely green** -- it was 58/59 before, with `test_bip39` as
its only failure and the only red entry of the matrix. The default configuration
used by `unit_tests.yml` is 59/59 as well. The `ctest` count is unchanged: the
three tests join the existing `test_bip39` target, so there is no new
`add_executable()` and no list to touch.

A file of `src/` changes, so all six devices of `ledger_app.toml` were
cross-compiled, with no warnings:

| device | `text` |
|---|---|
| nanos | 40 648 |
| nanox | 46 136 |
| nanos+ | 46 152 |
| stax | 72 305 |
| flex | 72 845 |
| apex_p | 69 233 |

`nanos` is built by hand, since `ci-workflow.yml` deliberately no longer builds
it. Its size is **identical before and after** the change -- 40 648 text, 0 data,
3 708 bss -- which is what a reordered condition should cost.

`clang-format --dry-run -Werror` is clean on both files. The Speculos scripts
are not concerned by this change.
