### PR TITLE
build: turn on the SDK per-function stack canary

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,6 +18,13 @@
 ifeq ($(BOLOS_SDK),)
 $(error Environment variable BOLOS_SDK is not set)
 endif
+
+# Per-function stack canary (-fstack-protector-strong). Must be set before
+# Makefile.defines is included: that file guards itself against a second
+# inclusion, so a later assignment would never be read. Ignored by the nanos
+# SDK, which has no stack protector support.
+ENABLE_STACK_PROTECTOR = 1
+
 include $(BOLOS_SDK)/Makefile.defines
 
 all: default


### PR DESCRIPTION
## What this is

One line in the `Makefile`, turning on the SDK's per-function stack canary
(`-fstack-protector-strong`). Everything worth reviewing is the measurement
below, not the diff.

This is defence in depth, not a fix for anything. No defect this repository
has had would have been caught by it — the overflows found here came from
guards deliberately removed for mutation testing, and they were all caught by
the tests that hold those guards.

## Why

`src/common/sskr/` is a port of Blockchain Commons' `bc-sskr` and `bc-shamir`
— their copyright headers are still on eleven files there — and those two
libraries were audited by Radically Open Security in 2021. The findings are
published in each upstream repository's `SECURITY-REVIEW.md`
(<https://github.com/BlockchainCommons/bc-sskr/blob/master/SECURITY-REVIEW.md>,
<https://github.com/BlockchainCommons/bc-shamir/blob/master/SECURITY-REVIEW.md>),
with the full report under `reviews/`.

Eight findings are listed as resolved there. Seven were resolved by changing
the code — bounds checks in `split_secret()` and `recover_secret()`, the
`serialize_shard()` length parameter, the `hazmat_lagrange_basis()` overflow,
and so on — so those fixes travelled with the source when it was ported here.
**`BTM-010`, "Compiler hardening flags were missing", is the only one of the
eight whose remedy is a build setting rather than a code change, and therefore
the only one a port does not inherit for free.**

Upstream reached for `-fstack-protector-all` and `-D_FORTIFY_SOURCE=2`. This
proposes only what the Ledger SDK actually offers,
`-fstack-protector-strong`; the last section says why `_FORTIFY_SOURCE` is not
on the table here.

The stronger argument is not the auditor's, though. It is that **Ledger's own
reference application sets this variable**:

- `LedgerHQ/app-boilerplate`, `Makefile:140` —
  [`ENABLE_STACK_PROTECTOR = 1`](https://github.com/LedgerHQ/app-boilerplate/blob/953abe92bcae7b7058bbbc9768d744a28a07ca43/Makefile#L140),
  at `953abe92bcae7b7058bbbc9768d744a28a07ca43`. Added by
  [PR #212](https://github.com/LedgerHQ/app-boilerplate/pull/212), merged
  2026-06-11, one week after the SDK reworked its stack-protector support
  (`ledger-secure-sdk@604227ff`, 2026-06-03).
- `LedgerHQ/app-bitcoin` (`Makefile:149`) and `LedgerHQ/app-ethereum`
  (`Makefile:175`) both set it too.
- Nothing in the guideline enforcer asks for it: `check_makefile.sh` does not
  mention it, and there is no documentation recommendation I could find. It is
  what the template does, not what a check requires.

## Not the same thing as `HAVE_BOLOS_APP_STACK_CANARY`

This is the first objection worth answering, and it matters more than it
looks.

`Makefile:55` already sets `HAVE_BOLOS_APP_STACK_CANARY`. That is **one
canary for the whole application**, `app_stack_canary`, written once at I/O
initialisation and compared against a fixed magic value by the SDK. This is a
**per-function** canary: a random word placed in each protected frame and
checked when that function returns.

They do not replace each other. On this fleet they barely even overlap:

| | global canary written | global canary **checked** | per-function canary available |
|---|---|---|---|
| `nanos` (SDK `lns-2.1.0-v24.0`) | yes | **yes** — `os_io_seproxyhal.c:894`, `io_seproxyhal_se_reset()` on mismatch | **no** |
| the five others (SDK `v26.5.0`) | yes — `io_legacy/src/os_io_legacy.c:323` | **no** — nothing reads it back anywhere in the SDK | yes |

So the device that has the whole-app check is the one that cannot have the
per-function one, and the five that get the per-function one have no
whole-app check at all. Enabling this does not duplicate an existing
protection; on those five it is the only stack integrity check in the
binary.

## The flag is inert on `nanos`, and that is the SDK's doing

`nanos` builds against `lns-2.1.0-v24.0`, a separate SDK line. It contains no
`ENABLE_STACK_PROTECTOR`, no `__stack_chk_fail`, no `__stack_chk_guard` — the
string `stack_chk` does not appear anywhere in it. Setting the variable
changes nothing there.

Verified rather than assumed, by counting the flag on the actual compile
lines (`make -n`) rather than by reading the `Makefile`:

| target | compile lines carrying `-fstack-protector-strong` | link line carrying `--wrap=__stack_chk_fail` |
|---|---|---|
| `nanos` | **0** | 0 |
| `nanox` | 101 | 1 |
| `nanos+` | 101 | 1 |
| `stax` | 88 | 1 |
| `flex` | 88 | 1 |
| `apex_p` | 88 | 1 |

**A note for whoever moves this line later.** It has to sit *before*
`include $(BOLOS_SDK)/Makefile.defines`, which this `Makefile` does on
line 21. `Makefile.defines` guards itself against a second inclusion
(`__MAKEFILE_DEFINES__`), so the copy that `Makefile.standard_app` includes
at its line 332 is a no-op, and an assignment placed anywhere below line 21 is
read too late. `app-boilerplate` does not hit this because it has no early
include of its own. Written the obvious way — next to the other `DEFINES` —
the change compiled cleanly and produced six binaries **identical to the byte**
to the ones before it. That is the failure mode this section exists to
prevent.

## The canary is real, and it is randomised

Three outcomes were possible: the symbols are provided; nobody provides them
and the link fails; or they resolve but `__stack_chk_guard` is never
initialised, leaving a known constant. Settled by looking at the binaries.

`arm-none-eabi-nm` on each hardened `app.elf`:

```
=== flex
da7a0000 B __stack_chk_guard
c0debd84 T __wrap___stack_chk_fail
c0de0000 T __wrap___stack_chk_init
da7a1ac0 B app_stack_canary        <- the whole-app canary, still there
```

Same on `nanox`, `nanos+`, `stax`, `apex_p`. On `nanos`: no `__stack_chk_*`
symbol at all, only `app_stack_canary`, as expected.

- `__wrap___stack_chk_fail` calls `os_sched_exit(37)` (`src/stack_protector.c`).
- `__wrap___stack_chk_init` sits at the very start of the code region, in its
  own `.boot.ssp_init` section that the link script places first and comments
  as such; `main` is linked immediately after it and the init code falls
  through into it. Disassembled, it issues `SYSCALL_cx_get_random_bytes` for
  four bytes into `__stack_chk_guard` — so the canary is random per boot, not
  a constant.
- The SDK also refuses to link unless `__stack_chk_guard` is the first symbol
  in `.bss` (`Makefile.rules_generic:173`); it is, at `0xda7a0000`, on all
  five.

Worth noting for a reader diffing the two builds: `__stack_chk_guard` is
already present in the *unhardened* binaries too — four bytes reserved and
never used. That is why RAM does not move below.

## Cost

Flash, `arm-none-eabi-size`, against the same six builds of
`bip85@41891fd` without the flag:

| target | `.text` before | `.text` after | Δ | Δ % | `.bss` before | after |
|---|---|---|---|---|---|---|
| **`nanos`** | **40 648** | **40 648** | **0** | **0 %** | 3 708 | 3 708 |
| `nanox` | 46 136 | 47 672 | +1 536 | +3.3 % | 28 672 | 28 672 |
| `nanos+` | 46 152 | 47 688 | +1 536 | +3.3 % | 40 960 | 40 960 |
| `stax` | 72 305 | 75 377 | +3 072 | +4.2 % | 36 864 | 36 864 |
| `flex` | 72 845 | 75 917 | +3 072 | +4.2 % | 36 864 | 36 864 |
| `apex_p` | 69 233 | 72 305 | +3 072 | +4.4 % | 40 960 | 40 960 |

`.bss` as `size` reports it is the whole RAM region, so it would not show a
small change. Measured as `_ebss - _bss` instead, actual RAM use is
**identical before and after** on all five: 5 189 bytes on `nanox` and
`nanos+`, 6 902 on `stax`, 6 846 on `flex` and `apex_p`.

**Stack**, which `size` does not show, measured with `-fstack-usage` on
`nanox` and `flex`:

- **+8 bytes per protected frame** (a handful of SHA-3/SHAKE frames take +16
  through alignment). About 29 % of functions are protected —
  176 of 617 on `nanox`, 229 of 796 on `flex`.
- The **largest single frame is unchanged**, 2 096 bytes on both.
- Along the deepest SSKR generation chain —
  `generate_sskr` → `bolos_ux_bip39_to_sskr_convert` → `bolos_ux_sskr_generate`
  → `sskr_generate_shards` → `sss_split_secret` → `interpolate` — the total
  frame cost goes from **2 344 to 2 368 bytes, +24**.

I did not produce a whole-program worst-case stack figure. Reconstructing the
call graph from the binary is defeated by the linker's outlined helpers
(`OUTLINED_FUNCTION_*`), which merge unrelated call chains; the numbers it
gives are not trustworthy and I would rather say so than quote them. The
per-frame figure above is solid, and the chain that actually matters here is
measured directly.

**On `nanos` all of this is moot** — the flag produces nothing there, so there
is no "everywhere except `nanos`" option to weigh. The device whose entire
stack is 1 924 bytes (`_estack - _stack`, `0x20001400 - 0x20000c7c`) is also
the one the SDK will not hand this to.

## Verification

- **Six targets built**, `nanos` included and checked by hand, no warnings.
  `ledger-app-builder@sha256:036d9fd1…` (2026-07-09); SDKs `lns-2.1.0-v24.0`
  for `nanos`, `v26.5.0` for the five others.
- **Unit suite unchanged**, as it must be: this touches no C file, and the
  suite builds for the host. 65/65 in each of the six configurations of
  `unit-tests-matrix.yml` (ASan, UBSan, `-O2`, `-Os`, `-fsigned-char`,
  `-funsigned-char`). Pure non-regression.
- **Ledger guideline enforcer**, `manifest` and `makefile` checks, run
  locally against `ledger-app-workflows@v1` (`e76d3312`) on `nanos` and
  `flex`: "The Makefile is compliant", both.
- **Speculos**, on the hardened `flex` build:
  `tests/speculos/verify_sskr_generated_shares_dashboard_return.py` — **PASS**.
  That script types a full 12-word mnemonic, generates a 3-share SSKR set and
  pages through all of it, which is the deepest stack chain the application
  has. It is the only evidence here that a hardened binary still *works*: a
  deeper stack on a constrained device is exactly the kind of regression a
  clean compile does not catch.
  **No emulator covers Nano S** — Speculos removed it in `9b44f7dc`
  (2025-09-30, PR #608), and `--model` now accepts only
  `nanox`, `nanosp`, `stax`, `flex`, `apex_p`. That is part of why the static
  measurement above matters, and it is also why nothing changes for that
  device here.
- `clang-format` does not apply — no C or header file is touched.

## What I am not proposing

`_FORTIFY_SOURCE` makes little sense in a `-nostdlib` build and appears
nowhere in the SDK. Other hardening options exist (`ENABLE_LINK_TIME_OPTIMIZATION`
is right next to this one in `Makefile.defines`) and are deliberately left
alone — they are a different question with a different cost.
