### PR TITLE
tests: cover the SSKR and BIP-39 keyboard suggestions, which no target compiled

### DIFF
--- a/tests/unit/CMakeLists.txt
+++ b/tests/unit/CMakeLists.txt
@@ -857,6 +857,20 @@ target_compile_definitions(test_sskr_keyboard_candidates_stax PRIVATE HAVE_NBGL 
 target_include_directories(test_sskr_keyboard_candidates_stax PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/../../src/common)
 target_link_libraries(test_sskr_keyboard_candidates_stax PUBLIC cmocka gcov sskr sss testutils)
 
+# The BIP-39 half of the same gap, on the same pattern as the SSKR pair above:
+# the two functions are structurally identical, and only the wordlist they walk
+# differs. Unlike SSKR, this one needs neither sskr nor sss -- seed_bip39.c and
+# its wordlist are the whole dependency, as they already are for test_bip39.
+add_executable(test_bip39_keyboard_candidates ./tests/bip39_keyboard_candidates.c ../../src/common/bip39/seed_rom_variables.c ../../src/common/bip39/seed_bip39.c)
+target_compile_definitions(test_bip39_keyboard_candidates PRIVATE HAVE_NBGL TARGET_FLEX)
+target_include_directories(test_bip39_keyboard_candidates PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/../../src/common)
+target_link_libraries(test_bip39_keyboard_candidates PUBLIC cmocka gcov testutils)
+
+add_executable(test_bip39_keyboard_candidates_stax ./tests/bip39_keyboard_candidates.c ../../src/common/bip39/seed_rom_variables.c ../../src/common/bip39/seed_bip39.c)
+target_compile_definitions(test_bip39_keyboard_candidates_stax PRIVATE HAVE_NBGL TARGET_STAX)
+target_include_directories(test_bip39_keyboard_candidates_stax PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/../../src/common)
+target_link_libraries(test_bip39_keyboard_candidates_stax PUBLIC cmocka gcov testutils)
+
 # Register every executable this file builds, instead of repeating their names
 # in a list kept by hand. A name missing from such a list costs nothing
 # visible: the target still compiles, still passes when run directly, and the

--- a/tests/unit/CMakeLists.txt
+++ b/tests/unit/CMakeLists.txt
@@ -818,6 +818,45 @@ add_executable(test_sskr_cbor_length_header ./tests/sskr_cbor_length_header.c ..
 target_include_directories(test_sskr_cbor_length_header PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/../../src/common)
 target_link_libraries(test_sskr_cbor_length_header PUBLIC cmocka gcov sskr sss testutils)
 
+# The targets below are the first in this suite to define HAVE_NBGL.
+#
+# The keyboard suggestions of both entry paths -- bolos_ux_*_fill_with_candidates()
+# and bolos_ux_*_get_keyboard_mask(), at the end of seed_sskr.c and seed_bip39.c
+# -- live behind `#if defined(HAVE_NBGL)`, and until these targets existed the
+# preprocessor removed them from every build the suite made. That is a harder
+# gap to notice than an untested function: lines the preprocessor removes are
+# neither covered nor uncovered in coverage.info, so lcov reported 96.2% for
+# seed_sskr.c over lines 52-486 of a 542-line file, and 95.8% for seed_bip39.c
+# over lines 26-319 of a 376-line file, with nothing marked missing. Comparing
+# the extent of the DA: entries against the length of the file is what shows it.
+# (The same is still true of src/common/bip85/seed_bip85.c, noted above: every
+# function in its HAVE_NBGL block reaches os_derive_bip32_no_throw() through
+# bolos_ux_bip85_entropy(), a BOLOS syscall with no host equivalent, so that one
+# is out of reach for a different reason and stays where it is.)
+#
+# What blocked it was one line: both guarded blocks open with
+# `#include <nbgl_layout.h>`, an SDK header the harness does not have. The only
+# symbol they take from it is NB_MAX_SUGGESTION_BUTTONS, so lib/nbgl_layout.h
+# supplies that and nothing else, on the model of the empty lib/glyphs.h and
+# lib/bolos_target.h.
+#
+# That constant is target-dependent in the SDK -- 12 on Stax, 8 on Flex and
+# Apex -- and it is the cap fill_with_candidates() applies with MIN() before
+# writing into buffers the caller sized from the same constant. Since it decides
+# what the cap test is testing, each of the two files is built twice, once per
+# live value, rather than a value being picked. TARGET_STAX and TARGET_FLEX are
+# read by lib/nbgl_layout.h only; neither seed_sskr.c nor seed_bip39.c nor the
+# wordlists mention any TARGET_* macro.
+add_executable(test_sskr_keyboard_candidates ./tests/sskr_keyboard_candidates.c ../../src/common/bip39/seed_rom_variables.c ../../src/common/bip39/seed_bip39.c ../../src/common/sskr/seed_rom_variables.c ../../src/common/sskr/seed_sskr.c)
+target_compile_definitions(test_sskr_keyboard_candidates PRIVATE HAVE_NBGL TARGET_FLEX)
+target_include_directories(test_sskr_keyboard_candidates PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/../../src/common)
+target_link_libraries(test_sskr_keyboard_candidates PUBLIC cmocka gcov sskr sss testutils)
+
+add_executable(test_sskr_keyboard_candidates_stax ./tests/sskr_keyboard_candidates.c ../../src/common/bip39/seed_rom_variables.c ../../src/common/bip39/seed_bip39.c ../../src/common/sskr/seed_rom_variables.c ../../src/common/sskr/seed_sskr.c)
+target_compile_definitions(test_sskr_keyboard_candidates_stax PRIVATE HAVE_NBGL TARGET_STAX)
+target_include_directories(test_sskr_keyboard_candidates_stax PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/../../src/common)
+target_link_libraries(test_sskr_keyboard_candidates_stax PUBLIC cmocka gcov sskr sss testutils)
+
 # Register every executable this file builds, instead of repeating their names
 # in a list kept by hand. A name missing from such a list costs nothing
 # visible: the target still compiles, still passes when run directly, and the

--- a/tests/unit/lib/nbgl_layout.h
+++ b/tests/unit/lib/nbgl_layout.h
@@ -1,0 +1,60 @@
+#pragma once
+
+/*
+ * Stand-in for the SDK's lib_nbgl/include/nbgl_layout.h.
+ *
+ * lib/glyphs.h and lib/bolos_target.h are here for the same reason and are
+ * empty: the harness only has to make an `#include` resolve. This one cannot
+ * be empty, because the block it unblocks reads a value from it.
+ *
+ * `#if defined(HAVE_NBGL)` at the end of src/common/sskr/seed_sskr.c and
+ * src/common/bip39/seed_bip39.c opens with `#include <nbgl_layout.h>`, and the
+ * only symbol the four functions behind that guard take from it is
+ * NB_MAX_SUGGESTION_BUTTONS. Nothing else in the real header is referenced
+ * (MIN comes from the SDK's os.h, PRINTF from its debug header, and
+ * ALPHABET_LENGTH/KBD_LETTERS from src/common/common.h), so nothing else is
+ * reproduced here.
+ *
+ * The value is not a free choice: it is the cap that
+ * bolos_ux_*_fill_with_candidates() applies with MIN() before writing into
+ * buffers its caller sized from the same constant, so it decides what the
+ * tests are actually testing. It is copied from the SDK, per target, with the
+ * SDK's own conditional structure:
+ *
+ *   ledger-secure-sdk, lib_nbgl/include/nbgl_layout.h (tag
+ *   stax_1.10.0-tr1-293-g4cd6b839, the revision shipped in
+ *   ghcr.io/ledgerhq/ledger-app-builder/ledger-app-dev-tools:latest):
+ *
+ *     #ifdef HAVE_SE_TOUCH
+ *     #if defined(TARGET_STAX)
+ *     #define NB_MAX_SUGGESTION_BUTTONS 12    (line 38)
+ *     #elif defined(TARGET_FLEX)
+ *     #define NB_MAX_SUGGESTION_BUTTONS 8     (line 68)
+ *     #elif defined(TARGET_APEX)
+ *     #define NB_MAX_SUGGESTION_BUTTONS 8     (line 98)
+ *     ...
+ *     #else  // HAVE_SE_TOUCH
+ *     #define NB_MAX_SUGGESTION_BUTTONS 8     (line 141)
+ *
+ * Of those, only the first three are live for this application. HAVE_NBGL is
+ * defined for stax, flex and apex_p; the other three devices in
+ * ledger_app.toml (nanos, nanox, nanos+) build with HAVE_BAGL, since the SDK
+ * only turns NBGL on for TARGET_NANOX/TARGET_NANOS2 when USE_NBGL=1 and this
+ * application's Makefile does not set it. So the constant is 12 on one device
+ * and 8 on the other two, and both values are exercised: each test file below
+ * is compiled into two executables, one with TARGET_STAX and one with
+ * TARGET_FLEX.
+ *
+ * The `#else` is an error rather than a default for the same reason the SDK
+ * writes `#error Undefined target` there: a silent fallback would let a test
+ * target compile against a number no device uses.
+ */
+
+#if defined(TARGET_STAX)
+#define NB_MAX_SUGGESTION_BUTTONS 12
+#elif defined(TARGET_FLEX) || defined(TARGET_APEX)
+#define NB_MAX_SUGGESTION_BUTTONS 8
+#else
+#error \
+    "No target defined: NB_MAX_SUGGESTION_BUTTONS is target-dependent in the SDK and must not be guessed"
+#endif

--- a/tests/unit/lib/ux_nbgl.h
+++ b/tests/unit/lib/ux_nbgl.h
@@ -1,0 +1,17 @@
+#pragma once
+
+/*
+ * Deliberately empty, like lib/glyphs.h and lib/bolos_target.h.
+ *
+ * Defining HAVE_NBGL for a target makes the SDK's own include chain reach this
+ * header -- os.h pulls in ux.h, which does `#ifdef HAVE_NBGL / #include
+ * "ux_nbgl.h"` -- and the real one lives in lib_ux_nbgl, a directory the
+ * harness does not put on the include path, behind nbgl_screen.h and
+ * nbgl_touch.h and the rest of the graphics library.
+ *
+ * None of that is reachable from what the HAVE_NBGL targets actually compile:
+ * the guarded blocks of seed_sskr.c and seed_bip39.c are string matching over
+ * a wordlist and take nothing from the UX state. So this file exists only to
+ * let the SDK's `#include` resolve, and the moment anything in it were needed,
+ * the link would say so rather than this quietly standing in.
+ */

--- a/tests/unit/tests/bip39_keyboard_candidates.c
+++ b/tests/unit/tests/bip39_keyboard_candidates.c
@@ -1,0 +1,611 @@
+/*
+ * The BIP-39 keyboard suggestions: bolos_ux_bip39_fill_with_candidates() and
+ * bolos_ux_bip39_get_keyboard_mask(), the two functions behind
+ * `#if defined(HAVE_NBGL)` at the end of src/common/bip39/seed_bip39.c.
+ *
+ * Same blind spot as its twin, tests/sskr_keyboard_candidates.c: no test
+ * target defined HAVE_NBGL, so the preprocessor removed both functions from
+ * every build, and lcov reported neither a covered nor an uncovered line for
+ * them -- seed_bip39.c showed 95.8% over lines 26-319 of a 376-line file.
+ *
+ * The two files assert the same properties. They cannot share an oracle: the
+ * SSKR wordlist is 256 ByteWords of a fixed four characters, while this one is
+ * 2048 words of one to eight characters reached through an offset table, and
+ * the offset table is exactly what an oracle has to walk independently.
+ *
+ * See lib/nbgl_layout.h for the stubbed NBGL constant these functions read and
+ * why this file is compiled into two executables.
+ */
+
+#include <cmocka.h>
+#include <inttypes.h>
+#include <setjmp.h>
+#include <stdarg.h>
+#include <stdbool.h>
+#include <stddef.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+/* Two ordering constraints, hence the clang-format exclusion: testutils.h has
+ * to come first because it defines WIDE, which bip39/seed_rom_variables.h uses
+ * without defining, and cx.h has to precede common.h, which declares
+ * compare_recovery_phrase_finish() as taking a cx_err_t. */
+// clang-format off
+#include "testutils.h"
+#include <cx.h>
+#include "common.h"
+#include "bip39/common_bip39.h"
+#include "bip39/seed_rom_variables.h"
+#include <nbgl_layout.h>
+// clang-format on
+
+#define BIP39_WORD_COUNT (BIP39_WORDLIST_OFFSETS_LENGTH - 1)
+
+/* Longest word in the list. src/constants.h calls it BIP39_MAX_WORD_LENGTH and
+ * src/nbgl/ui.c sizes its buffers from it; that header is not on this target's
+ * include path, and the value is checked against the offset table below rather
+ * than trusted. */
+#define BIP39_LONGEST_WORD 8
+
+/* The keypad's own key, always left enabled so a wrong letter can be undone.
+ * seed_bip39.c writes it as `1 << 28` with no name. */
+#define BACK_KEY_BIT (UINT32_C(1) << 28)
+
+/* Longest prefix the sweep below enumerates over the whole alphabet. Above
+ * this it enumerates prefixes taken from the wordlist instead: the 26^4
+ * four-letter prefixes would be 457k calls for the 456k of them that match
+ * nothing. */
+#define MAX_SWEPT_LENGTH 3
+
+/* Enough for any prefix either half of the sweep produces, plus a terminator.
+ * One character past the longest word is swept too, so that a prefix longer
+ * than any word is covered. */
+#define PREFIX_CAPACITY (BIP39_LONGEST_WORD + 2)
+
+static const char kbd_letters[] = KBD_LETTERS;
+
+/* ---------------------------------------------------------------- oracles */
+
+/* The wordlist read directly through its offset table, not through the
+ * functions under test, so that a defect in
+ * bolos_ux_bip39_get_word_count_starting_with() and friends cannot cancel out
+ * against the same defect in the expectation. */
+
+static size_t word_length(size_t index) {
+    return (size_t)(BIP39_WORDLIST_OFFSETS[index + 1] -
+                    BIP39_WORDLIST_OFFSETS[index]);
+}
+
+static const unsigned char* word_at(size_t index) {
+    return &BIP39_WORDLIST[BIP39_WORDLIST_OFFSETS[index]];
+}
+
+/* A word matches when it is at least as long as the prefix and agrees with it
+ * over the prefix's whole length -- the condition seed_bip39.c's inner `while`
+ * loop expresses as "j reached prefixlength". */
+static bool word_matches(size_t index, const char* prefix,
+                         size_t prefix_length) {
+    return word_length(index) >= prefix_length &&
+           memcmp(word_at(index), prefix, prefix_length) == 0;
+}
+
+static size_t oracle_match_count(const char* prefix, size_t prefix_length) {
+    size_t count = 0;
+    for (size_t i = 0; i < BIP39_WORD_COUNT; i++) {
+        if (word_matches(i, prefix, prefix_length)) {
+            count++;
+        }
+    }
+    return count;
+}
+
+/* Index of the first matching word, or BIP39_WORD_COUNT if there is none. */
+static size_t oracle_first_match(const char* prefix, size_t prefix_length) {
+    for (size_t i = 0; i < BIP39_WORD_COUNT; i++) {
+        if (word_matches(i, prefix, prefix_length)) {
+            return i;
+        }
+    }
+    return BIP39_WORD_COUNT;
+}
+
+/* The set of letters that extend `prefix` into a word, as a bitmask over
+ * KBD_LETTERS positions. Built with |=, deliberately: the function under test
+ * uses += (see test_the_mask_matches_the_wordlist_for_every_prefix). */
+static uint32_t oracle_next_letter_bits(const char* prefix,
+                                        size_t prefix_length) {
+    uint32_t bits = 0;
+    for (size_t i = 0; i < BIP39_WORD_COUNT; i++) {
+        /* A word the prefix spells out in full has no next letter. 49 words of
+         * this list are proper prefixes of another one -- "add" of "addict",
+         * "art" of "artist" -- so this is a real case, not a formality. */
+        if (!word_matches(i, prefix, prefix_length) ||
+            word_length(i) == prefix_length) {
+            continue;
+        }
+        const char next = (char)word_at(i)[prefix_length];
+        /* strchr() would find a '\0' at the end of KBD_LETTERS and report
+         * position 26, one past the 26 letters; the wordlist holds no such
+         * character and this says so rather than assuming it. */
+        assert_true(next != '\0');
+        const char* const position = strchr(kbd_letters, next);
+        assert_non_null(position);
+        bits |= UINT32_C(1) << (size_t)(position - kbd_letters);
+    }
+    return bits;
+}
+
+static uint32_t oracle_keyboard_mask(const char* prefix, size_t prefix_length) {
+    return ~(BACK_KEY_BIT | oracle_next_letter_bits(prefix, prefix_length));
+}
+
+static size_t oracle_next_letter_count(const char* prefix,
+                                       size_t prefix_length) {
+    uint32_t bits = oracle_next_letter_bits(prefix, prefix_length);
+    size_t count = 0;
+    while (bits != 0) {
+        count += bits & 1u;
+        bits >>= 1;
+    }
+    return count;
+}
+
+/* ------------------------------------------------------------------ sweep */
+
+/* Every prefix of length 0 to MAX_SWEPT_LENGTH over the 26 keyboard letters,
+ * then every prefix of every word, then every word with one extra letter
+ * appended -- prefixes longer than the word they extend, which the entry code
+ * can produce since it does not stop the user at the word's length. */
+static void sweep_prefixes(void (*check)(const char* prefix,
+                                         size_t prefix_length)) {
+    char prefix[PREFIX_CAPACITY];
+
+    for (size_t length = 0; length <= MAX_SWEPT_LENGTH; length++) {
+        size_t combinations = 1;
+        for (size_t i = 0; i < length; i++) {
+            combinations *= 26;
+        }
+        for (size_t combination = 0; combination < combinations;
+             combination++) {
+            size_t remainder = combination;
+            for (size_t position = length; position-- > 0;) {
+                prefix[position] = kbd_letters[remainder % 26];
+                remainder /= 26;
+            }
+            prefix[length] = '\0';
+            check(prefix, length);
+        }
+    }
+
+    for (size_t i = 0; i < BIP39_WORD_COUNT; i++) {
+        const size_t length_of_word = word_length(i);
+        assert_true(length_of_word <= BIP39_LONGEST_WORD);
+        memcpy(prefix, word_at(i), length_of_word);
+        for (size_t length = MAX_SWEPT_LENGTH + 1; length <= length_of_word;
+             length++) {
+            prefix[length] = '\0';
+            check(prefix, length);
+        }
+        prefix[length_of_word] = 'a';
+        prefix[length_of_word + 1] = '\0';
+        check(prefix, length_of_word + 1);
+    }
+}
+
+/* ------------------------------------------- the candidate suggestions */
+
+/* Buffers sized exactly to what the correct behaviour writes, on the heap so
+ * that AddressSanitizer's redzones make a single byte past the end a failure
+ * in the ASan configuration of .github/workflows/unit-tests-matrix.yml, and
+ * not only a wrong return value in the others. src/nbgl/ui.c hands over
+ * `wordCandidates[(BIP39_MAX_WORD_LENGTH + 1) * NB_MAX_SUGGESTION_BUTTONS]`
+ * and `buttonTexts[NB_MAX_SUGGESTION_BUTTONS]`; sizing to the words actually
+ * expected rather than to that worst case is what makes an overrun visible. */
+struct candidate_buffers {
+    char* words;
+    size_t words_size;
+    const char** indexor;
+    size_t indexor_count;
+};
+
+/* Room for `count` candidates starting at word `first`, each with its own
+ * terminator -- the layout fill_with_candidates() is supposed to produce. */
+static struct candidate_buffers alloc_candidate_buffers(size_t first,
+                                                        size_t count) {
+    struct candidate_buffers buffers;
+    buffers.indexor_count = count;
+    buffers.words_size = 0;
+    for (size_t i = 0; i < count; i++) {
+        buffers.words_size += word_length(first + i) + 1;
+    }
+    /* calloc(0, ...) may return NULL; one spare byte keeps the no-match case
+     * pointing at real memory so that "the buffer was not written" is a
+     * statement about a buffer that exists. It doubles as the guard byte the
+     * capped case checks. */
+    buffers.words = calloc(buffers.words_size + 1, 1);
+    buffers.indexor = calloc(count + 1, sizeof(*buffers.indexor));
+    assert_non_null(buffers.words);
+    assert_non_null(buffers.indexor);
+    return buffers;
+}
+
+static void free_candidate_buffers(struct candidate_buffers* buffers) {
+    free(buffers->words);
+    free((void*)buffers->indexor);
+    buffers->words = NULL;
+    buffers->indexor = NULL;
+}
+
+static void test_no_match_returns_zero_and_writes_nothing(void** state) {
+    (void)state;
+
+    /* No BIP-39 word starts with "zz". */
+    const char prefix[] = "zz";
+    assert_int_equal(oracle_match_count(prefix, strlen(prefix)), 0);
+
+    struct candidate_buffers buffers =
+        alloc_candidate_buffers(0, NB_MAX_SUGGESTION_BUTTONS);
+    memset(buffers.words, 0xA5, buffers.words_size);
+    for (size_t i = 0; i < buffers.indexor_count; i++) {
+        buffers.indexor[i] = (const char*)(uintptr_t)0xA5A5A5A5u;
+    }
+
+    const size_t returned = bolos_ux_bip39_fill_with_candidates(
+        (const unsigned char*)prefix, strlen(prefix), buffers.words,
+        buffers.indexor);
+
+    assert_int_equal(returned, 0);
+    for (size_t i = 0; i < buffers.words_size; i++) {
+        if ((unsigned char)buffers.words[i] != 0xA5) {
+            fail_msg(
+                "byte %zu of the candidate buffer was written for a "
+                "prefix that matches no word",
+                i);
+        }
+    }
+    for (size_t i = 0; i < buffers.indexor_count; i++) {
+        if (buffers.indexor[i] != (const char*)(uintptr_t)0xA5A5A5A5u) {
+            fail_msg(
+                "entry %zu of the indexor was written for a prefix that "
+                "matches no word",
+                i);
+        }
+    }
+
+    free_candidate_buffers(&buffers);
+}
+
+static void test_a_single_match_is_copied_and_terminated(void** state) {
+    (void)state;
+
+    /* "aerobic" is the only word starting with "ae". */
+    const char prefix[] = "ae";
+    const size_t prefix_length = strlen(prefix);
+    assert_int_equal(oracle_match_count(prefix, prefix_length), 1);
+    const size_t first = oracle_first_match(prefix, prefix_length);
+
+    struct candidate_buffers buffers = alloc_candidate_buffers(first, 1);
+
+    const size_t returned = bolos_ux_bip39_fill_with_candidates(
+        (const unsigned char*)prefix, prefix_length, buffers.words,
+        buffers.indexor);
+
+    assert_int_equal(returned, 1);
+    assert_string_equal(buffers.words, "aerobic");
+    /* The word is NUL-terminated inside the buffer, not merely followed by
+     * one: the byte at the word's own length is the terminator. */
+    assert_int_equal(buffers.words[word_length(first)], '\0');
+    /* And the indexor points at it, rather than anywhere else that happens to
+     * hold the same characters. */
+    assert_ptr_equal(buffers.indexor[0], buffers.words);
+
+    free_candidate_buffers(&buffers);
+}
+
+static void test_more_matches_than_buttons_are_capped(void** state) {
+    (void)state;
+
+    /* 48 words start with "re", far past either live value of
+     * NB_MAX_SUGGESTION_BUTTONS (12 on Stax, 8 on Flex and Apex). Unlike its
+     * SSKR twin, this cap is reached constantly in use: two characters is the
+     * shortest prefix src/nbgl/ui.c ever passes, and this list has 67
+     * two-character prefixes that match more than 12 words.
+     *
+     * It is the MIN() on this line that bounds the writes into the caller's
+     * two buffers, and so the only line of this function that memory safety
+     * depends on. */
+    const char prefix[] = "re";
+    const size_t prefix_length = strlen(prefix);
+    assert_true(oracle_match_count(prefix, prefix_length) >
+                NB_MAX_SUGGESTION_BUTTONS);
+    const size_t first = oracle_first_match(prefix, prefix_length);
+
+    struct candidate_buffers buffers =
+        alloc_candidate_buffers(first, NB_MAX_SUGGESTION_BUTTONS);
+
+    const size_t returned = bolos_ux_bip39_fill_with_candidates(
+        (const unsigned char*)prefix, prefix_length, buffers.words,
+        buffers.indexor);
+
+    assert_int_equal(returned, NB_MAX_SUGGESTION_BUTTONS);
+    /* The spare slot past the cap is untouched, in the build configurations
+     * where ASan is not watching the redzone for us. */
+    assert_null(buffers.indexor[NB_MAX_SUGGESTION_BUTTONS]);
+    assert_int_equal(buffers.words[buffers.words_size], '\0');
+
+    free_candidate_buffers(&buffers);
+}
+
+static void test_the_buffer_holds_consecutive_nul_separated_words(
+    void** state) {
+    (void)state;
+
+    /* Six words start with "bri", of two different lengths (brick, bridge,
+     * brief, bright, bring, brisk), so the offset the writer advances by is
+     * not the same for every candidate. Checking the count alone would let an
+     * offset that drifts go unnoticed, so every candidate is checked against
+     * the wordlist entry it should be, at the offset it should be at. */
+    const char prefix[] = "bri";
+    const size_t prefix_length = strlen(prefix);
+    const size_t matches = oracle_match_count(prefix, prefix_length);
+    assert_true(matches > 1);
+    assert_true(matches <= NB_MAX_SUGGESTION_BUTTONS);
+    const size_t first = oracle_first_match(prefix, prefix_length);
+
+    struct candidate_buffers buffers = alloc_candidate_buffers(first, matches);
+
+    const size_t returned = bolos_ux_bip39_fill_with_candidates(
+        (const unsigned char*)prefix, prefix_length, buffers.words,
+        buffers.indexor);
+
+    assert_int_equal(returned, matches);
+
+    size_t offset = 0;
+    for (size_t i = 0; i < returned; i++) {
+        const size_t expected_length = word_length(first + i);
+
+        /* Consecutive, one after the other, each ending in its own '\0'. */
+        if (memcmp(&buffers.words[offset], word_at(first + i),
+                   expected_length) != 0) {
+            fail_msg("candidate %zu is '%s', expected '%.*s'", i,
+                     &buffers.words[offset], (int)expected_length,
+                     (const char*)word_at(first + i));
+        }
+        assert_int_equal(buffers.words[offset + expected_length], '\0');
+        /* And the indexor entry points inside the buffer the caller supplied,
+         * at that word. */
+        assert_ptr_equal(buffers.indexor[i], &buffers.words[offset]);
+
+        offset += expected_length + 1;
+    }
+    assert_int_equal(offset, buffers.words_size);
+
+    free_candidate_buffers(&buffers);
+}
+
+static void test_the_empty_prefix_returns_the_head_of_the_wordlist(
+    void** state) {
+    (void)state;
+
+    /* Not reachable through the interface: src/nbgl/ui.c calls this function
+     * only when the entered text is two characters or more ("Suggestions only
+     * when the word contains 2+ letters"), and the mask function only when it
+     * is at least one. Established rather than assumed, and pinned here
+     * anyway, because the function is public and an empty prefix is the case
+     * where every word matches -- the widest input the cap has to hold. */
+    const char prefix[] = "";
+    assert_int_equal(oracle_match_count(prefix, 0), BIP39_WORD_COUNT);
+
+    struct candidate_buffers buffers =
+        alloc_candidate_buffers(0, NB_MAX_SUGGESTION_BUTTONS);
+
+    const size_t returned = bolos_ux_bip39_fill_with_candidates(
+        (const unsigned char*)prefix, 0, buffers.words, buffers.indexor);
+
+    assert_int_equal(returned, NB_MAX_SUGGESTION_BUTTONS);
+    size_t offset = 0;
+    for (size_t i = 0; i < returned; i++) {
+        if (memcmp(&buffers.words[offset], word_at(i), word_length(i)) != 0) {
+            fail_msg(
+                "candidate %zu of the empty prefix is '%s', expected the "
+                "wordlist's own word %zu, '%.*s'",
+                i, &buffers.words[offset], i, (int)word_length(i),
+                (const char*)word_at(i));
+        }
+        offset += word_length(i) + 1;
+    }
+
+    free_candidate_buffers(&buffers);
+}
+
+/* ------------------------------------------------- the keyboard mask */
+
+static void check_mask(const char* prefix, size_t prefix_length) {
+    const uint32_t returned = bolos_ux_bip39_get_keyboard_mask(
+        (const unsigned char*)prefix, (unsigned int)prefix_length);
+    const uint32_t expected = oracle_keyboard_mask(prefix, prefix_length);
+    if (returned != expected) {
+        fail_msg("prefix '%s': mask is 0x%08" PRIX32 ", expected 0x%08" PRIX32
+                 " (differing bits 0x%08" PRIX32 ")",
+                 prefix, returned, expected, returned ^ expected);
+    }
+}
+
+static void test_the_mask_matches_the_wordlist_for_every_prefix(void** state) {
+    (void)state;
+
+    /* Exact in both directions, on every prefix the sweep produces: a letter
+     * is enabled if and only if it extends some word. Inclusion alone would
+     * pass a mask that enables the whole alphabet.
+     *
+     * This is also what holds the `existing_mask += 1 << i` in seed_bip39.c,
+     * which is an addition where a bitwise or would be the natural thing to
+     * write. The two agree only while no letter is offered twice: a second
+     * `+= 1 << i` for the same i carries into bit i+1, enabling the wrong
+     * key. bolos_ux_bip39_get_word_next_letters_starting_with() cannot produce
+     * that duplicate, because it compares each candidate letter against the
+     * one it wrote last and the wordlist is alphabetically ordered, which
+     * makes equal next-letters contiguous. That reasoning is what this
+     * exhaustive comparison against an oracle built with |= turns into
+     * something the suite checks rather than something a reader has to
+     * accept: any duplicate, on any prefix, moves a bit and shows up here. */
+    sweep_prefixes(check_mask);
+}
+
+static void test_the_back_key_is_always_enabled(void** state) {
+    (void)state;
+
+    /* seed_bip39.c seeds the mask with `1 << 28` before adding letters, and
+     * the caller reads the result as the set of *disabled* keys, so the bit
+     * is clear in every mask this function returns -- including for a prefix
+     * that matches nothing, where it is the only key left to press. */
+    static const char* const prefixes[] = {"",   "a",       "ab",
+                                           "zz", "abandon", "abandona"};
+    for (size_t i = 0; i < sizeof(prefixes) / sizeof(prefixes[0]); i++) {
+        const uint32_t mask =
+            bolos_ux_bip39_get_keyboard_mask((const unsigned char*)prefixes[i],
+                                             (unsigned int)strlen(prefixes[i]));
+        if ((mask & BACK_KEY_BIT) != 0) {
+            fail_msg("prefix '%s': the back key is disabled (mask 0x%08" PRIX32
+                     ")",
+                     prefixes[i], mask);
+        }
+    }
+}
+
+static void test_a_dead_end_prefix_disables_every_letter(void** state) {
+    (void)state;
+
+    /* No word starts with "zz", so no letter can extend it. */
+    assert_int_equal(oracle_next_letter_count("zz", 2), 0);
+    assert_int_equal(
+        bolos_ux_bip39_get_keyboard_mask((const unsigned char*)"zz", 2),
+        ~BACK_KEY_BIT);
+
+    /* A complete word that no other word extends is a dead end too. */
+    assert_int_equal(oracle_next_letter_count("abandon", 7), 0);
+    assert_int_equal(
+        bolos_ux_bip39_get_keyboard_mask((const unsigned char*)"abandon", 7),
+        ~BACK_KEY_BIT);
+}
+
+static void test_a_word_that_extends_another_still_offers_its_letters(
+    void** state) {
+    (void)state;
+
+    /* "add" is a word and is also the start of "addict" and "address", so the
+     * prefix is complete and extendable at once: the mask has to offer i and
+     * r while the suggestions already hold "add" itself. The next-letter
+     * scan skips the exact match (there is no fourth letter to take from it)
+     * without letting that stop the scan. */
+    assert_int_equal(oracle_match_count("add", 3), 3);
+    assert_int_equal(oracle_next_letter_count("add", 3), 2);
+    check_mask("add", 3);
+}
+
+static void test_the_returned_mask_is_the_disabled_keys(void** state) {
+    (void)state;
+
+    /* One frozen value, so that the final `-1 ^ existing_mask` in
+     * seed_bip39.c has something holding it: what the function returns is the
+     * complement of what it computed, the keys to grey out rather than the
+     * keys to offer. Everything above is written against the oracle and would
+     * follow the convention if it flipped; this would not.
+     *
+     * "sa" is extended by ten letters -- d, f, i, l, m, n, t, u, v and y
+     * (sad, safe, sail, salad, same, sand, satisfy, sauce, save, satoshi and
+     * so on). In KBD_LETTERS ("qwertyuiopasdfghjklzxcvbnm") those sit at
+     * positions 12, 13, 7, 18, 25, 24, 4, 6, 22 and 5, and with bit 28 for the
+     * back key the enabled set is 0x134430F0. The function returns its
+     * complement. */
+    assert_int_equal(oracle_next_letter_count("sa", 2), 10);
+    assert_int_equal(
+        bolos_ux_bip39_get_keyboard_mask((const unsigned char*)"sa", 2),
+        0xECBBCF0F);
+}
+
+/* --------------------------------------------- the next-letter buffer */
+
+static size_t widest_next_letter_count;
+
+static void check_next_letters(const char* prefix, size_t prefix_length) {
+    /* Exactly the array bolos_ux_bip39_get_keyboard_mask() declares, on the
+     * heap so ASan sees a write past it. That function then writes
+     * `next_letters[nb_letters] = '\0'`, so a count of ALPHABET_LENGTH would
+     * already be one too many. */
+    unsigned char* const next_letters = calloc(ALPHABET_LENGTH, 1);
+    assert_non_null(next_letters);
+
+    const size_t count = bolos_ux_bip39_get_word_next_letters_starting_with(
+        (const unsigned char*)prefix, (unsigned int)prefix_length,
+        next_letters);
+
+    if (count >= ALPHABET_LENGTH) {
+        fail_msg(
+            "prefix '%s': %zu next letters, which leaves no room for "
+            "the terminator get_keyboard_mask() writes at index %zu of a "
+            "%d-byte array",
+            prefix, count, count, ALPHABET_LENGTH);
+    }
+    /* The write that the caller makes right after, at the index this function
+     * reported. Out of bounds by one byte and ASan says so. */
+    next_letters[count] = '\0';
+
+    assert_int_equal(count, oracle_next_letter_count(prefix, prefix_length));
+    for (size_t i = 0; i < count; i++) {
+        /* No letter read back as '\0'. The mask loop runs i over the full
+         * ALPHABET_LENGTH, one past the 26 letters of KBD_LETTERS, so it
+         * compares against that string's terminator once; a '\0' among the
+         * next letters would match it and enable bit 26, a key that is not on
+         * the keyboard. */
+        if (next_letters[i] == '\0') {
+            fail_msg("prefix '%s': next letter %zu is a NUL", prefix, i);
+        }
+        assert_non_null(strchr(kbd_letters, next_letters[i]));
+    }
+
+    if (count > widest_next_letter_count) {
+        widest_next_letter_count = count;
+    }
+
+    free(next_letters);
+}
+
+static void test_next_letters_never_fills_its_array(void** state) {
+    (void)state;
+
+    /* `unsigned char next_letters[ALPHABET_LENGTH]` with ALPHABET_LENGTH 27
+     * (src/common/common.h), filled by this function and then terminated by
+     * its caller at the returned index. The margin is not obvious from the
+     * declaration -- 27 for a 26-letter keyboard -- so it is measured here
+     * over every prefix in the sweep rather than argued.
+     *
+     * The widest case is the empty prefix, which offers the first letter of
+     * all 2048 words: 25 distinct letters, every letter except x. That leaves
+     * index 25 for the terminator and one byte spare. */
+    widest_next_letter_count = 0;
+    sweep_prefixes(check_next_letters);
+    assert_int_equal(widest_next_letter_count, 25);
+    assert_int_equal(oracle_next_letter_count("", 0), 25);
+}
+
+int main(void) {
+    const struct CMUnitTest tests[] = {
+        cmocka_unit_test(test_no_match_returns_zero_and_writes_nothing),
+        cmocka_unit_test(test_a_single_match_is_copied_and_terminated),
+        cmocka_unit_test(test_more_matches_than_buttons_are_capped),
+        cmocka_unit_test(test_the_buffer_holds_consecutive_nul_separated_words),
+        cmocka_unit_test(
+            test_the_empty_prefix_returns_the_head_of_the_wordlist),
+        cmocka_unit_test(test_the_mask_matches_the_wordlist_for_every_prefix),
+        cmocka_unit_test(test_the_back_key_is_always_enabled),
+        cmocka_unit_test(test_a_dead_end_prefix_disables_every_letter),
+        cmocka_unit_test(
+            test_a_word_that_extends_another_still_offers_its_letters),
+        cmocka_unit_test(test_the_returned_mask_is_the_disabled_keys),
+        cmocka_unit_test(test_next_letters_never_fills_its_array),
+    };
+    return cmocka_run_group_tests(tests, NULL, NULL);
+}

--- a/tests/unit/tests/sskr_keyboard_candidates.c
+++ b/tests/unit/tests/sskr_keyboard_candidates.c
@@ -1,0 +1,574 @@
+/*
+ * The SSKR keyboard suggestions: bolos_ux_sskr_fill_with_candidates() and
+ * bolos_ux_sskr_get_keyboard_mask(), the two functions behind
+ * `#if defined(HAVE_NBGL)` at the end of src/common/sskr/seed_sskr.c.
+ *
+ * Until this file existed, no test target defined HAVE_NBGL, so the
+ * preprocessor removed both of them from every build the suite made -- and
+ * lcov did not report a gap, because lines the preprocessor removes are
+ * neither covered nor uncovered: they do not exist for the tool. seed_sskr.c
+ * showed a healthy 96.2%, computed over lines 52-486 of a 542-line file. The
+ * DA: entries in coverage.info were the only place the hole was visible.
+ *
+ * Both functions are pure -- a typed prefix in, candidate words or a keyboard
+ * mask out -- so nothing here needs a screen or a syscall. The NBGL header
+ * they include is stubbed in lib/nbgl_layout.h for the single constant they
+ * read from it; see that file for where its value comes from and why this test
+ * is compiled twice, once per live value.
+ *
+ * tests/bip39_keyboard_candidates.c is the twin of this file. The two
+ * wordlists differ in shape -- 256 fixed-width ByteWords here, 2048
+ * variable-length words there, reached through an offset table -- so each file
+ * carries its own oracle, but the properties asserted are the same.
+ */
+
+#include <cmocka.h>
+#include <inttypes.h>
+#include <setjmp.h>
+#include <stdarg.h>
+#include <stdbool.h>
+#include <stddef.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+/* Two ordering constraints, hence the clang-format exclusion: testutils.h has
+ * to come first because it defines WIDE, which sskr/seed_rom_variables.h uses
+ * without defining, and cx.h has to precede common.h, which declares
+ * compare_recovery_phrase_finish() as taking a cx_err_t. */
+// clang-format off
+#include "testutils.h"
+#include <cx.h>
+#include "common.h"
+#include "sskr/common_sskr.h"
+#include "sskr/seed_rom_variables.h"
+#include <nbgl_layout.h>
+// clang-format on
+
+#define SSKR_WORD_COUNT (SSKR_WORDLIST_LENGTH / SSKR_BYTEWORD_LENGTH)
+
+/* The keypad's own key, always left enabled so a wrong letter can be undone.
+ * seed_sskr.c writes it as `1 << 28` with no name. */
+#define BACK_KEY_BIT (UINT32_C(1) << 28)
+
+/* Longest prefix the sweep below enumerates over the whole alphabet. Above
+ * this it enumerates prefixes taken from the wordlist instead: 26^4 prefixes
+ * would be 457k calls for the 456k of them that match nothing. */
+#define MAX_SWEPT_LENGTH 3
+
+/* Enough for any prefix either half of the sweep produces, plus a terminator.
+ * ByteWords are all SSKR_BYTEWORD_LENGTH long, and one character past that is
+ * swept too so that an over-long prefix is covered. */
+#define PREFIX_CAPACITY (SSKR_BYTEWORD_LENGTH + 2)
+
+static const char kbd_letters[] = KBD_LETTERS;
+
+/* ---------------------------------------------------------------- oracles */
+
+/* The wordlist read directly, not through the functions under test. Both
+ * oracles below walk SSKR_WORDLIST themselves so that a defect in
+ * bolos_ux_sskr_get_word_count_starting_with() and friends cannot cancel out
+ * against the same defect in the expectation. */
+
+static size_t oracle_match_count(const char* prefix, size_t prefix_length) {
+    if (prefix_length > SSKR_BYTEWORD_LENGTH) {
+        return 0;
+    }
+    size_t count = 0;
+    for (size_t i = 0; i < SSKR_WORD_COUNT; i++) {
+        if (memcmp(&SSKR_WORDLIST[SSKR_BYTEWORD_LENGTH * i], prefix,
+                   prefix_length) == 0) {
+            count++;
+        }
+    }
+    return count;
+}
+
+/* Index of the first matching word, or SSKR_WORD_COUNT if there is none. */
+static size_t oracle_first_match(const char* prefix, size_t prefix_length) {
+    if (prefix_length > SSKR_BYTEWORD_LENGTH) {
+        return SSKR_WORD_COUNT;
+    }
+    for (size_t i = 0; i < SSKR_WORD_COUNT; i++) {
+        if (memcmp(&SSKR_WORDLIST[SSKR_BYTEWORD_LENGTH * i], prefix,
+                   prefix_length) == 0) {
+            return i;
+        }
+    }
+    return SSKR_WORD_COUNT;
+}
+
+/* The set of letters that extend `prefix` into a word, as a bitmask over
+ * KBD_LETTERS positions. Built with |=, deliberately: the function under test
+ * uses += (see test_the_mask_matches_the_wordlist_for_every_prefix). */
+static uint32_t oracle_next_letter_bits(const char* prefix,
+                                        size_t prefix_length) {
+    uint32_t bits = 0;
+    if (prefix_length >= SSKR_BYTEWORD_LENGTH) {
+        /* A full-length ByteWord has no next letter, and neither has anything
+         * longer, which matches nothing at all. */
+        return bits;
+    }
+    for (size_t i = 0; i < SSKR_WORD_COUNT; i++) {
+        const unsigned char* const word =
+            &SSKR_WORDLIST[SSKR_BYTEWORD_LENGTH * i];
+        if (memcmp(word, prefix, prefix_length) != 0) {
+            continue;
+        }
+        const char next = (char)word[prefix_length];
+        /* strchr() would find a '\0' at the end of KBD_LETTERS and report
+         * position 26, one past the 26 letters; the wordlist holds no such
+         * character and this says so rather than assuming it. */
+        assert_true(next != '\0');
+        const char* const position = strchr(kbd_letters, next);
+        assert_non_null(position);
+        bits |= UINT32_C(1) << (size_t)(position - kbd_letters);
+    }
+    return bits;
+}
+
+static uint32_t oracle_keyboard_mask(const char* prefix, size_t prefix_length) {
+    return ~(BACK_KEY_BIT | oracle_next_letter_bits(prefix, prefix_length));
+}
+
+static size_t oracle_next_letter_count(const char* prefix,
+                                       size_t prefix_length) {
+    uint32_t bits = oracle_next_letter_bits(prefix, prefix_length);
+    size_t count = 0;
+    while (bits != 0) {
+        count += bits & 1u;
+        bits >>= 1;
+    }
+    return count;
+}
+
+/* ------------------------------------------------------------------ sweep */
+
+/* Every prefix of length 0 to MAX_SWEPT_LENGTH over the 26 keyboard letters,
+ * then every prefix of every ByteWord, then every ByteWord with one extra
+ * letter appended -- prefixes longer than a word, which the entry code can
+ * produce since it does not stop the user at four characters. */
+static void sweep_prefixes(void (*check)(const char* prefix,
+                                         size_t prefix_length)) {
+    char prefix[PREFIX_CAPACITY];
+
+    for (size_t length = 0; length <= MAX_SWEPT_LENGTH; length++) {
+        size_t combinations = 1;
+        for (size_t i = 0; i < length; i++) {
+            combinations *= 26;
+        }
+        for (size_t combination = 0; combination < combinations;
+             combination++) {
+            size_t remainder = combination;
+            for (size_t position = length; position-- > 0;) {
+                prefix[position] = kbd_letters[remainder % 26];
+                remainder /= 26;
+            }
+            prefix[length] = '\0';
+            check(prefix, length);
+        }
+    }
+
+    for (size_t i = 0; i < SSKR_WORD_COUNT; i++) {
+        memcpy(prefix, &SSKR_WORDLIST[SSKR_BYTEWORD_LENGTH * i],
+               SSKR_BYTEWORD_LENGTH);
+        for (size_t length = MAX_SWEPT_LENGTH + 1;
+             length <= SSKR_BYTEWORD_LENGTH; length++) {
+            prefix[length] = '\0';
+            check(prefix, length);
+        }
+        prefix[SSKR_BYTEWORD_LENGTH] = 'a';
+        prefix[SSKR_BYTEWORD_LENGTH + 1] = '\0';
+        check(prefix, SSKR_BYTEWORD_LENGTH + 1);
+    }
+}
+
+/* ------------------------------------------- the candidate suggestions */
+
+/* Buffers sized exactly to what the correct behaviour writes, on the heap so
+ * that AddressSanitizer's redzones make a single byte past the end a failure
+ * in the ASan configuration of .github/workflows/unit-tests-matrix.yml, and
+ * not only a wrong return value in the others. src/nbgl/ui.c hands over
+ * `wordCandidates[(BIP39_MAX_WORD_LENGTH + 1) * NB_MAX_SUGGESTION_BUTTONS]`
+ * and `buttonTexts[NB_MAX_SUGGESTION_BUTTONS]`; nothing here relies on that
+ * being roomier than SSKR needs. */
+struct candidate_buffers {
+    char* words;
+    size_t words_size;
+    const char** indexor;
+    size_t indexor_count;
+};
+
+static struct candidate_buffers alloc_candidate_buffers(
+    size_t expected_candidates) {
+    struct candidate_buffers buffers;
+    buffers.indexor_count = expected_candidates;
+    buffers.words_size = expected_candidates * (SSKR_BYTEWORD_LENGTH + 1);
+    /* calloc(0, ...) may return NULL; one spare byte keeps the no-match case
+     * pointing at real memory so that "the buffer was not written" is a
+     * statement about a buffer that exists. */
+    buffers.words = calloc(buffers.words_size + 1, 1);
+    buffers.indexor = calloc(expected_candidates + 1, sizeof(*buffers.indexor));
+    assert_non_null(buffers.words);
+    assert_non_null(buffers.indexor);
+    return buffers;
+}
+
+static void free_candidate_buffers(struct candidate_buffers* buffers) {
+    free(buffers->words);
+    free((void*)buffers->indexor);
+    buffers->words = NULL;
+    buffers->indexor = NULL;
+}
+
+static void test_no_match_returns_zero_and_writes_nothing(void** state) {
+    (void)state;
+
+    /* No ByteWord starts with "zz". */
+    const char prefix[] = "zz";
+    assert_int_equal(oracle_match_count(prefix, strlen(prefix)), 0);
+
+    struct candidate_buffers buffers =
+        alloc_candidate_buffers(NB_MAX_SUGGESTION_BUTTONS);
+    memset(buffers.words, 0xA5, buffers.words_size);
+    for (size_t i = 0; i < buffers.indexor_count; i++) {
+        buffers.indexor[i] = (const char*)(uintptr_t)0xA5A5A5A5u;
+    }
+
+    const size_t returned = bolos_ux_sskr_fill_with_candidates(
+        (const unsigned char*)prefix, strlen(prefix), buffers.words,
+        buffers.indexor);
+
+    assert_int_equal(returned, 0);
+    for (size_t i = 0; i < buffers.words_size; i++) {
+        if ((unsigned char)buffers.words[i] != 0xA5) {
+            fail_msg(
+                "byte %zu of the candidate buffer was written for a "
+                "prefix that matches no ByteWord",
+                i);
+        }
+    }
+    for (size_t i = 0; i < buffers.indexor_count; i++) {
+        if (buffers.indexor[i] != (const char*)(uintptr_t)0xA5A5A5A5u) {
+            fail_msg(
+                "entry %zu of the indexor was written for a prefix that "
+                "matches no ByteWord",
+                i);
+        }
+    }
+
+    free_candidate_buffers(&buffers);
+}
+
+static void test_a_single_match_is_copied_and_terminated(void** state) {
+    (void)state;
+
+    /* "able" is the only ByteWord starting with "ab". */
+    const char prefix[] = "ab";
+    assert_int_equal(oracle_match_count(prefix, strlen(prefix)), 1);
+
+    struct candidate_buffers buffers = alloc_candidate_buffers(1);
+
+    const size_t returned = bolos_ux_sskr_fill_with_candidates(
+        (const unsigned char*)prefix, strlen(prefix), buffers.words,
+        buffers.indexor);
+
+    assert_int_equal(returned, 1);
+    assert_string_equal(buffers.words, "able");
+    /* The word is NUL-terminated inside the buffer, not merely followed by
+     * one: the byte at index SSKR_BYTEWORD_LENGTH is the terminator. */
+    assert_int_equal(buffers.words[SSKR_BYTEWORD_LENGTH], '\0');
+    /* And the indexor points at it, rather than anywhere else that happens to
+     * hold the same characters. */
+    assert_ptr_equal(buffers.indexor[0], buffers.words);
+
+    free_candidate_buffers(&buffers);
+}
+
+static void test_more_matches_than_buttons_are_capped(void** state) {
+    (void)state;
+
+    /* 15 ByteWords start with "f", more than either live value of
+     * NB_MAX_SUGGESTION_BUTTONS (12 on Stax, 8 on Flex and Apex).
+     *
+     * This is a one-character prefix, which src/nbgl/ui.c never passes: it
+     * calls this function only once the entered text reaches two characters,
+     * and no two-character prefix matches more than 6 ByteWords -- so on this
+     * wordlist the cap is never reached through the interface. It is still
+     * the one line of this function that memory safety depends on, since it
+     * is what bounds the writes into the caller's two buffers, and the
+     * function is a public entry point of common_sskr.h. It is held here on
+     * the shortest prefix that reaches it. */
+    const char prefix[] = "f";
+    const size_t matches = oracle_match_count(prefix, strlen(prefix));
+    assert_true(matches > NB_MAX_SUGGESTION_BUTTONS);
+
+    struct candidate_buffers buffers =
+        alloc_candidate_buffers(NB_MAX_SUGGESTION_BUTTONS);
+
+    const size_t returned = bolos_ux_sskr_fill_with_candidates(
+        (const unsigned char*)prefix, strlen(prefix), buffers.words,
+        buffers.indexor);
+
+    assert_int_equal(returned, NB_MAX_SUGGESTION_BUTTONS);
+    /* The spare slot past the cap is untouched, in the build configurations
+     * where ASan is not watching the redzone for us. */
+    assert_null(buffers.indexor[NB_MAX_SUGGESTION_BUTTONS]);
+    assert_int_equal(buffers.words[buffers.words_size], '\0');
+
+    free_candidate_buffers(&buffers);
+}
+
+static void test_the_buffer_holds_consecutive_nul_separated_words(
+    void** state) {
+    (void)state;
+
+    /* Six ByteWords start with "wa", the widest two-character prefix there
+     * is, and the entry code reaches it. Checking the count alone would let
+     * an offset that drifts by one word go unnoticed, so every candidate is
+     * checked against the wordlist entry it should be, at the offset it
+     * should be at. */
+    const char prefix[] = "wa";
+    const size_t prefix_length = strlen(prefix);
+    const size_t matches = oracle_match_count(prefix, prefix_length);
+    assert_true(matches > 1);
+    assert_true(matches <= NB_MAX_SUGGESTION_BUTTONS);
+
+    struct candidate_buffers buffers = alloc_candidate_buffers(matches);
+
+    const size_t returned = bolos_ux_sskr_fill_with_candidates(
+        (const unsigned char*)prefix, prefix_length, buffers.words,
+        buffers.indexor);
+
+    assert_int_equal(returned, matches);
+
+    const size_t first = oracle_first_match(prefix, prefix_length);
+    for (size_t i = 0; i < returned; i++) {
+        const size_t offset = i * (SSKR_BYTEWORD_LENGTH + 1);
+        const unsigned char* const expected =
+            &SSKR_WORDLIST[SSKR_BYTEWORD_LENGTH * (first + i)];
+
+        /* Consecutive, one after the other, each ending in its own '\0'. */
+        if (memcmp(&buffers.words[offset], expected, SSKR_BYTEWORD_LENGTH) !=
+            0) {
+            fail_msg("candidate %zu is '%.4s', expected '%.4s'", i,
+                     &buffers.words[offset], (const char*)expected);
+        }
+        assert_int_equal(buffers.words[offset + SSKR_BYTEWORD_LENGTH], '\0');
+        /* And the indexor entry points inside the buffer the caller supplied,
+         * at that word. */
+        assert_ptr_equal(buffers.indexor[i], &buffers.words[offset]);
+    }
+
+    free_candidate_buffers(&buffers);
+}
+
+static void test_the_empty_prefix_returns_the_head_of_the_wordlist(
+    void** state) {
+    (void)state;
+
+    /* Not reachable through the interface: src/nbgl/ui.c calls this function
+     * only when the entered text is two characters or more ("Suggestions only
+     * when the word contains 2+ letters"), and the mask function only when it
+     * is at least one. Established rather than assumed, and pinned here
+     * anyway, because the function is public and an empty prefix is the case
+     * where every word matches -- the widest input the cap has to hold. */
+    const char prefix[] = "";
+    assert_int_equal(oracle_match_count(prefix, 0), SSKR_WORD_COUNT);
+
+    struct candidate_buffers buffers =
+        alloc_candidate_buffers(NB_MAX_SUGGESTION_BUTTONS);
+
+    const size_t returned = bolos_ux_sskr_fill_with_candidates(
+        (const unsigned char*)prefix, 0, buffers.words, buffers.indexor);
+
+    assert_int_equal(returned, NB_MAX_SUGGESTION_BUTTONS);
+    for (size_t i = 0; i < returned; i++) {
+        const size_t offset = i * (SSKR_BYTEWORD_LENGTH + 1);
+        if (memcmp(&buffers.words[offset],
+                   &SSKR_WORDLIST[SSKR_BYTEWORD_LENGTH * i],
+                   SSKR_BYTEWORD_LENGTH) != 0) {
+            fail_msg(
+                "candidate %zu of the empty prefix is '%.4s', expected "
+                "the wordlist's own word %zu, '%.4s'",
+                i, &buffers.words[offset], i,
+                (const char*)&SSKR_WORDLIST[SSKR_BYTEWORD_LENGTH * i]);
+        }
+    }
+
+    free_candidate_buffers(&buffers);
+}
+
+/* ------------------------------------------------- the keyboard mask */
+
+static void check_mask(const char* prefix, size_t prefix_length) {
+    const uint32_t returned = bolos_ux_sskr_get_keyboard_mask(
+        (const unsigned char*)prefix, (unsigned int)prefix_length);
+    const uint32_t expected = oracle_keyboard_mask(prefix, prefix_length);
+    if (returned != expected) {
+        fail_msg("prefix '%s': mask is 0x%08" PRIX32 ", expected 0x%08" PRIX32
+                 " (differing bits 0x%08" PRIX32 ")",
+                 prefix, returned, expected, returned ^ expected);
+    }
+}
+
+static void test_the_mask_matches_the_wordlist_for_every_prefix(void** state) {
+    (void)state;
+
+    /* Exact in both directions, on every prefix the sweep produces: a letter
+     * is enabled if and only if it extends some ByteWord. Inclusion alone
+     * would pass a mask that enables the whole alphabet.
+     *
+     * This is also what holds the `existing_mask += 1 << i` in seed_sskr.c,
+     * which is an addition where a bitwise or would be the natural thing to
+     * write. The two agree only while no letter is offered twice: a second
+     * `+= 1 << i` for the same i carries into bit i+1, enabling the wrong
+     * key. bolos_ux_sskr_get_word_next_letters_starting_with() cannot produce
+     * that duplicate, because it compares each candidate letter against the
+     * one it wrote last and the wordlist is alphabetically ordered, which
+     * makes equal next-letters contiguous. That reasoning is what this
+     * exhaustive comparison against an oracle built with |= turns into
+     * something the suite checks rather than something a reader has to
+     * accept: any duplicate, on any prefix, moves a bit and shows up here. */
+    sweep_prefixes(check_mask);
+}
+
+static void test_the_back_key_is_always_enabled(void** state) {
+    (void)state;
+
+    /* seed_sskr.c seeds the mask with `1 << 28` before adding letters, and
+     * the caller reads the result as the set of *disabled* keys, so the bit
+     * is clear in every mask this function returns -- including for a prefix
+     * that matches nothing, where it is the only key left to press. */
+    static const char* const prefixes[] = {"",   "a",    "ab",
+                                           "zz", "able", "ablea"};
+    for (size_t i = 0; i < sizeof(prefixes) / sizeof(prefixes[0]); i++) {
+        const uint32_t mask =
+            bolos_ux_sskr_get_keyboard_mask((const unsigned char*)prefixes[i],
+                                            (unsigned int)strlen(prefixes[i]));
+        if ((mask & BACK_KEY_BIT) != 0) {
+            fail_msg("prefix '%s': the back key is disabled (mask 0x%08" PRIX32
+                     ")",
+                     prefixes[i], mask);
+        }
+    }
+}
+
+static void test_a_dead_end_prefix_disables_every_letter(void** state) {
+    (void)state;
+
+    /* No ByteWord starts with "zz", so no letter can extend it. */
+    assert_int_equal(oracle_next_letter_count("zz", 2), 0);
+    assert_int_equal(
+        bolos_ux_sskr_get_keyboard_mask((const unsigned char*)"zz", 2),
+        ~BACK_KEY_BIT);
+
+    /* A complete ByteWord is a dead end too: there is no fifth letter. */
+    assert_int_equal(oracle_next_letter_count("able", 4), 0);
+    assert_int_equal(
+        bolos_ux_sskr_get_keyboard_mask((const unsigned char*)"able", 4),
+        ~BACK_KEY_BIT);
+}
+
+static void test_the_returned_mask_is_the_disabled_keys(void** state) {
+    (void)state;
+
+    /* One frozen value, so that the final `-1 ^ existing_mask` in
+     * seed_sskr.c has something holding it: what the function returns is the
+     * complement of what it computed, the keys to grey out rather than the
+     * keys to offer. Everything above is written against the oracle and would
+     * follow the convention if it flipped; this would not.
+     *
+     * "fl" is extended by exactly three ByteWords -- flap, flew, flux -- so
+     * a, e and u are the letters to leave enabled. In KBD_LETTERS
+     * ("qwertyuiopasdfghjklzxcvbnm") those sit at positions 10, 2 and 6, and
+     * with bit 28 for the back key the enabled set is 0x10000444. The
+     * function returns its complement. */
+    assert_int_equal(oracle_next_letter_count("fl", 2), 3);
+    assert_int_equal(
+        bolos_ux_sskr_get_keyboard_mask((const unsigned char*)"fl", 2),
+        0xEFFFFBBB);
+}
+
+/* --------------------------------------------- the next-letter buffer */
+
+static size_t widest_next_letter_count;
+
+static void check_next_letters(const char* prefix, size_t prefix_length) {
+    /* Exactly the array bolos_ux_sskr_get_keyboard_mask() declares, on the
+     * heap so ASan sees a write past it. That function then writes
+     * `next_letters[nb_letters] = '\0'`, so a count of ALPHABET_LENGTH would
+     * already be one too many. */
+    unsigned char* const next_letters = calloc(ALPHABET_LENGTH, 1);
+    assert_non_null(next_letters);
+
+    const size_t count = bolos_ux_sskr_get_word_next_letters_starting_with(
+        (const unsigned char*)prefix, (unsigned int)prefix_length,
+        next_letters);
+
+    if (count >= ALPHABET_LENGTH) {
+        fail_msg(
+            "prefix '%s': %zu next letters, which leaves no room for "
+            "the terminator get_keyboard_mask() writes at index %zu of a "
+            "%d-byte array",
+            prefix, count, count, ALPHABET_LENGTH);
+    }
+    /* The write that the caller makes right after, at the index this function
+     * reported. Out of bounds by one byte and ASan says so. */
+    next_letters[count] = '\0';
+
+    assert_int_equal(count, oracle_next_letter_count(prefix, prefix_length));
+    for (size_t i = 0; i < count; i++) {
+        /* No letter read back as '\0'. The mask loop runs i over the full
+         * ALPHABET_LENGTH, one past the 26 letters of KBD_LETTERS, so it
+         * compares against that string's terminator once; a '\0' among the
+         * next letters would match it and enable bit 26, a key that is not on
+         * the keyboard. */
+        if (next_letters[i] == '\0') {
+            fail_msg("prefix '%s': next letter %zu is a NUL", prefix, i);
+        }
+        assert_non_null(strchr(kbd_letters, next_letters[i]));
+    }
+
+    if (count > widest_next_letter_count) {
+        widest_next_letter_count = count;
+    }
+
+    free(next_letters);
+}
+
+static void test_next_letters_never_fills_its_array(void** state) {
+    (void)state;
+
+    /* `unsigned char next_letters[ALPHABET_LENGTH]` with ALPHABET_LENGTH 27
+     * (src/common/common.h), filled by this function and then terminated by
+     * its caller at the returned index. The margin is not obvious from the
+     * declaration -- 27 for a 26-letter keyboard -- so it is measured here
+     * over every prefix in the sweep rather than argued.
+     *
+     * The widest case is the empty prefix, which offers the first letter of
+     * all 256 ByteWords: 25 distinct letters, every letter except x. That
+     * leaves index 25 for the terminator and one byte spare. */
+    widest_next_letter_count = 0;
+    sweep_prefixes(check_next_letters);
+    assert_int_equal(widest_next_letter_count, 25);
+    assert_int_equal(oracle_next_letter_count("", 0), 25);
+}
+
+int main(void) {
+    const struct CMUnitTest tests[] = {
+        cmocka_unit_test(test_no_match_returns_zero_and_writes_nothing),
+        cmocka_unit_test(test_a_single_match_is_copied_and_terminated),
+        cmocka_unit_test(test_more_matches_than_buttons_are_capped),
+        cmocka_unit_test(test_the_buffer_holds_consecutive_nul_separated_words),
+        cmocka_unit_test(
+            test_the_empty_prefix_returns_the_head_of_the_wordlist),
+        cmocka_unit_test(test_the_mask_matches_the_wordlist_for_every_prefix),
+        cmocka_unit_test(test_the_back_key_is_always_enabled),
+        cmocka_unit_test(test_a_dead_end_prefix_disables_every_letter),
+        cmocka_unit_test(test_the_returned_mask_is_the_disabled_keys),
+        cmocka_unit_test(test_next_letters_never_fills_its_array),
+    };
+    return cmocka_run_group_tests(tests, NULL, NULL);
+}


### PR DESCRIPTION
Four functions that no test target compiled, and a coverage report that did not say so.

`bolos_ux_sskr_fill_with_candidates()`, `bolos_ux_sskr_get_keyboard_mask()` and their BIP-39 twins -- the keyboard suggestions of both entry paths, a typed prefix in and either candidate words or a mask of keys to grey out -- sit behind `#if defined(HAVE_NBGL)` at the end of `seed_sskr.c` and `seed_bip39.c`. No target in `tests/unit` defined `HAVE_NBGL`, so the preprocessor removed all four from every build the suite has ever made.

**The most useful part of this PR is that the coverage measurement did not show that.** Lines the preprocessor removes are neither covered nor uncovered -- they do not exist for lcov -- so `seed_sskr.c` reported a healthy **96.2%**, computed over **lines 52 to 486 of a 542-line file**, with nothing marked missing. The only place the hole was visible is the extent of the `DA:` entries in `coverage.info`, compared against the length of the file.

## The `DA:` extent, before and after

| file | lines | extent before | extent after |
|---|---|---|---|
| `src/common/sskr/seed_sskr.c` | 542 | **52-486**, 211 entries, 96.2% | **52-540**, 237 entries, 96.6% |
| `src/common/bip39/seed_bip39.c` | 376 | **26-319**, 166 entries, 95.8% | **26-374**, 193 entries, 96.4% |

540 and 374 are the last executable lines of the two files -- `return (-1 ^ existing_mask);`, followed only by `}` and `#endif` -- so the measured range now runs to the end of both. All 53 newly visible lines are covered (SSKR 203/211 hit before, 229/237 after; BIP-39 159/166 before, 186/193 after).

A caveat for whoever reads the next report: **a rate computed over a reduced portion of a file is not comparable with one computed over the whole of it**, and putting lines back into the measured set can make a percentage *fall* while strictly more code is tested. Here it happens to rise on both files, because the lines that came back are covered; across `src/` the suite goes from 90.62% over 1098 lines to 91.05% over 1151. The line counts, not the percentages, are what carry the meaning.

## What was blocking it

One `#include`. Both guarded blocks open with `#include <nbgl_layout.h>`, an SDK header the harness does not have, and the only symbol either of them takes from it is `NB_MAX_SUGGESTION_BUTTONS` (`MIN` comes from the SDK's `os.h`, `PRINTF` from its debug header, `ALPHABET_LENGTH` and `KBD_LETTERS` from `src/common/common.h`). So `tests/unit/lib/nbgl_layout.h` supplies that and nothing else, on the model of the empty `lib/glyphs.h` and `lib/bolos_target.h` already there. Defining `HAVE_NBGL` also makes the SDK's own `ux.h` reach for `ux_nbgl.h`, which sits behind the whole graphics library and none of which is reachable from string matching over a wordlist; that one is stubbed the same way, and is empty.

The constant is not a free choice, because it is the cap `fill_with_candidates()` applies with `MIN()` before writing into buffers the caller sized from the same constant -- a stub that lied about it would give green tests unrelated to the application. It is copied from the SDK with the SDK's own conditional structure, cited in the stub:

> `ledger-secure-sdk`, `lib_nbgl/include/nbgl_layout.h`, tag `stax_1.10.0-tr1-293-g4cd6b839` (the revision shipped in `ghcr.io/ledgerhq/ledger-app-builder/ledger-app-dev-tools:latest`): 12 on `TARGET_STAX` (line 38), 8 on `TARGET_FLEX` (line 68) and `TARGET_APEX` (line 98), 8 for the non-touch case (line 141).

Of those, three are live here: `HAVE_NBGL` is defined for stax, flex and apex_p, while the other three devices in `ledger_app.toml` build with `HAVE_BAGL` (the SDK only turns NBGL on for `TARGET_NANOX`/`TARGET_NANOS2` when `USE_NBGL=1`, which this application's `Makefile` does not set). So the constant is 12 on one device and 8 on the other two, and **both values are exercised**: each test file is built into two executables, one with `TARGET_STAX` and one with `TARGET_FLEX`. Neither `seed_sskr.c` nor `seed_bip39.c` nor either wordlist mentions any `TARGET_*` macro; the stub is the only reader.

## What is now held

For `*_fill_with_candidates()`:

- a prefix matching nothing returns 0 and leaves both caller buffers exactly as they were;
- a unique match is copied and terminated *inside* the buffer, with `wordIndexorBuffer[0]` pointing at it;
- **more matches than `NB_MAX_SUGGESTION_BUTTONS` are capped to it.** The buffers are heap allocations sized exactly to what the correct behaviour writes, so the ASan entry of the matrix reports an overrun rather than only the return value being wrong. On BIP-39 the cap is reached in ordinary use -- two characters is the shortest prefix `src/nbgl/ui.c` ever passes, and 67 two-character prefixes of that list match more than 12 words. On SSKR it is not: no two-character prefix matches more than 6 ByteWords, so the cap is tested on the shortest prefix that reaches it at all;
- **the buffer layout**: consecutive words, each ending in its own `'\0'`, each `wordIndexorBuffer[i]` pointing at its own word inside the supplied buffer. Checking the count alone would let an offset that drifts by a word pass. The BIP-39 case uses `"bri"` -- six words of two different lengths -- so the step is not constant;
- **the empty prefix is not reachable from the interface**, established rather than assumed: `src/nbgl/ui.c` calls `fill_with_candidates()` only from two entered characters on ("Suggestions only when the word contains 2+ letters") and `get_keyboard_mask()` only from one. It is pinned anyway, being the widest input the cap has to hold.

For `*_get_keyboard_mask()`:

- the back-key bit (`1 << 28`) is enabled in every mask returned, including for a prefix that matches nothing, where it is the only key left to press;
- **exactly** the letters that extend a word are enabled, checked in both directions against an oracle that walks the wordlist itself -- over every prefix of length 0 to 3 and every prefix of every word. A test that only checked inclusion would pass a mask that enables the whole alphabet;
- a dead-end prefix (and, for SSKR, any complete four-letter ByteWord) disables every letter;
- one frozen value per stack pins the final `-1 ^ existing_mask`: what is returned is the set of keys to grey out, not the set to offer. Everything else is written against the oracle and would follow the convention if it flipped.

## The two things worth a second look

Both were examined, and in both cases **the code is correct**; neither was "fixed".

**1. `existing_mask += 1 << i` uses `+=`, not `|=`.** The two agree only while no letter is offered twice: a second `+=` for the same bit carries into its neighbour and enables the wrong key. `*_get_word_next_letters_starting_with()` cannot produce that duplicate -- it compares each candidate letter against the one it wrote last (`next_letters_buffer` is advanced, so `[0]` is always the previous letter), and both wordlists are alphabetically ordered, which makes equal next-letters contiguous. Rather than leave that as an argument, the exhaustive sweep above compares the mask against an oracle built with `|=`, so any duplicate on any prefix moves a bit and turns the suite red. It stays green on both lists.

**2. The sizing of `next_letters`.** `unsigned char next_letters[ALPHABET_LENGTH]` with `ALPHABET_LENGTH` 27, filled by the scan and then terminated by its caller at the returned index -- so a count of 27 would already be one byte too many, and 26 would use the last byte. Measured over the same sweep rather than argued: the widest case on **both** lists is the empty prefix, at **25** distinct letters (every letter except `x`), which puts the terminator at index 25 and leaves one byte spare. A test asserts that, and writes the terminator itself at the reported index, on a 27-byte heap allocation, so ASan would see it go over. The related detail is also covered: the mask loop runs `i` over the full `ALPHABET_LENGTH`, one past the 26 letters of `KBD_LETTERS`, so it compares against that string's terminator once -- and no `next_letters[j]` can be `'\0'`, since every byte of both wordlists is a lowercase letter, which the tests assert directly.

## No `src/` change

`git diff --stat origin/bip85..HEAD -- src/` is empty. Nothing in the application is touched, so there is no cross-compilation and no size measurement to report, and the Speculos scripts are not concerned.

## Verification

- `ctest` goes from **61 to 65**; registration is automatic, no list was touched.
- **All six configurations of the unit-test matrix** were replayed on the committed tree -- ASan, UBSan, `-O2`, `-Os`, `-fsigned-char`, `-funsigned-char` -- **65/65 each**, with no warning naming any of the new files.
- **Four mutations, one per function per stack**, each rebuilt and run, each restored:
  - dropping the `MIN()` cap in `bolos_ux_sskr_fill_with_candidates()`: 2 red (`test_sskr_keyboard_candidates`, `..._stax`), 63 green. The failure lands inside `test_more_matches_than_buttons_are_capped`, where the writes run past the exactly-sized buffers and glibc aborts (`malloc(): unaligned tcache chunk detected`);
  - inverting the letter comparison in `bolos_ux_sskr_get_keyboard_mask()`: the same 2 red, 63 green;
  - the same two on the BIP-39 side: 2 red each (`test_bip39_keyboard_candidates`, `..._stax`), 63 green.
  - In all four cases exactly the pair for the stack under mutation turns red and nothing else does. Restored to `origin/bip85` bytes afterwards.
- The first commit is green on its own (63/63), so the pair bisects.
- `clang-format --dry-run -Werror` clean on all four new files.
