### PR TITLE
tests: cover the multi-group refusals and the CBOR length header, and correct the 128-bit interop vector

### DIFF
--- a/tests/unit/CMakeLists.txt
+++ b/tests/unit/CMakeLists.txt
@@ -799,6 +799,19 @@ add_executable(test_bip39_properties ./tests/bip39_properties.c ../../src/common
 target_include_directories(test_bip39_properties PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/../../src/common)
 target_link_libraries(test_bip39_properties PUBLIC cmocka gcov testutils)
 
+# Built with AddressSanitizer, and with sskr.c (plus sss.c/interpolate.c)
+# compiled into the test itself rather than linked from libsskr/libsss: the
+# refusals this file is about are what keep sskr_combine_shards_internal()
+# inside its own one-element groups[]/gx[]/gy[] arrays, so ASan has to
+# instrument those frames rather than only this file's. Same arrangement as
+# test_sskr_bound_group_count above. seed_sskr.c comes along for
+# bolos_ux_sskr_hex_check(), the entry point the user reaches first.
+add_executable(test_sskr_multi_group_refusal ./tests/sskr_multi_group_refusal.c ../../src/common/sskr/sskr.c ../../src/common/sskr/sss/sss.c ../../src/common/sskr/sss/interpolate.c ../../src/common/bip39/seed_rom_variables.c ../../src/common/bip39/seed_bip39.c ../../src/common/sskr/seed_rom_variables.c ../../src/common/sskr/seed_sskr.c)
+target_include_directories(test_sskr_multi_group_refusal PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/../../src/common ${CMAKE_CURRENT_SOURCE_DIR}/../../src/common/sskr ${CMAKE_CURRENT_SOURCE_DIR}/../../src/common/sskr/sss)
+target_compile_options(test_sskr_multi_group_refusal PRIVATE -fsanitize=address -fno-omit-frame-pointer)
+target_link_options(test_sskr_multi_group_refusal PRIVATE -fsanitize=address)
+target_link_libraries(test_sskr_multi_group_refusal PUBLIC cmocka gcov testutils)
+
 # Register every executable this file builds, instead of repeating their names
 # in a list kept by hand. A name missing from such a list costs nothing
 # visible: the target still compiles, still passes when run directly, and the

--- a/tests/unit/CMakeLists.txt
+++ b/tests/unit/CMakeLists.txt
@@ -812,6 +812,12 @@ target_compile_options(test_sskr_multi_group_refusal PRIVATE -fsanitize=address 
 target_link_options(test_sskr_multi_group_refusal PRIVATE -fsanitize=address)
 target_link_libraries(test_sskr_multi_group_refusal PUBLIC cmocka gcov testutils)
 
+# Goes through bolos_ux_bip39_to_sskr_convert(), so it needs the same set of
+# sources as the other seed_sskr.c tests.
+add_executable(test_sskr_cbor_length_header ./tests/sskr_cbor_length_header.c ../../src/common/bip39/seed_rom_variables.c ../../src/common/bip39/seed_bip39.c ../../src/common/sskr/seed_rom_variables.c ../../src/common/sskr/seed_sskr.c)
+target_include_directories(test_sskr_cbor_length_header PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/../../src/common)
+target_link_libraries(test_sskr_cbor_length_header PUBLIC cmocka gcov sskr sss testutils)
+
 # Register every executable this file builds, instead of repeating their names
 # in a list kept by hand. A name missing from such a list costs nothing
 # visible: the target still compiles, still passes when run directly, and the

--- a/tests/unit/tests/sskr_cbor_length_header.c
+++ b/tests/unit/tests/sskr_cbor_length_header.c
@@ -1,0 +1,288 @@
+/*
+ * The exact CBOR byte-string header this port emits, for the three share
+ * lengths it can produce, and nothing about it read back with the encoder's
+ * own convention.
+ *
+ * seed_sskr.c picks the form of that header from one threshold:
+ *
+ *     if (share_len < 24) { cbor[3] |= (share_len & 0x1F); cbor_len--; }
+ *     else                { cbor[3] |= 0x18; cbor[4] = share_len; }
+ *
+ * RFC 8949 section 3: for a byte string, additional-info values 0-23 carry
+ * the length in the initial byte, 24 announces one length byte, and 28-30
+ * are reserved -- data using them is *not well-formed*. Moving that
+ * threshold to 32 leaves the entire suite green while a 192-bit seed (18
+ * BIP-39 words, share_len 29) makes the application emit 0x5D on its own:
+ * major type 2, additional info 29, malformed CBOR, instead of 0x58 0x1D.
+ * 192 bits is the only seed size whose share length falls in 24-31, so it is
+ * the only one where the mistake shows.
+ *
+ * Nothing in the repository noticed, and the reason is worth stating because
+ * it dictates how this file is written:
+ *
+ *   - bolos_ux_sskr_hex_check() checks 3 tag bytes and the CRC-32; it never
+ *     parses the header.
+ *   - bolos_ux_sskr_combine() reads the length back as
+ *     sskr_shares_hex[3] & 0x1F -- its own encoder's convention. The
+ *     internal round trip stays consistent while the format leaves the
+ *     specification.
+ *   - sskr_wire_properties.c does generate 18-word sets, but its property is
+ *     "the encoder is accepted by this repository's own verifier".
+ *
+ * So a test that read the header back with `& 0x1F` would be worth nothing
+ * here. Two springs, both needed:
+ *
+ *   1. the emitted bytes are frozen as constants derived from RFC 8949, not
+ *      from this code: 21-byte shard -> 0x55, 29 -> 0x58 0x1D, 37 ->
+ *      0x58 0x25, with the whole wire length that follows from each;
+ *   2. a minimal header decoder written from RFC 8949 section 3, local to
+ *      this file, which insists on major type 2 and on the shortest form,
+ *      and refuses additional-info 28-30 as malformed. No `& 0x1F`.
+ *
+ * External anchor: BCR-2020-011 publishes the complete wire form of a
+ * 21-byte shard,
+ *     d99d75 55 4bbf1101025abd490ee65b6084859854ee67736e75
+ * so the 0x55 expected below is the specification's own byte, not this
+ * port's.
+ *     https://github.com/BlockchainCommons/Research/blob/master/papers/bcr-2020-011-sskr.md
+ */
+
+#include <cmocka.h>
+#include <setjmp.h>
+#include <stdarg.h>
+#include <stdbool.h>
+#include <stddef.h>
+#include <stdint.h>
+#include <string.h>
+
+/* testutils.h has to come first: it defines WIDE, which
+ * sskr/seed_rom_variables.h uses without defining. Not sorted, hence the
+ * clang-format exclusion. */
+// clang-format off
+#include "testutils.h"
+#include "bip39/common_bip39.h"
+#include "sskr/common_sskr.h"
+// clang-format on
+
+#define CBOR_TAG_LEN (3) /* D9 9D 75, tag #6.40309 */
+#define CRC_LEN (4)
+#define MAX_SHARES (3)
+#define MAX_WIRE_BYTES SSKR_SHARE_MAX_WIRE_LENGTH
+#define MAX_WORDS_PER_SHARE (MAX_WIRE_BYTES * (SSKR_BYTEWORD_LENGTH + 1))
+#define MAX_MNEMONIC_LEN (24 * 9)
+
+typedef struct {
+    unsigned int words; /* BIP-39 word count */
+    uint8_t seed_len;   /* bytes of entropy */
+    uint8_t shard_len;  /* SSKR_METADATA_LENGTH_BYTES + seed_len */
+    uint8_t header[2];  /* the byte-string header, from RFC 8949 */
+    uint8_t header_len; /* 1 or 2 */
+} expectation_t;
+
+/*
+ * The three seed sizes this application offers, with the byte-string header
+ * RFC 8949 section 3 prescribes for each shard length:
+ *
+ *   21 < 24  -> additional info carries the length: 0x40 | 21 = 0x55
+ *   29 >= 24 -> additional info 24 (0x58), then the length byte 0x1D
+ *   37 >= 24 -> 0x58, then 0x25
+ *
+ * Written out rather than computed so that this table cannot drift with the
+ * code it pins.
+ */
+static const expectation_t k_expectations[] = {
+    {12, 16, 21, {0x55, 0x00}, 1},
+    {18, 24, 29, {0x58, 0x1D}, 2},
+    {24, 32, 37, {0x58, 0x25}, 2},
+};
+
+/* Fixed entropy per size; the header does not depend on it, and a constant
+ * keeps a failure reproducible. */
+static const uint8_t k_entropy[32] = {
+    0x00, 0x11, 0x22, 0x33, 0x44, 0x55, 0x66, 0x77, 0x88, 0x99, 0xAA,
+    0xBB, 0xCC, 0xDD, 0xEE, 0xFF, 0x0F, 0x1E, 0x2D, 0x3C, 0x4B, 0x5A,
+    0x69, 0x78, 0x87, 0x96, 0xA5, 0xB4, 0xC3, 0xD2, 0xE1, 0xF0};
+
+/*
+ * A byte-string header decoder written from RFC 8949 section 3, on purpose
+ * knowing nothing of how seed_sskr.c builds one. Returns the declared length
+ * and writes how many bytes the header occupies. Anything that is not a
+ * well-formed, shortest-form definite-length byte string fails the test on
+ * the spot.
+ */
+static size_t rfc8949_byte_string_length(const uint8_t* header,
+                                         size_t available, size_t* header_len) {
+    assert_true(available >= 1);
+
+    const uint8_t major_type = (uint8_t)(header[0] >> 5);
+    const uint8_t additional_info = (uint8_t)(header[0] & 0x1F);
+
+    if (major_type != 2) {
+        fail_msg("initial byte 0x%02X is major type %u, not 2 (byte string)",
+                 header[0], major_type);
+    }
+
+    if (additional_info <= 23) {
+        *header_len = 1;
+        return additional_info;
+    }
+
+    if (additional_info == 24) {
+        assert_true(available >= 2);
+        /* Shortest form: a length below 24 has to be carried by the initial
+         * byte, so the long form may not be used for it. */
+        if (header[1] < 24) {
+            fail_msg(
+                "length %u encoded in long form 0x58 %02X, but it fits "
+                "in the initial byte",
+                header[1], header[1]);
+        }
+        *header_len = 2;
+        return header[1];
+    }
+
+    if (additional_info >= 25 && additional_info <= 27) {
+        fail_msg(
+            "initial byte 0x%02X announces a %u-byte length; no share is "
+            "long enough to need one",
+            header[0], 1u << (additional_info - 24));
+    }
+
+    if (additional_info >= 28 && additional_info <= 30) {
+        fail_msg(
+            "initial byte 0x%02X uses reserved additional info %u: "
+            "RFC 8949 makes this data item not well-formed",
+            header[0], additional_info);
+    }
+
+    fail_msg(
+        "initial byte 0x%02X is an indefinite-length byte string, which "
+        "is not a share",
+        header[0]);
+    return 0; /* not reached: fail_msg() does not return */
+}
+
+/*
+ * Drives the production encoder for one seed size and hands back the first
+ * share as bytes, exactly as the entry screens reconstruct them from typed
+ * ByteWords. Returns the length of one share in bytes.
+ */
+static unsigned int encode_first_share(const expectation_t* expected,
+                                       uint8_t* share) {
+    unsigned char mnemonic[MAX_MNEMONIC_LEN];
+    unsigned char words[MAX_SHARES * MAX_WORDS_PER_SHARE];
+    unsigned int group_descriptor[2] = {2, MAX_SHARES};
+    unsigned int words_len = 0;
+    uint8_t share_count = 0;
+
+    const unsigned int mnemonic_len = bolos_ux_bip39_mnemonic_encode(
+        k_entropy, expected->seed_len, mnemonic, sizeof(mnemonic));
+    assert_int_not_equal(mnemonic_len, 0);
+
+    bolos_ux_bip39_to_sskr_convert(mnemonic, mnemonic_len, expected->words,
+                                   group_descriptor, &share_count, words,
+                                   &words_len);
+
+    assert_int_equal(share_count, MAX_SHARES);
+    assert_int_not_equal(words_len, 0);
+
+    /* Space-separated ByteWords: one share of n bytes is
+     * n * (length + 1) - 1 characters long. */
+    const unsigned int chars_per_share = words_len / share_count;
+    const unsigned int bytes_per_share =
+        (chars_per_share + 1) / (SSKR_BYTEWORD_LENGTH + 1);
+
+    assert_true(bytes_per_share <= MAX_WIRE_BYTES);
+
+    for (unsigned int i = 0; i < bytes_per_share; i++) {
+        const unsigned char* byteword = &words[i * (SSKR_BYTEWORD_LENGTH + 1)];
+        assert_true(bolos_ux_sskr_byteword_to_hex(byteword, &share[i]));
+    }
+
+    return bytes_per_share;
+}
+
+/*
+ * Spring 1: the bytes on the wire are the ones RFC 8949 prescribes, and the
+ * frame is exactly as long as those bytes imply.
+ */
+static void test_emitted_length_header_is_frozen(void** state) {
+    (void)state;
+
+    for (size_t i = 0; i < sizeof(k_expectations) / sizeof(k_expectations[0]);
+         i++) {
+        const expectation_t* expected = &k_expectations[i];
+        uint8_t share[MAX_WIRE_BYTES];
+
+        const unsigned int share_bytes = encode_first_share(expected, share);
+
+        const uint8_t tag[CBOR_TAG_LEN] = {0xD9, 0x9D, 0x75};
+        assert_memory_equal(share, tag, sizeof(tag));
+
+        assert_memory_equal(&share[CBOR_TAG_LEN], expected->header,
+                            expected->header_len);
+
+        assert_int_equal(share_bytes, CBOR_TAG_LEN + expected->header_len +
+                                          expected->shard_len + CRC_LEN);
+    }
+}
+
+/*
+ * Spring 2: read back with RFC 8949 rather than with `& 0x1F`. The declared
+ * length has to be the shard length, in a well-formed shortest-form header.
+ */
+static void test_emitted_header_parses_as_rfc8949(void** state) {
+    (void)state;
+
+    for (size_t i = 0; i < sizeof(k_expectations) / sizeof(k_expectations[0]);
+         i++) {
+        const expectation_t* expected = &k_expectations[i];
+        uint8_t share[MAX_WIRE_BYTES];
+
+        const unsigned int share_bytes = encode_first_share(expected, share);
+
+        size_t header_len = 0;
+        const size_t declared = rfc8949_byte_string_length(
+            &share[CBOR_TAG_LEN], share_bytes - CBOR_TAG_LEN, &header_len);
+
+        assert_int_equal(declared, expected->shard_len);
+        assert_int_equal(header_len, expected->header_len);
+        assert_int_equal(share_bytes,
+                         CBOR_TAG_LEN + header_len + declared + CRC_LEN);
+    }
+}
+
+/*
+ * The same decoder against the complete wire form BCR-2020-011 publishes for
+ * a 21-byte shard. Its header byte is the specification's, and it is the one
+ * the table above expects for a 128-bit seed.
+ */
+static void test_published_wire_form_agrees(void** state) {
+    (void)state;
+
+    static const uint8_t k_published[] = {
+        0xD9, 0x9D, 0x75, 0x55, 0x4B, 0xBF, 0x11, 0x01, 0x02,
+        0x5A, 0xBD, 0x49, 0x0E, 0xE6, 0x5B, 0x60, 0x84, 0x85,
+        0x98, 0x54, 0xEE, 0x67, 0x73, 0x6E, 0x75};
+
+    size_t header_len = 0;
+    const size_t declared = rfc8949_byte_string_length(
+        &k_published[CBOR_TAG_LEN], sizeof(k_published) - CBOR_TAG_LEN,
+        &header_len);
+
+    assert_int_equal(header_len, 1);
+    assert_int_equal(declared, 21);
+    assert_int_equal(sizeof(k_published), CBOR_TAG_LEN + header_len + declared);
+
+    /* and it is the byte this port is expected to emit for a 128-bit seed */
+    assert_int_equal(k_published[CBOR_TAG_LEN], k_expectations[0].header[0]);
+}
+
+int main(void) {
+    const struct CMUnitTest tests[] = {
+        cmocka_unit_test(test_emitted_length_header_is_frozen),
+        cmocka_unit_test(test_emitted_header_parses_as_rfc8949),
+        cmocka_unit_test(test_published_wire_form_agrees),
+    };
+    return cmocka_run_group_tests(tests, NULL, NULL);
+}

--- a/tests/unit/tests/sskr_interop_bc128.c
+++ b/tests/unit/tests/sskr_interop_bc128.c
@@ -12,12 +12,25 @@
  *     fly mule excess resource treat plunge nose soda reflect adult ramp
  *     planet
  *
- * Independently verified before writing this test by cloning and building
- * Blockchain Commons' own bc-sskr + bc-shamir + bc-crypto-base reference
- * implementation (unrelated to this repository) and combining share 1 with
- * share 2 below: it reconstructs 59f2293a5bce7d4de59e71b4207ac5d2. This is
- * coverage against an independent oracle, not a bug fix -- sskr_combine_shards()
- * is already correct.
+ * That document publishes its shares as ByteWords only, so the bytes below
+ * were obtained from it this way: each 29-word share was decoded with the
+ * 256-word table of BCR-2020-012, its trailing CRC-32 recomputed over the
+ * preceding 25 bytes and compared (all three match), and the 21-byte
+ * serialized shard taken out from between the CBOR header and that CRC-32.
+ * Nothing was recomputed with this port. The three shares decode to
+ *
+ *     747200010041c07bbc6ae0b757ac459350ac76e051
+ *     74720001017a8ed97600e5ac541199c54ebee621f7
+ *     7472000102375c2433beea8151cde63f6c884d7906
+ *
+ * and any two of them reconstruct 59f2293a5bce7d4de59e71b4207ac5d2 with a
+ * valid SLIP-39 share digest, checked against an independent GF(2^8)
+ * implementation written from the specification. This is coverage against an
+ * external oracle, not a bug fix -- sskr_combine_shards() is already correct.
+ *
+ * Only the shard layer is used here, which is why the document's bytes fit
+ * unchanged: the wire frames it publishes carry the now-superseded CBOR tag
+ * 309, and that layer is not involved below.
  *
  * Only 2 of the 3 published shares are needed (2-of-3 threshold); the third
  * one is not used here. No 192-bit vector exists in the source document
@@ -36,13 +49,14 @@ static void test_sskr_combine_bc_128bit_vector(void **state) {
     (void) state;
 
     /* metadata (5 bytes) + value (16 bytes), member_index 0 and 1 of a
-     * 2-of-3 single-group set, hex from sskr-test-vector.md unmodified. */
-    const uint8_t share1[] = {0x74, 0x72, 0x00, 0x01, 0x00, 0x72, 0x79, 0x90,
-                              0x3D, 0xCB, 0x83, 0x3F, 0x4B, 0xF7, 0xD4, 0x33,
-                              0xFD, 0xAE, 0x81, 0x59, 0x13};
-    const uint8_t share2[] = {0x74, 0x72, 0x00, 0x01, 0x01, 0x1B, 0x3F, 0x98,
-                              0x69, 0x92, 0x4E, 0x46, 0x03, 0x14, 0x4D, 0x4A,
-                              0x40, 0x84, 0xF0, 0x90, 0xCC};
+     * 2-of-3 single-group set, as decoded from the ByteWords published in
+     * sskr-test-vector.md. */
+    const uint8_t share1[] = {0x74, 0x72, 0x00, 0x01, 0x00, 0x41, 0xC0, 0x7B,
+                              0xBC, 0x6A, 0xE0, 0xB7, 0x57, 0xAC, 0x45, 0x93,
+                              0x50, 0xAC, 0x76, 0xE0, 0x51};
+    const uint8_t share2[] = {0x74, 0x72, 0x00, 0x01, 0x01, 0x7A, 0x8E, 0xD9,
+                              0x76, 0x00, 0xE5, 0xAC, 0x54, 0x11, 0x99, 0xC5,
+                              0x4E, 0xBE, 0xE6, 0x21, 0xF7};
     const uint8_t expected_secret[] = {0x59, 0xF2, 0x29, 0x3A, 0x5B, 0xCE,
                                        0x7D, 0x4D, 0xE5, 0x9E, 0x71, 0xB4,
                                        0x20, 0x7A, 0xC5, 0xD2};

--- a/tests/unit/tests/sskr_interop_bc128_bytewords.c
+++ b/tests/unit/tests/sskr_interop_bc128_bytewords.c
@@ -17,9 +17,9 @@
  * Blockchain Commons' published sskr-test-vector.md cannot be used directly
  * at this layer: it uses the now-superseded CBOR tag 309 (0xD90135), while
  * the current spec (bcr-2020-011-sskr.md) and this port both use 40309
- * (0xD99D75) -- see SECURITY-AUDIT.md / the note added to
- * sskr-test-vector.md for the discovery. Hence the manual wrap instead of
- * reusing that document's own wire bytes.
+ * (0xD99D75). Hence the manual wrap instead of reusing that document's own
+ * wire bytes. Its shards are used unchanged one layer down, in
+ * sskr_interop_bc128.c, where no CBOR tag is involved.
  *
  * The round trip (bc-sskr generate -> manual CBOR/ByteWords wrap -> decoded
  * back with bc-sskr) was verified before writing this test. Expected

--- a/tests/unit/tests/sskr_multi_group_refusal.c
+++ b/tests/unit/tests/sskr_multi_group_refusal.c
@@ -1,0 +1,243 @@
+/*
+ * The two places this port refuses a multi-group shard set, and the entry
+ * point a user reaches before either of them.
+ *
+ * SSKR_MAX_GROUP_COUNT is 1 here (sskr-constants.h), where upstream bc-sskr
+ * and BCR-2020-011 both allow 16, and sskr_combine_shards_internal()
+ * declares its working array on the stack accordingly:
+ *
+ *     sskr_group_t groups[SSKR_MAX_GROUP_COUNT];
+ *
+ * Two refusals stand between that one-element array and a shard set that
+ * names more than one group:
+ *
+ *   - sskr.c:507, `next_group >= SSKR_MAX_GROUP_COUNT` -> -8. This is the
+ *     only thing that stops the ten lines below it from filling
+ *     groups[next_group] with next_group == 1. Replacing it with `if (0)`
+ *     and building the suite with -fsanitize=address aborts in
+ *     sskr_combine_invariants.c with a stack-buffer-overflow at sskr.c:512,
+ *     so that one is already held. What this file adds for it is thin, and
+ *     worth naming as such: sskr_combine_invariants.c goes through
+ *     bolos_ux_sskr_combine(), whose unsigned return collapses the 25 codes
+ *     reachable there to 0, so the -8 is read here at the library boundary
+ *     instead. sskr_shard_count.c does already read -8 out of
+ *     sskr_combine_shards(), but for the shards_count bound at sskr.c:599,
+ *     not for this guard.
+ *   - sskr.c:524, `next_group < group_threshold` -> -14, for a set whose
+ *     header asks for two groups when only one was supplied. A gcov run over
+ *     the whole suite gives this one an execution count of zero: nothing
+ *     reaches it. It is a bound too, not just a diagnosis: gx and gy are
+ *     also SSKR_MAX_GROUP_COUNT long, and without it sss_recover_secret() is
+ *     called with the header's group threshold of 2 and reads gx[1]. Turning
+ *     it into `else if (0)` and running this file under
+ *     -fsanitize=address gives
+ *
+ *         stack-buffer-overflow ... READ of size 1
+ *         #0 interpolate interpolate.c:168
+ *         #1 sss_recover_secret sss.c:181
+ *         #2 sskr_combine_shards_internal sskr.c:563
+ *         [48, 49) 'gx' (line 530) <== Memory access at offset 49 overflows
+ *
+ *     which is why this target is built with the sanitizer.
+ *
+ * Nothing here is a live defect: both refusals are present and correct. The
+ * input that reaches them is ordinary user input -- shares of a multi-group
+ * SSKR backup, produced by another tool and typed in on the device -- not a
+ * contrived case, which is why the third test below drives the entry point
+ * the device actually runs first rather than the library underneath it.
+ *
+ * The vector is the worked example of BCR-2020-011 itself:
+ *     https://github.com/BlockchainCommons/Research/blob/master/papers/bcr-2020-011-sskr.md
+ * group 0 is 2-of-3, group 1 is 3-of-5, group threshold 2, master secret
+ * 7daa851251002874e1a1995f0897e6b1. The 8 serialized shards are published
+ * there; each 5-byte header decodes as the document annotates it, byte 2 =
+ * 0x11 meaning group-threshold-1 = 1 and group-count-1 = 1. Reconstructing
+ * that secret from them was checked outside this repository with a GF(2^8)
+ * implementation written from the specification -- group 0 yields
+ * 6015c954ff45a28b7058353d11817e11, group 1 yields
+ * 3755185d7868f88a35118ae93612c73e, the two together yield the published
+ * master secret, with valid SLIP-39 share digests at both levels. Nothing
+ * was recomputed with this port, which would have been circular.
+ *
+ * The wire frames further down add the CBOR tag 40309, the byte-string
+ * length header and the CRC-32 the entry screens produce. Their prefix is
+ * the specification's own published wire form for the third shard,
+ * d99d75554bbf1101025abd490ee65b6084859854ee67736e75, which is what
+ * authenticates them.
+ */
+
+#include <cmocka.h>
+#include <setjmp.h>
+#include <stdarg.h>
+#include <stddef.h>
+#include <stdint.h>
+#include <string.h>
+
+/* testutils.h has to come first: it defines WIDE, which
+ * sskr/seed_rom_variables.h uses without defining. Not sorted, hence the
+ * clang-format exclusion. */
+// clang-format off
+#include "testutils.h"
+#include "sskr.h"
+#include "sskr-constants.h"
+#include "sskr/common_sskr.h"
+// clang-format on
+
+#define SHARD_LEN (SSKR_METADATA_LENGTH_BYTES + 16)
+#define WIRE_LEN (29)  /* tag(3) + length byte(1) + shard(21) + CRC-32(4) */
+#define GROUP_SIZE (3) /* how many shards of each group are used here */
+
+/* BCR-2020-011 "Example/Test Vector", serialized shards, verbatim.
+ * Header bytes: 4b bf | 11 | gi mt-1 | mi. */
+static const uint8_t k_group0[GROUP_SIZE][SHARD_LEN] = {
+    {0x4B, 0xBF, 0x11, 0x01, 0x00, 0x3E, 0x99, 0x0C, 0x1F, 0x04, 0x35,
+     0xE2, 0xB3, 0x3C, 0x72, 0x15, 0x35, 0xC7, 0x46, 0x03, 0xD0},
+    {0x4B, 0xBF, 0x11, 0x01, 0x01, 0x0C, 0x8B, 0xA3, 0x9A, 0x75, 0x02,
+     0xA3, 0x25, 0xED, 0x07, 0xB8, 0xD5, 0x97, 0xD1, 0xB8, 0x0F},
+    {0x4B, 0xBF, 0x11, 0x01, 0x02, 0x5A, 0xBD, 0x49, 0x0E, 0xE6, 0x5B,
+     0x60, 0x84, 0x85, 0x98, 0x54, 0xEE, 0x67, 0x73, 0x6E, 0x75},
+};
+
+static const uint8_t k_group1[GROUP_SIZE][SHARD_LEN] = {
+    {0x4B, 0xBF, 0x11, 0x12, 0x00, 0x44, 0xEF, 0x45, 0x3F, 0x66, 0x92,
+     0x3D, 0x32, 0x65, 0x3B, 0x37, 0x7D, 0xE5, 0xC9, 0x4B, 0x39},
+    {0x4B, 0xBF, 0x11, 0x12, 0x01, 0x6F, 0xFB, 0x1B, 0x0C, 0xC5, 0xAB,
+     0x48, 0x5F, 0x5A, 0x67, 0x13, 0x6C, 0x80, 0x2B, 0xC6, 0x7B},
+    {0x4B, 0xBF, 0x11, 0x12, 0x02, 0xA3, 0x76, 0x31, 0x55, 0xFC, 0xFD,
+     0xB5, 0x88, 0x7A, 0xBC, 0xE6, 0xEE, 0x69, 0xC4, 0xBB, 0xCD},
+};
+
+/* The same shards in the form the share entry screens hand to
+ * bolos_ux_sskr_hex_check(): CBOR tag D9 9D 75, short-form byte-string
+ * header 0x55 (21 bytes), the shard, then the CRC-32 in network byte order
+ * over the 25 preceding bytes. */
+static const uint8_t k_group0_wire[GROUP_SIZE][WIRE_LEN] = {
+    {0xD9, 0x9D, 0x75, 0x55, 0x4B, 0xBF, 0x11, 0x01, 0x00, 0x3E,
+     0x99, 0x0C, 0x1F, 0x04, 0x35, 0xE2, 0xB3, 0x3C, 0x72, 0x15,
+     0x35, 0xC7, 0x46, 0x03, 0xD0, 0x52, 0x3C, 0xDA, 0x82},
+    {0xD9, 0x9D, 0x75, 0x55, 0x4B, 0xBF, 0x11, 0x01, 0x01, 0x0C,
+     0x8B, 0xA3, 0x9A, 0x75, 0x02, 0xA3, 0x25, 0xED, 0x07, 0xB8,
+     0xD5, 0x97, 0xD1, 0xB8, 0x0F, 0x47, 0xF4, 0x7B, 0x79},
+    {0xD9, 0x9D, 0x75, 0x55, 0x4B, 0xBF, 0x11, 0x01, 0x02, 0x5A,
+     0xBD, 0x49, 0x0E, 0xE6, 0x5B, 0x60, 0x84, 0x85, 0x98, 0x54,
+     0xEE, 0x67, 0x73, 0x6E, 0x75, 0x86, 0x82, 0xBD, 0xB2},
+};
+
+static const uint8_t k_group1_wire[GROUP_SIZE][WIRE_LEN] = {
+    {0xD9, 0x9D, 0x75, 0x55, 0x4B, 0xBF, 0x11, 0x12, 0x00, 0x44,
+     0xEF, 0x45, 0x3F, 0x66, 0x92, 0x3D, 0x32, 0x65, 0x3B, 0x37,
+     0x7D, 0xE5, 0xC9, 0x4B, 0x39, 0xBE, 0xD9, 0x49, 0x68},
+    {0xD9, 0x9D, 0x75, 0x55, 0x4B, 0xBF, 0x11, 0x12, 0x01, 0x6F,
+     0xFB, 0x1B, 0x0C, 0xC5, 0xAB, 0x48, 0x5F, 0x5A, 0x67, 0x13,
+     0x6C, 0x80, 0x2B, 0xC6, 0x7B, 0xC4, 0xE1, 0xF2, 0x20},
+    {0xD9, 0x9D, 0x75, 0x55, 0x4B, 0xBF, 0x11, 0x12, 0x02, 0xA3,
+     0x76, 0x31, 0x55, 0xFC, 0xFD, 0xB5, 0x88, 0x7A, 0xBC, 0xE6,
+     0xEE, 0x69, 0xC4, 0xBB, 0xCD, 0x82, 0xD1, 0x9A, 0xB8},
+};
+
+/*
+ * The refusal at sskr.c:507, read at the library boundary rather than
+ * through bolos_ux_sskr_combine(). Both shards carry the same identifier,
+ * group threshold, group count and value length, so the common-metadata
+ * check above it passes and they are genuinely sorted into groups; they
+ * differ only in group_index, which is exactly the case a one-element
+ * groups[] cannot hold. Without the guard this is a write to groups[1].
+ *
+ * The lightest of the three tests here: sskr_combine_invariants.c already
+ * reaches this branch, and only sees the 0 that bolos_ux_sskr_combine()
+ * turns every failure into. -8 rather than, say, -10 is what says the set
+ * names more than one group.
+ */
+static void test_combine_refuses_shards_from_two_groups(void** state) {
+    (void)state;
+
+    const uint8_t* shards[] = {k_group0[0], k_group1[0]};
+    uint8_t output[SSKR_MAX_STRENGTH_BYTES];
+
+    const int16_t result =
+        sskr_combine_shards(shards, SHARD_LEN, 2, output, sizeof(output));
+
+    assert_int_equal(result, SSKR_ERROR_INVALID_SHARD_SET);
+}
+
+/*
+ * The refusal at sskr.c:524, the one nothing reached. Here the member
+ * threshold of group 0 is satisfied -- two shards of a 2-of-3 group, enough
+ * to recover that group's own secret -- but the header of both says two
+ * groups are required, and only one was supplied. The distinct code matters:
+ * -14 says "bring shares from the other group", where -11 (not enough member
+ * shards) or -8 would send the user looking for the wrong thing. What is
+ * behind it matters more: the group threshold this compares against is read
+ * out of the entered shards, and everything the recombination indexes by it
+ * is one element long.
+ */
+static void test_combine_refuses_a_single_group_of_a_two_group_set(
+    void** state) {
+    (void)state;
+
+    const uint8_t* shards[] = {k_group0[0], k_group0[1]};
+    uint8_t output[SSKR_MAX_STRENGTH_BYTES];
+
+    const int16_t result =
+        sskr_combine_shards(shards, SHARD_LEN, 2, output, sizeof(output));
+
+    assert_int_equal(result, SSKR_ERROR_NOT_ENOUGH_GROUPS);
+}
+
+/* bolos_ux_sskr_hex_check() wipes what it rejects, so every call works on a
+ * fresh copy. */
+static unsigned int hex_check_copy(const uint8_t* frames,
+                                   unsigned int share_count) {
+    uint8_t buffer[GROUP_SIZE * 2 * WIRE_LEN];
+    const unsigned int length = share_count * WIRE_LEN;
+
+    assert_true(length <= sizeof(buffer));
+    memcpy(buffer, frames, length);
+
+    return bolos_ux_sskr_hex_check(buffer, length, share_count);
+}
+
+/*
+ * The path the user actually reaches: the shares are typed in, and
+ * bolos_ux_sskr_hex_check() runs before sskr_combine_shards() ever sees
+ * them. Its "the first 8 bytes of every share must match" test is what
+ * refuses a set drawn from two groups, one byte earlier than the group
+ * index itself -- D9 9D 75 55 4B BF 11 01 against ... 11 12, differing at
+ * byte 7, the group-count/group-index boundary.
+ *
+ * The three controls come first and are not decoration: this function
+ * rejects on a bad CRC-32 too, and a wrong CRC in the frames above would
+ * make the rejection below pass for the wrong reason. Each group on its own
+ * is accepted, so the CRCs are right and the tag is right, and the only
+ * thing left to reject the mixed set is the byte comparison.
+ */
+static void test_hex_check_refuses_shares_from_two_groups(void** state) {
+    (void)state;
+
+    /* controls: each group, on its own, is well-formed */
+    assert_int_equal(hex_check_copy(&k_group0_wire[0][0], GROUP_SIZE), 1);
+    assert_int_equal(hex_check_copy(&k_group1_wire[0][0], GROUP_SIZE), 1);
+    assert_int_equal(hex_check_copy(&k_group0_wire[0][0], 1), 1);
+    assert_int_equal(hex_check_copy(&k_group1_wire[0][0], 1), 1);
+
+    /* the frames differ for the first time at byte 7, inside the 8 bytes
+     * compared, and nowhere earlier */
+    assert_memory_equal(k_group0_wire[0], k_group1_wire[0], 7);
+    assert_int_not_equal(k_group0_wire[0][7], k_group1_wire[0][7]);
+
+    uint8_t mixed[2 * WIRE_LEN];
+    memcpy(&mixed[0], k_group0_wire[0], WIRE_LEN);
+    memcpy(&mixed[WIRE_LEN], k_group1_wire[0], WIRE_LEN);
+
+    assert_int_equal(hex_check_copy(mixed, 2), 0);
+}
+
+int main(void) {
+    const struct CMUnitTest tests[] = {
+        cmocka_unit_test(test_combine_refuses_shards_from_two_groups),
+        cmocka_unit_test(
+            test_combine_refuses_a_single_group_of_a_two_group_set),
+        cmocka_unit_test(test_hex_check_refuses_shares_from_two_groups),
+    };
+    return cmocka_run_group_tests(tests, NULL, NULL);
+}


### PR DESCRIPTION
Three independent test-side subjects on SSKR. **No file under `src/` changes**
-- `git diff --stat <base>..HEAD -- src/` is empty. The compiled application is
unchanged, so no cross-compilation or size measurement was needed, and the
Speculos scripts are not concerned.

## 1. A test vector of ours was not what its header said it was

`tests/unit/tests/sskr_interop_bc128.c` described its bytes as *"hex from
sskr-test-vector.md unmodified"*. They were not those bytes.

That document publishes its 2-of-3 shares as ByteWords only. Decoding all three
with the 256-word table of BCR-2020-012 and recomputing their trailing CRC-32
over the preceding 25 bytes (all three match) gives:

```
747200010041c07bbc6ae0b757ac459350ac76e051
74720001017a8ed97600e5ac541199c54ebee621f7
7472000102375c2433beea8151cde63f6c884d7906
```

The file held different bytes: the ones in `sskr_interop_bc128_bytewords.c`,
generated with `bc-sskr` under identifier `0x0100`, with the identifier
rewritten to the document's `0x7472`. Verified by decoding the ByteWords of
that second file and comparing: with the identifier put back, the two byte
strings are equal.

So the two vectors presented as independent were one vector counted twice.

This is not a bug fix. The old bytes are a valid share set, the test passed,
and it still passes. What was wrong is the provenance the header claimed. The
published shares are now in the file; only the raw shard layer is exercised
here (`sskr_combine_shards()`, no CBOR header and no CRC-32), so the document's
bytes fit unchanged and the expected secret `59f2293a5bce7d4de59e71b4207ac5d2`
does not move. There is now genuinely a second external oracle.

Separately, the header of `sskr_interop_bc128_bytewords.c` carried **two dead
references**: one to a document that is not part of this repository, and one to
a note "added to sskr-test-vector.md" that does not appear in the published
document (re-fetched to confirm -- it contains no occurrence of "309", "40309"
or "0135"). Both are removed. The rest of that comment is accurate -- its bytes
do come from `bc-sskr` -- and is left alone.

## 2. One of the two multi-group refusals was an unguarded stack read

`SSKR_MAX_GROUP_COUNT` is 1 in this port, where upstream `bc-sskr`
(`src/encoding.c`: `sskr_group groups[16]`, `gx[16]`, `gy[16]`) and
BCR-2020-011 both allow 16. `sskr_combine_shards_internal()` sizes its stack
arrays on it: `groups[1]`, `gx[1]`, `gy[1]`. Two refusals stand between those
arrays and a shard set naming more than one group.

**`sskr.c:507`, `next_group >= SSKR_MAX_GROUP_COUNT` -> `-8`** -- already held.
`sskr_combine_invariants.c` drives a two-group set through
`bolos_ux_sskr_combine()`, and replacing the guard with `if (0)` makes that
file abort under `-fsanitize=address` with a `stack-buffer-overflow` at
`sskr.c:512`. What it never sees is the code, because `bolos_ux_sskr_combine()`
returns an unsigned length and turns the 25 codes reachable through it into 0,
so `-8` is now read at the library boundary. That is the lightest of the three
additions, and worth saying plainly: `sskr_shard_count.c` already reads `-8`
out of `sskr_combine_shards()`, for the `shards_count` bound at `sskr.c:599`
rather than for this guard.

**`sskr.c:524`, `next_group < group_threshold` -> `-14`** -- this one had an
execution count of zero over the whole suite, and it is a bound, not only a
diagnosis. The group threshold it compares against is read out of the entered
shards, and `gx`/`gy` are one element long. Turned into `else if (0)`, two
shards of a 2-of-3 group whose header declares two groups required send
`sss_recover_secret()` looking for a second group, and it reads `gx[1]`:

```
ERROR: AddressSanitizer: stack-buffer-overflow  READ of size 1
  #0 interpolate                  src/common/sskr/sss/interpolate.c:168
  #1 sss_recover_secret           src/common/sskr/sss/sss.c:181
  #2 sskr_combine_shards_internal src/common/sskr/sskr.c:563
  [48, 49) 'gx' (line 530) <== Memory access at offset 49 overflows this variable
```

With that mutation the other 60 tests stay green and only the new file goes
red.

**There is no live defect here.** Both refusals are present and correct. What
was missing was anything holding the second one in place.

**The input that reaches them is ordinary user input**: the shares of a
multi-group SSKR backup, produced by another tool and typed in on the device.
A third test therefore drives `bolos_ux_sskr_hex_check()`, the entry point the
three share-entry screens run before the library sees anything. Its "the first
8 bytes of every share must match" test is what refuses a set drawn from two
groups -- `D9 9D 75 55 4B BF 11 01` against `... 11 12`, differing at byte 7.
Each group is checked on its own first and accepted, so the rejection cannot be
blamed on a wrong CRC-32 in the frames.

## 3. The CBOR length header was held by nothing

`seed_sskr.c` chooses between the short and the long form of the RFC 8949
byte-string header on one comparison, `share_len < 24`. Moving it to 32 leaves
all 59 existing tests green while, for a 192-bit seed (18 BIP-39 words,
`share_len` 29), the application emits `0x5D` on its own -- major type 2,
additional info 29, which RFC 8949 section 3 reserves and which is therefore
**not well-formed CBOR** -- instead of `0x58 0x1D`. The share loses a word. 192
bits is the only seed size whose share length falls in 24-31.

Nothing saw it, and the reasons dictate how the test is written:

- `bolos_ux_sskr_hex_check()` checks three tag bytes and the CRC-32; it never
  parses the header;
- `bolos_ux_sskr_combine()` reads the length back as
  `sskr_shares_hex[3] & 0x1F`, **its own encoder's convention**, so the
  internal round trip stays consistent while the format leaves the
  specification;
- `sskr_wire_properties.c` does generate 18-word sets, but its property is that
  this repository's encoder is accepted by this repository's verifier.

A test reading the header back with `& 0x1F` would be worth nothing here. Two
springs, both needed: the emitted bytes are frozen as constants derived from
RFC 8949 (21 -> `0x55`, 29 -> `0x58 0x1D`, 37 -> `0x58 0x25`) together with the
frame length each implies; and a byte-string header decoder written **from
RFC 8949 section 3**, local to the file, which insists on major type 2 and on
the shortest form and rejects additional info 28-30 as not well-formed. With
the threshold moved to 32, both fire -- `5d 01` where `58 1d` was expected, and
*"initial byte 0x5D uses reserved additional info 29"* -- and no other test in
the suite goes red.

## Vectors

Both come from published specifications, are cited by URL, and **were never
recomputed with this port**, which would have been circular. They were checked
against a GF(2^8) implementation written from the specification and controlled
on the AES reference product `gmul(0x57, 0x83) == 0xC1`.

- [BCR-2020-011, "Example/Test Vector"](https://github.com/BlockchainCommons/Research/blob/master/papers/bcr-2020-011-sskr.md)
  -- 2 groups, group 0 in 2-of-3, group 1 in 3-of-5, group threshold 2. Group 0
  yields `6015c954ff45a28b7058353d11817e11`, group 1 yields
  `3755185d7868f88a35118ae93612c73e`, the two together yield the published
  master secret `7daa851251002874e1a1995f0897e6b1`, with valid SLIP-39 share
  digests at both levels. The wire frames used for `hex_check()` add the CBOR
  tag, length header and CRC-32; their prefix reproduces the complete wire form
  the specification itself publishes for the third shard,
  `d99d75554bbf1101025abd490ee65b6084859854ee67736e75`.
- [crypto-commons, `Docs/sskr-test-vector.md`, 128-bit seed](https://github.com/BlockchainCommons/crypto-commons/blob/master/Docs/sskr-test-vector.md#128-bit-seed)
  -- any two of the three published shares reconstruct
  `59f2293a5bce7d4de59e71b4207ac5d2` with a valid SLIP-39 share digest.

## Two things this pins down for later

- **The single-group restriction is now written into the tests.** Nothing here
  changes it -- `SSKR_MAX_GROUP_COUNT` still equals 1 -- but the day it is
  raised, the first two tests of `sskr_multi_group_refusal.c` go red by
  construction, since they assert that a two-group set is refused. That is
  intended: it makes lifting the restriction an explicit act rather than a side
  effect.
- **The wire format is frozen.** Any future change to `seed_sskr.c` that alters
  the bytes a share carries now breaks the build, which is exactly what was
  missing.

## Verification

| Configuration | Result |
|---|---|
| ASan | 61/61 |
| UBSan | 61/61 |
| `-O2` | 61/61 |
| `-Os` | 61/61 |
| `-fsigned-char` | 61/61 |
| `-funsigned-char` | 61/61 |
| default (Debug, `-O0`) | 61/61 |

- `ctest` goes from 59 to 61; registration is automatic, no list was touched.
- 19 compiler warnings, all pre-existing, none in the two new files.
- Line coverage of `src/common/sskr/sskr.c`: **220/238 -> 226/238** (92.4% ->
  95.0%). `sskr.c:508` goes from 1 to 2 and `sskr.c:524` from 0 to 1; the four
  other lines gained are the stack-array declarations of the two combine
  functions. All six are attributable to the new target alone, checked by
  running it in isolation.
- The matrix was replayed on the committed tree, not only on the working tree.
- `clang-format` is clean on both new files. The two pre-existing files edited
  here were already not `clang-format` clean on the base branch (as are about
  twenty other files under `tests/`) and were deliberately not reformatted, so
  that the diff stays readable.

## Commits

1. `tests: use the published shares in the 128-bit interop vector`
2. `tests: hold the two multi-group refusals of sskr_combine_shards()`
3. `tests: freeze the CBOR byte-string length header a share carries`
