### PR TITLE
tests: cover the SSKR share paging and menus, which no target compiled

### DIFF
--- a/src/bagl/ux_sskr.c
+++ b/src/bagl/ux_sskr.c
@@ -17,24 +17,27 @@
 
 #include <os_io_seproxyhal.h>
 
+#include "common/sskr/common_sskr.h"
 #include "constants.h"
 #include "ui.h"
 
 #if defined(HAVE_BAGL)
 
+#include "./ux_sskr_menu.h"
+
 bool get_next_data(bool share_step) {
+    size_t offset;
+    size_t length;
+
     if (G_bolos_ux_context.sskr_share_index >= 1 &&
-        G_bolos_ux_context.sskr_share_index <=
-            G_bolos_ux_context.sskr_share_count) {
+        bolos_ux_sskr_share_slice(G_bolos_ux_context.sskr_words_buffer_length,
+                                  G_bolos_ux_context.sskr_share_count,
+                                  G_bolos_ux_context.sskr_share_index - 1,
+                                  &offset, &length)) {
         SPRINTF(G_bolos_ux_context.string_buffer, "SSKR Share #%d",
                 G_bolos_ux_context.sskr_share_index);
         memcpy(G_bolos_ux_context.words_buffer,
-               G_bolos_ux_context.sskr_words_buffer +
-                   (G_bolos_ux_context.sskr_share_index - 1) *
-                       G_bolos_ux_context.sskr_words_buffer_length /
-                       G_bolos_ux_context.sskr_share_count,
-               G_bolos_ux_context.sskr_words_buffer_length /
-                   G_bolos_ux_context.sskr_share_count);
+               G_bolos_ux_context.sskr_words_buffer + offset, length);
 
         G_bolos_ux_context.sskr_share_index += share_step ? 1 : -1;
         return true;
@@ -168,19 +171,12 @@ UX_STEP_NOCB(ux_threshold_warn_step_2, pbb,
 UX_FLOW(ux_threshold_warn_flow, &ux_threshold_warn_step_1,
         &ux_threshold_warn_step_2, &step_sskr_clean_exit);
 
-const char* const sskr_descriptor_values[] = {"1",  "2",  "3",  "4",  "5",
-                                              "6",  "7",
-#ifndef TARGET_NANOS
-                                              "8",  "9",  "10", "11", "12",
-                                              "13", "14", "15", "16"
-#endif
-};
-
 const char* sskr_threshold_getter(unsigned int idx) {
-    if (idx < G_bolos_ux_context.sskr_group_descriptor[0][1]) {
-        return sskr_descriptor_values[idx];
-    }
-    return NULL;
+    // Bounded by the share count the user just chose, which is what keeps a
+    // threshold from ever exceeding the number of shares it would be taken
+    // out of.
+    return sskr_descriptor_label(
+        idx, G_bolos_ux_context.sskr_group_descriptor[0][1]);
 }
 
 void sskr_threshold_selector(unsigned int idx) {
@@ -209,10 +205,7 @@ UX_FLOW(ux_threshold_flow, &ux_threshold_instruction_step,
         &ux_threshold_menu_step);
 
 const char* sskr_shares_number_getter(unsigned int idx) {
-    if (idx < ARRAYLEN(sskr_descriptor_values)) {
-        return sskr_descriptor_values[idx];
-    }
-    return NULL;
+    return sskr_descriptor_label(idx, sskr_descriptor_count());
 }
 
 void sskr_shares_number_selector(unsigned int idx) {

--- a/src/bagl/ux_sskr_menu.c
+++ b/src/bagl/ux_sskr_menu.c
@@ -1,0 +1,57 @@
+/*******************************************************************************
+ *   Ledger Seed Tool application
+ *   (c) 2016-2026 Ledger SAS
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ ********************************************************************************/
+
+#include "./ux_sskr_menu.h"
+
+// os.h is here for bolos_target.h, which is where TARGET_NANOS comes from on
+// the device -- the application build passes no -DTARGET_NANOS of its own.
+// sss-constants.h below is guarded on it too, so a translation unit that saw
+// one without the other would size the table for one device and the bound
+// that has to hold it for another. It has to be included before both.
+#include <os.h>
+
+#include "../common/sskr/sss/sss-constants.h"
+
+static const char* const sskr_descriptor_values[] = {
+    "1",  "2", "3",  "4",  "5",  "6",  "7",
+#ifndef TARGET_NANOS
+    "8",  "9", "10", "11", "12", "13", "14",
+    "15", "16"
+#endif
+};
+
+#define SSKR_DESCRIPTOR_COUNT \
+    (sizeof(sskr_descriptor_values) / sizeof(sskr_descriptor_values[0]))
+
+// The share-count menu offers 1..SSKR_DESCRIPTOR_COUNT, and every share the
+// user asks for is one the Shamir layer then has to produce -- where
+// sss_validate_parameters() refuses any count above SSS_MAX_SHARE_COUNT.
+// Nothing else ties the two together: the table is guarded on TARGET_NANOS
+// here, SSS_MAX_SHARE_COUNT is guarded on TARGET_NANOS in sss-constants.h,
+// and the second configuration has no slack at all (16 and 16).
+_Static_assert(SSKR_DESCRIPTOR_COUNT <= SSS_MAX_SHARE_COUNT,
+               "the SSKR share-count menu offers more shares than "
+               "SSS_MAX_SHARE_COUNT lets sss_split_secret() produce");
+
+unsigned int sskr_descriptor_count(void) { return SSKR_DESCRIPTOR_COUNT; }
+
+const char* sskr_descriptor_label(unsigned int idx, unsigned int count) {
+    if (idx < count) {
+        return sskr_descriptor_values[idx];
+    }
+    return NULL;
+}

--- a/src/bagl/ux_sskr_menu.h
+++ b/src/bagl/ux_sskr_menu.h
@@ -1,0 +1,37 @@
+/*******************************************************************************
+ *   Ledger Seed Tool application
+ *   (c) 2016-2026 Ledger SAS
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ ********************************************************************************/
+
+#pragma once
+
+// The two SSKR menus of the BAGL stack -- "how many shares" and "what
+// threshold" -- are both a list of consecutive numbers starting at 1, drawn
+// from one table of labels. This is that table's bound and its lookup, away
+// from the UX_STEP_MENULIST plumbing that reads it.
+
+// How many labels the table holds, and so the largest share count the
+// share-count menu will offer. Target-dependent: fewer entries on Nano S,
+// whose share buffer is sized for a smaller set.
+unsigned int sskr_descriptor_count(void);
+
+// Label for entry `idx` of a menu offering `count` consecutive values from
+// "1", or NULL when `idx` is past the last one -- which is what a
+// UX_STEP_MENULIST getter returns to end the list.
+//
+// Callers must pass a `count` no larger than sskr_descriptor_count(). The
+// share-count menu passes exactly that; the threshold menu passes the share
+// count the user just chose from it, which is therefore bounded by it too.
+const char *sskr_descriptor_label(unsigned int idx, unsigned int count);

--- a/src/common/sskr/common_sskr.h
+++ b/src/common/sskr/common_sskr.h
@@ -63,6 +63,29 @@ void bolos_ux_sskr_entry_header_update(const uint8_t *buffer,
                                        size_t *final_size,
                                        uint8_t *count);
 
+// Locate one share inside the buffer a generated set is concatenated into.
+//
+// bolos_ux_bip39_to_sskr_convert() writes the whole set into a single buffer,
+// back to back and with no separator, and reports how many shares it holds.
+// Paging through them is therefore a division, and both display paths --
+// bagl/ux_sskr.c walking the set one screen at a time, nbgl/ui.c handing one
+// share per generic-review page -- carried a copy of it.
+//
+// `share_index` is zero-based. On success `*offset` is where that share
+// starts in the buffer and `*length` is how long one share is; on failure
+// neither is written.
+//
+// Returning false rather than dividing is what holds the one thing this
+// arithmetic can get wrong: `share_count` reaching it as 0. The BAGL path
+// kept that out with a `1 <= index <= share_count` guard which cannot pass
+// when the count is 0; the NBGL path had no guard of its own and relied on
+// the review never being opened on an empty set.
+bool bolos_ux_sskr_share_slice(size_t buffer_length,
+                               uint8_t share_count,
+                               uint8_t share_index,
+                               size_t *offset,
+                               size_t *length);
+
 // Encode SSKR ByteWord as hex. Returns false, without writing to *value, if
 // the ByteWord is not in the wordlist.
 bool bolos_ux_sskr_byteword_to_hex(const unsigned char *byteword, uint8_t *value);

--- a/src/common/sskr/sskr_share_slice.c
+++ b/src/common/sskr/sskr_share_slice.c
@@ -1,0 +1,45 @@
+/*******************************************************************************
+ *   Ledger Seed Tool application
+ *   (c) 2016-2026 Ledger SAS
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ ********************************************************************************/
+
+#include <os.h>
+
+#include "./common_sskr.h"
+
+// See common_sskr.h for the contract. This is the arithmetic both share
+// display paths -- bagl/ux_sskr.c and nbgl/ui.c -- each carried a copy of.
+bool bolos_ux_sskr_share_slice(size_t buffer_length, uint8_t share_count,
+                               uint8_t share_index, size_t* offset,
+                               size_t* length) {
+    // One bound covers both things that can go wrong. An index past the last
+    // share is not a share; and a share count of zero, which is what would
+    // make the division below undefined, is a count no index can be below --
+    // so it leaves through the same door. Spelling the zero out separately
+    // adds a condition no input can reach, and no test can hold.
+    if (share_index >= share_count) {
+        return false;
+    }
+
+    // Multiply before dividing, which is what both call sites did: `index *
+    // buffer_length / share_count` groups left to right in C. The two forms
+    // only differ when the buffer is not an exact multiple of the share
+    // count, which never happens for a generated set -- every share of a set
+    // has the same length -- but preserving the order keeps this a move
+    // rather than a change.
+    *offset = ((size_t)share_index * buffer_length) / share_count;
+    *length = buffer_length / share_count;
+    return true;
+}

--- a/src/nbgl/ui.c
+++ b/src/nbgl/ui.c
@@ -644,12 +644,22 @@ static void review_sskr_shares_contentGetter(uint8_t index,
                                          : sizeof(headerText) - 2] = '\0';
     pairs[0].item = PIC(headerText);
 
-    strncpy(reviewText,
-            sskr_shares_get() +
-                (index * sskr_shares_length_get() / sskr_sharecount_get()),
-            sskr_shares_length_get() / sskr_sharecount_get());
+    size_t offset;
+    size_t length;
+    if (!bolos_ux_sskr_share_slice(sskr_shares_length_get(),
+                                   sskr_sharecount_get(), index, &offset,
+                                   &length)) {
+        // Unreachable while nbContents is the share count and that count is
+        // non-zero: nbgl_useCaseGenericReview() never asks for a page past
+        // it. Kept because the division below is the one this file cannot
+        // recover from.
+        offset = 0;
+        length = 0;
+    }
+
+    strncpy(reviewText, sskr_shares_get() + offset, length);
     // Ensure null termination
-    reviewText[sskr_shares_length_get() / sskr_sharecount_get()] = '\0';
+    reviewText[length] = '\0';
     pairs[0].value = PIC(reviewText);
 }
 

--- a/tests/unit/CMakeLists.txt
+++ b/tests/unit/CMakeLists.txt
@@ -871,6 +871,41 @@ target_compile_definitions(test_bip39_keyboard_candidates_stax PRIVATE HAVE_NBGL
 target_include_directories(test_bip39_keyboard_candidates_stax PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/../../src/common)
 target_link_libraries(test_bip39_keyboard_candidates_stax PUBLIC cmocka gcov testutils)
 
+# ---------------------------------------------------------------------------
+# The SSKR share display and the two SSKR menus of the BAGL stack.
+#
+# Both pieces come out of src/bagl/ux_sskr.c, which is compiled into no target
+# here and so is absent from the coverage report rather than sitting in it at
+# 0 %. Speculos dropped Nano S, so a unit test is the only thing that will
+# ever run that stack's arithmetic; Nano S+ and Nano X share the file and are
+# emulated, but only through a UX_FLOW.
+#
+# Each of the two is built twice, with and without TARGET_NANOS, for the same
+# reason the Shamir targets above are: what is not compiled is neither covered
+# nor uncovered. The share-count table has 7 entries under TARGET_NANOS and 16
+# otherwise, and SSS_MAX_SHARE_COUNT is 10 and 16 -- the relation between them
+# is the point of test_sskr_ux_menu, and it is a different relation in each of
+# the two configurations. target_compile_definitions() applies to every source
+# of a target, so the test file and the file under test always agree.
+add_executable(test_sskr_share_slice ./tests/sskr_share_slice.c ../../src/common/sskr/sskr_share_slice.c)
+target_include_directories(test_sskr_share_slice PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/../../src/common ${CMAKE_CURRENT_SOURCE_DIR}/../../src/common/sskr/sss)
+target_link_libraries(test_sskr_share_slice PUBLIC cmocka gcov testutils)
+
+add_executable(test_sskr_share_slice_nanos ./tests/sskr_share_slice.c ../../src/common/sskr/sskr_share_slice.c)
+target_include_directories(test_sskr_share_slice_nanos PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/../../src/common ${CMAKE_CURRENT_SOURCE_DIR}/../../src/common/sskr/sss)
+target_compile_definitions(test_sskr_share_slice_nanos PRIVATE TARGET_NANOS)
+target_link_libraries(test_sskr_share_slice_nanos PUBLIC cmocka gcov testutils)
+
+add_executable(test_sskr_ux_menu ./tests/sskr_ux_menu.c ../../src/bagl/ux_sskr_menu.c)
+target_include_directories(test_sskr_ux_menu PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/../../src ${CMAKE_CURRENT_SOURCE_DIR}/../../src/common/sskr/sss)
+target_link_libraries(test_sskr_ux_menu PUBLIC cmocka gcov testutils)
+
+add_executable(test_sskr_ux_menu_nanos ./tests/sskr_ux_menu.c ../../src/bagl/ux_sskr_menu.c)
+target_include_directories(test_sskr_ux_menu_nanos PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/../../src ${CMAKE_CURRENT_SOURCE_DIR}/../../src/common/sskr/sss)
+target_compile_definitions(test_sskr_ux_menu_nanos PRIVATE TARGET_NANOS)
+target_link_libraries(test_sskr_ux_menu_nanos PUBLIC cmocka gcov testutils)
+# ---------------------------------------------------------------------------
+
 # Register every executable this file builds, instead of repeating their names
 # in a list kept by hand. A name missing from such a list costs nothing
 # visible: the target still compiles, still passes when run directly, and the

--- a/tests/unit/tests/sskr_share_slice.c
+++ b/tests/unit/tests/sskr_share_slice.c
@@ -1,0 +1,147 @@
+/*
+ * bolos_ux_sskr_share_slice(): paging through a generated SSKR set.
+ *
+ * bolos_ux_bip39_to_sskr_convert() writes a whole share set into one buffer,
+ * back to back and with no separator. Showing share n therefore means
+ * dividing: offset = n * buffer_length / share_count, length =
+ * buffer_length / share_count. That arithmetic lived in two copies, one in
+ * bagl/ux_sskr.c (get_next_data()) and one in nbgl/ui.c
+ * (review_sskr_shares_contentGetter()), and neither file is compiled into any
+ * test target -- ux_sskr.c is not merely uncovered, it is absent from the
+ * lcov report entirely.
+ *
+ * The BAGL copy is the one that cannot be reached any other way. Speculos
+ * dropped Nano S, so no emulator runs that stack, and the two other devices
+ * sharing the file (Nano S+, Nano X) only reach it through a UX_FLOW.
+ *
+ * What is worth holding here is the division. It is guarded, in the sense
+ * that the BAGL caller's `1 <= index <= share_count` test cannot pass with a
+ * count of zero -- but the guard and the division lived in the same
+ * expression, and the NBGL caller had no guard at all.
+ */
+
+#include <stdarg.h>
+#include <stddef.h>
+#include <setjmp.h>
+#include <cmocka.h>
+#include <stdint.h>
+#include <stdbool.h>
+
+#include "testutils.h"
+#include "sskr/common_sskr.h"
+#include "sss-constants.h"
+
+/* Length of one share, in bytes, in the vectors below. Arbitrary; only the
+ * relation between it, the buffer length and the share count matters. */
+#define SHARE_LEN (46)
+
+/*
+ * A zero share count must be refused, not divided by. This is the invariant
+ * the extraction exists for: the BAGL caller kept it out with a guard whose
+ * reasoning had to be reconstructed by reading it (`index >= 1` and
+ * `index <= share_count` cannot both hold when share_count is 0), and the
+ * NBGL caller relied on never being opened on an empty set.
+ */
+static void test_share_slice_rejects_zero_count(void **state) {
+    (void) state;
+
+    size_t offset = 0xAA;
+    size_t length = 0xBB;
+
+    assert_false(bolos_ux_sskr_share_slice(0, 0, 0, &offset, &length));
+    /* outputs left alone on refusal */
+    assert_int_equal(offset, 0xAA);
+    assert_int_equal(length, 0xBB);
+
+    assert_false(bolos_ux_sskr_share_slice(SHARE_LEN, 0, 0, &offset, &length));
+    assert_int_equal(offset, 0xAA);
+    assert_int_equal(length, 0xBB);
+}
+
+/* An index at or past the share count is not a share. */
+static void test_share_slice_rejects_index_past_end(void **state) {
+    (void) state;
+
+    size_t offset = 0xAA;
+    size_t length = 0xBB;
+
+    assert_false(bolos_ux_sskr_share_slice(3 * SHARE_LEN, 3, 3, &offset, &length));
+    assert_int_equal(offset, 0xAA);
+    assert_int_equal(length, 0xBB);
+
+    assert_false(bolos_ux_sskr_share_slice(3 * SHARE_LEN, 3, 200, &offset, &length));
+    assert_int_equal(offset, 0xAA);
+    assert_int_equal(length, 0xBB);
+}
+
+/* The shares of a set tile the buffer exactly, in order, with no gap and no
+ * overlap -- which is the whole of what the two callers needed. */
+static void test_share_slice_tiles_the_buffer(void **state) {
+    (void) state;
+
+    for (uint8_t count = 1; count <= SSS_MAX_SHARE_COUNT; ++count) {
+        const size_t buffer_length = (size_t) count * SHARE_LEN;
+        size_t expected_offset = 0;
+
+        for (uint8_t index = 0; index < count; ++index) {
+            size_t offset = 0;
+            size_t length = 0;
+
+            assert_true(bolos_ux_sskr_share_slice(buffer_length, count, index,
+                                                  &offset, &length));
+            assert_int_equal(length, SHARE_LEN);
+            assert_int_equal(offset, expected_offset);
+            expected_offset += length;
+        }
+
+        /* the last share ends exactly at the end of the buffer */
+        assert_int_equal(expected_offset, buffer_length);
+    }
+}
+
+/*
+ * The first share starts at 0 and the last one ends inside the buffer. The
+ * `- 1` the BAGL caller applies to its one-based index used to sit inside the
+ * offset expression; getting it wrong there would have read one share too far
+ * on the last page, past the end of the set.
+ */
+static void test_share_slice_stays_inside_the_buffer(void **state) {
+    (void) state;
+
+    const uint8_t count = SSS_MAX_SHARE_COUNT;
+    const size_t buffer_length = (size_t) count * SHARE_LEN;
+    size_t offset = 0;
+    size_t length = 0;
+
+    assert_true(bolos_ux_sskr_share_slice(buffer_length, count, 0, &offset, &length));
+    assert_int_equal(offset, 0);
+
+    assert_true(bolos_ux_sskr_share_slice(buffer_length, count, count - 1, &offset,
+                                          &length));
+    assert_true(offset + length <= buffer_length);
+    assert_int_equal(offset + length, buffer_length);
+}
+
+/* A single share occupies the whole buffer: the degenerate case the 1-of-1
+ * backup produces, and the one where a stray `- 1` would underflow. */
+static void test_share_slice_single_share(void **state) {
+    (void) state;
+
+    size_t offset = 0;
+    size_t length = 0;
+
+    assert_true(bolos_ux_sskr_share_slice(SHARE_LEN, 1, 0, &offset, &length));
+    assert_int_equal(offset, 0);
+    assert_int_equal(length, SHARE_LEN);
+}
+
+int main(void) {
+    const struct CMUnitTest tests[] = {
+        cmocka_unit_test(test_share_slice_rejects_zero_count),
+        cmocka_unit_test(test_share_slice_rejects_index_past_end),
+        cmocka_unit_test(test_share_slice_tiles_the_buffer),
+        cmocka_unit_test(test_share_slice_stays_inside_the_buffer),
+        cmocka_unit_test(test_share_slice_single_share)
+    };
+    return cmocka_run_group_tests(tests, NULL, NULL);
+}

--- a/tests/unit/tests/sskr_ux_menu.c
+++ b/tests/unit/tests/sskr_ux_menu.c
@@ -1,0 +1,130 @@
+/*
+ * The two SSKR menus of the BAGL stack: how many shares, and what threshold.
+ *
+ * Both are a list of consecutive numbers starting at 1, read out of one table
+ * of labels by a UX_STEP_MENULIST getter. The table and its bound used to sit
+ * in src/bagl/ux_sskr.c, which is compiled into no test target at all -- so
+ * it does not appear in the coverage report at 0 %, it does not appear in it.
+ * And no emulator covers Nano S, the device whose table is the narrower of
+ * the two, so nothing else exercised this either.
+ *
+ * The property worth holding is not the lookup, it is the agreement between
+ * two constants that live in different files under the same guard used twice:
+ *
+ *   - sskr_descriptor_values[] has 7 entries under TARGET_NANOS, 16 otherwise
+ *     (src/bagl/ux_sskr_menu.c);
+ *   - SSS_MAX_SHARE_COUNT is 10 under TARGET_NANOS, 16 otherwise
+ *     (src/common/sskr/sss/sss-constants.h).
+ *
+ * Every share the share-count menu offers is a share sss_split_secret() is
+ * then asked to produce, and it refuses a count above SSS_MAX_SHARE_COUNT.
+ * The second configuration has no slack whatever: 16 and 16. A static
+ * assertion in ux_sskr_menu.c holds that at compile time for the device
+ * builds; this file holds the same relation on the host, in both
+ * configurations, and holds the chain the threshold menu depends on.
+ */
+
+#include <stdarg.h>
+#include <stddef.h>
+#include <setjmp.h>
+#include <cmocka.h>
+#include <stdio.h>
+#include <string.h>
+
+#include "bagl/ux_sskr_menu.h"
+#include "sss-constants.h"
+
+/*
+ * The share-count menu never offers a count the Shamir layer would refuse.
+ * The same relation the static assertion holds, replayed here so that the
+ * TARGET_NANOS build of this file states it for the device that has no
+ * emulator.
+ */
+static void test_menu_never_exceeds_sss_max_share_count(void **state) {
+    (void) state;
+
+    assert_true(sskr_descriptor_count() >= 1);
+    assert_true(sskr_descriptor_count() <= SSS_MAX_SHARE_COUNT);
+}
+
+/*
+ * A menu of `count` entries answers for 0..count-1 and stops after that.
+ * NULL is what UX_STEP_MENULIST reads as the end of the list, so returning a
+ * label one entry too far would add a selectable share count that nothing
+ * downstream expects.
+ */
+static void test_menu_ends_at_count(void **state) {
+    (void) state;
+
+    for (unsigned int count = 1; count <= sskr_descriptor_count(); ++count) {
+        for (unsigned int idx = 0; idx < count; ++idx) {
+            assert_non_null(sskr_descriptor_label(idx, count));
+        }
+        assert_null(sskr_descriptor_label(count, count));
+        assert_null(sskr_descriptor_label(count + 1, count));
+    }
+}
+
+/* An empty menu has no entries at all, including the first. */
+static void test_menu_of_zero_is_empty(void **state) {
+    (void) state;
+
+    assert_null(sskr_descriptor_label(0, 0));
+}
+
+/*
+ * Entry `idx` reads "idx + 1", which is what makes the selectors' `idx + 1`
+ * agree with what the user saw. A shifted table would let someone pick "3"
+ * and get a 4-of-n backup.
+ */
+static void test_menu_labels_are_one_based(void **state) {
+    (void) state;
+
+    for (unsigned int idx = 0; idx < sskr_descriptor_count(); ++idx) {
+        char expected[12];
+
+        assert_true(idx + 1 <= 99);
+        (void) snprintf(expected, sizeof(expected), "%u", idx + 1);
+        assert_string_equal(sskr_descriptor_label(idx, sskr_descriptor_count()),
+                            expected);
+    }
+}
+
+/*
+ * A threshold can never exceed the number of shares it would be taken out of.
+ * That is not enforced anywhere downstream with a message of its own -- a
+ * 3-of-2 backup would be turned away by sss_validate_parameters() much later,
+ * behind a generic error screen. What holds it is that the threshold menu is
+ * built with the share count the user just picked as its length, so this
+ * walks the whole chain: every share count the first menu offers, and every
+ * threshold the second menu then offers for it.
+ */
+static void test_threshold_menu_never_exceeds_chosen_share_count(void **state) {
+    (void) state;
+
+    for (unsigned int idx = 0; idx < sskr_descriptor_count(); ++idx) {
+        /* what sskr_shares_number_selector() stores for entry `idx` */
+        const unsigned int share_count = idx + 1;
+
+        /* what sskr_threshold_getter() then offers */
+        for (unsigned int t = 0; t < share_count; ++t) {
+            assert_non_null(sskr_descriptor_label(t, share_count));
+        }
+        /* and what it refuses: a threshold of share_count + 1 */
+        assert_null(sskr_descriptor_label(share_count, share_count));
+
+        /* the largest threshold selectable is exactly the share count */
+        assert_true(share_count <= sskr_descriptor_count());
+    }
+}
+
+int main(void) {
+    const struct CMUnitTest tests[] = {
+        cmocka_unit_test(test_menu_never_exceeds_sss_max_share_count),
+        cmocka_unit_test(test_menu_ends_at_count),
+        cmocka_unit_test(test_menu_of_zero_is_empty),
+        cmocka_unit_test(test_menu_labels_are_one_based),
+        cmocka_unit_test(test_threshold_menu_never_exceeds_chosen_share_count)
+    };
+    return cmocka_run_group_tests(tests, NULL, NULL);
+}


### PR DESCRIPTION
## What this is

`src/bagl/ux_sskr.c` is 236 lines and holds the entire SSKR interface of the
Nano S, Nano S+ and Nano X. **It is compiled into no unit test target.** That
is not the same as being at 0 % in the coverage report — a file at 0 % is
visible, a file compiled nowhere has no `SF:` entry at all and simply does not
appear. Crossing the report against the sources is the only way to see it:

```
grep '^SF:' coverage.info | sed 's|^SF:||' | sort -u
find src -name '*.c' | sort
```

On `bip85@41891fd`: **12 of the 27 `.c` files under `src/` are in the report,
15 are not.** Of those 15, **12 are compiled into no target at all** —
`app_main.c`, all seven `bagl/*.c`, `common/electrum.c`, `nbgl/bip85_app.c`,
`nbgl/layout_generic_screen.c`, `nbgl/ui.c` — and the other three are the
`seed_rom_variables.c` files, which *are* compiled but hold only data, so
`gcov` emits no lines for them. Worth separating: only the first group is a
gap.

Two things make `ux_sskr.c` the one worth starting with:

1. **This code became reachable again on Nano S.** Until the fix merged in
   #111, `G_bolos_ux_context.processing` was read by nobody and the whole SSKR
   generation chain was dropped from the binary. It runs again. The
   `#if defined(TARGET_NANOS)` arms of `generate_sskr()` and
   `sskr_threshold_selector()` are live and have never been exercised by
   anything.
2. **There is no emulator for Nano S.** Speculos removed it in `9b44f7dc`
   (2025-09-30, PR #608); `--model` now accepts only `nanox`, `nanosp`,
   `stax`, `flex`, `apex_p`. A unit test is the only thing that will ever run
   this logic for that device.
   Nano S+ and Nano X share the file and are emulated, but only through a
   `UX_FLOW`.

## What moved

Two pieces of arithmetic, neither of which needs a screen, a global, a
syscall or a `UX_` macro — and both of which were duplicated.

**1. Paging through a generated set.** `bolos_ux_bip39_to_sskr_convert()`
writes the whole set into one buffer, back to back with no separator, so
showing share *n* is a division. `ux_sskr.c` did it one screen at a time;
`nbgl/ui.c` did it one review page at a time. Now
`bolos_ux_sskr_share_slice()` in `src/common/sskr/sskr_share_slice.c`,
declared in `common_sskr.h`, called by both. Same pattern as
`bolos_ux_sskr_entry_header_update()` (#115).

**2. The two BAGL menus.** "How many shares" and "what threshold" are both a
list of consecutive numbers read from one table of labels. Table and lookup
are now `src/bagl/ux_sskr_menu.c`, with the table made `static` and reached
through `sskr_descriptor_label()` / `sskr_descriptor_count()`. Both getters
keep exactly the bound they had.

**Nothing else is touched.** No `UX_FLOW`, no `UX_STEP_*`, no label, no
navigation, no screen. The layering of the UI is not up for discussion in this
PR, which is what should make it readable without an architecture argument.

## What I deliberately did not extract

- `bnnn_paging_edgecase()` and `display_next_state()` reach straight into
  `G_ux.flow_stack` and the screen scheduler. Nothing pure to take out.
- `generate_sskr()` is an orchestrator; the part of it worth testing is
  already inside `bolos_ux_bip39_to_sskr_convert()`, which is tested.
- The two `*_selector()` functions. `descriptor = idx + 1` and then a branch
  into `ux_flow_init()`; extracting the assignment alone would be a function
  nobody would write on purpose. The `idx + 1` is instead held *indirectly*,
  by a test that checks entry *i* of the menu reads "i + 1" — so a shifted
  table, which is the way that arithmetic could actually go wrong, comes out
  red.
- The 1-of-m warning predicate
  (`threshold == 1 && share_count > 1`). It does appear in both stacks, but
  the NBGL copy sits inside a four-branch validation whose other three arms
  BAGL cannot reach; unifying them would have meant reshaping one of the two
  call sites, which is exactly the sort of change this PR is trying to stay
  out of.

## Behaviour

Unchanged, with one thing to declare. The NBGL review getter had no guard of
its own: it divided by the share count directly. It now goes through the same
helper and, if that helper refuses, renders an empty page instead. That state
is unreachable while `nbContents` is the share count and the count is
non-zero, so nothing observable changes; it is in the diff because the
division is the one thing that file could not recover from.

The share offset is still multiplied before it is divided
(`index * buffer_length / share_count`, left to right), which is how both
call sites grouped it. The two forms only differ when the buffer is not an
exact multiple of the share count, which a generated set never is — but
preserving the order keeps this a move rather than a change.

## The invariants this now holds

**The share-count menu can never offer more shares than the Shamir layer will
split into.** `sskr_descriptor_values[]` has 7 entries under `TARGET_NANOS`
and 16 otherwise; `SSS_MAX_SHARE_COUNT` is 10 and 16
(`src/common/sskr/sss/sss-constants.h`). It holds today, and the second
configuration holds **exactly**, with no slack at all. Nothing was keeping the
two in step: different files, and the same `#if defined(TARGET_NANOS)` written
out twice. There is now a `_Static_assert` in `ux_sskr_menu.c` — so this is
enforced on every one of the six device builds at compile time, not only in
the tests — plus a runtime test in each of the two configurations.

**A threshold can never exceed the number of shares it is taken out of.** A
3-of-2 backup is meaningless and has no error message of its own anywhere;
it would reach `sss_validate_parameters()` and come back as a generic failure
screen. What prevents it is that the threshold menu is built with the chosen
share count as its length. The test walks the whole chain: for every share
count the first menu offers, the threshold menu built from it stops exactly
there.

**No division by zero in the paging.** The reasoning that kept it out was
real — `index >= 1` and `index <= share_count` cannot both hold when the
count is 0 — but it lived in the same expression as the division, and the
NBGL side had no such reasoning at all. It is now a bound with a test on it.
That test also showed that writing the zero out separately
(`share_count == 0 || share_index >= share_count`) was a condition no input
could reach: mutating it away left the suite green. It is not in the diff.

## A trap this uncovered, worth knowing about

`TARGET_NANOS` is **not** on the compiler command line. It comes from
`bolos_target.h`, i.e. from `os.h`. A new translation unit that reads
`sss-constants.h` without including `os.h` first gets `SSS_MAX_SHARE_COUNT`
= 16 on a Nano S build.

The first version of `ux_sskr_menu.c` did exactly that, compiled without a
warning, and produced a **16-entry menu on a device whose share buffer is
sized for 7** — caught only because the `.rodata` for the table went from 28
to 64 bytes in the symbol diff. The include order is now deliberate and
commented, and the static assertion above would fail the build if it happened
again.

## Cost

`arm-none-eabi-size`, against the same six builds of `bip85@41891fd`:

| target | `.text` before | after | Δ | `.bss` |
|---|---|---|---|---|
| `nanos` | 40 648 | 40 712 | **+64** | unchanged |
| `nanox` | 46 136 | 46 136 | 0 | unchanged |
| `nanos+` | 46 152 | 46 152 | 0 | unchanged |
| `stax` | 72 305 | 72 305 | 0 | unchanged |
| `flex` | 72 845 | 72 845 | 0 | unchanged |
| `apex_p` | 69 233 | 69 233 | 0 | unchanged |

Only `nanos` moves, and only by 64 bytes. Symbol by symbol the change is
small and entirely accounted for:

```
nanos   bolos_ux_sskr_share_slice   -> 54     sskr_descriptor_count      ->  4
        sskr_descriptor_label       -> 24     get_next_data          144 -> 140
        sskr_shares_number_getter 24 -> 18    sskr_threshold_getter   36 ->  20
nanox   bolos_ux_sskr_share_slice   -> 38     get_next_data          132 -> 152
/S+     sskr_descriptor_count       ->  4     sskr_descriptor_label      -> 24
        sskr_shares_number_getter 24 -> 20    sskr_threshold_getter   36 ->  16
stax    bolos_ux_sskr_share_slice   -> 38
/flex   review_sskr_shares_contentGetter                          188 -> 168
/apex
```

No other symbol changes size on any target. On the four devices whose `.text`
does not move, the added bytes fit inside existing section padding.

## Verification

- **Six targets built**, `nanos` included and checked by hand, no warnings.
- **`ctest` 65 → 69**, 69/69 green in each of the six configurations of
  `unit-tests-matrix.yml` (ASan, UBSan, `-O2`, `-Os`, `-fsigned-char`,
  `-funsigned-char`), with the **same warning counts as before the change**.
- **Both configurations compiled.** Each of the two test files is built twice,
  with and without `TARGET_NANOS`, for the reason the Shamir targets next to
  them already are: what is not compiled is neither covered nor uncovered, and
  the two configurations are genuinely different code here.
- **Coverage.** The two new files are at 5/5 and 6/6 lines, 2/2
  branches each. `src/` overall goes from 1048/1151 to 1059/1162 lines and
  from 12 to 14 files present in the report. **`ux_sskr.c` and `nbgl/ui.c` are still
  absent from it** — they are still compiled into no test target, and this PR
  does not change that. What it changes is that the arithmetic they used to
  hold is now somewhere a test can reach.
- **Five mutations, both states reported for each**, none left in the commits:

  | mutation | muted | restored |
  |---|---|---|
  | share offset shifted by one share | 2 red (both slice targets) | 69/69 |
  | index bound `>=` relaxed to `>` | 2 red (both slice targets) | 69/69 |
  | share length taken as the whole buffer | 2 red (both slice targets) | 69/69 |
  | menu bound `<` relaxed to `<=` | 2 red (both menu targets) | 69/69 |
  | table widened past `SSS_MAX_SHARE_COUNT` | **does not compile** — static assertion fails on the host build and on the `nanos` ARM build | 69/69 |

- **Speculos**, on the `flex` build of this branch:
  `tests/speculos/verify_sskr_generated_shares_dashboard_return.py` — **PASS**.
  That is the script that generates a 3-share SSKR set and pages through all of
  it, i.e. the NBGL call site this PR rewires.
- `clang-format --dry-run -Werror` clean on every file under `src/` that this
  touches (clang-format 21.1.8; the lint workflow runs version 11 over `src`
  only).
- The first commit is green on its own (65/65), so the pair bisects.
