### PR TITLE
build: include Makefile.target rather than Makefile.defines

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,15 +19,7 @@ ifeq ($(BOLOS_SDK),)
 $(error Environment variable BOLOS_SDK is not set)
 endif
 
-# Per-function stack canary (-fstack-protector-strong). Must be set before
-# Makefile.defines is included: that file guards itself against a second
-# inclusion, so a later assignment would never be read. Ignored by the nanos
-# SDK, which has no stack protector support.
-ENABLE_STACK_PROTECTOR = 1
-
-include $(BOLOS_SDK)/Makefile.defines
-
-all: default
+include $(BOLOS_SDK)/Makefile.target
 
 APPNAME = "Seed Tool"
 APPVERSION_M = 1
@@ -64,7 +56,6 @@ DEFINES += HAVE_BOLOS_APP_STACK_CANARY
 ifeq ($(TARGET_NAME),TARGET_NANOS)
     $(info Using BAGL)
     DISABLE_STANDARD_USB = 1
-    CFLAGS += -gdwarf-4 -Wno-unterminated-string-initialization
 else ifeq ($(TARGET_NAME), $(filter $(TARGET_NAME), TARGET_NANOS2 TARGET_NANOX))
     $(info Using BAGL)
 else
@@ -73,6 +64,10 @@ else
     ENABLE_NBGL_KEYPAD = 1
 endif
 
+# Per-function stack canary (-fstack-protector-strong). Ignored by the nanos
+# SDK, which has no stack protector support.
+ENABLE_STACK_PROTECTOR = 1
+
 DEBUG = 0
 
 APP_SOURCE_PATH += src
@@ -80,5 +75,10 @@ APP_SOURCE_PATH += src
 include $(BOLOS_SDK)/Makefile.standard_app
 
 ifeq ($(TARGET_NAME),TARGET_NANOS)
+    # Appended after the SDK makefiles so that they win over the SDK defaults:
+    # -gdwarf-4 has to follow the -g0 that Makefile.defines adds on a release
+    # build, and -Wno-unterminated-string-initialization has to follow the
+    # -Wextra that would otherwise turn the warning back on.
+    CFLAGS += -gdwarf-4 -Wno-unterminated-string-initialization
     APP_LOAD_PARAMS += --apiLevel 0
 endif


### PR DESCRIPTION
## What

One line in the `Makefile`:

```diff
-include $(BOLOS_SDK)/Makefile.defines
+include $(BOLOS_SDK)/Makefile.target
```

plus the three things that follow from it: the local `all: default` rule
goes away, `ENABLE_STACK_PROTECTOR` moves down to sit with the other build
options, and the nanos-only `CFLAGS +=` moves below
`include Makefile.standard_app`.

Nothing else. No new SDK variable, no behaviour change: the six `app.elf`
files are byte-identical before and after.

## Why

`Makefile.defines` opens on an include guard:

```make
ifeq ($(__MAKEFILE_DEFINES__),)
__MAKEFILE_DEFINES__ := 1

include $(BOLOS_SDK)/Makefile.target
```

`Makefile.standard_app` includes `Makefile.defines` at its end, once the
application has finished declaring itself. Including it at the top of our
`Makefile` makes that second inclusion a no-op, so everything
`Makefile.defines` decides by `ifeq`/`ifneq` is decided at `Makefile:28`,
before the application has set anything. The variables that lose their
effect:

| Variable | What is lost |
|---|---|
| `ENABLE_STACK_PROTECTOR` | `-fstack-protector-strong` and the linker `--wrap`s |
| `ENABLE_NBGL_FOR_NANO_DEVICES` | `HAVE_NBGL` / `NBGL_STEP` on nanox / nanos+ |
| `ENABLE_LINK_TIME_OPTIMIZATION` | `-flto` |
| `ENABLE_ADDRESS_BOOK` | `OS_IO_SEPH_BUFFER_SIZE=448` |
| `DEBUG` | `-Og -g3` (but not `HAVE_PRINTF`, read later: a half-applied debug build) |

That is not hypothetical. `ENABLE_STACK_PROTECTOR` already had to be
declared *above* the include, under a comment saying so in as many words:

```make
# Per-function stack canary (-fstack-protector-strong). Must be set before
# Makefile.defines is included: that file guards itself against a second
# inclusion, so a later assignment would never be read.
```

This change removes the reason for that workaround instead of
institutionalising it.

`app-boilerplate/Makefile:22` includes `Makefile.target`, which provides
`TARGET_NAME` — the only thing the target conditionals here use — without
setting the guard. It also declares `all: default`
(`Makefile.target:72` on `ledger-secure-sdk`, `:50` on the nanos SDK), so
the local copy is redundant in both SDK generations.

## The one thing that is not a pure move

The nanos-only line

```make
CFLAGS += -gdwarf-4 -Wno-unterminated-string-initialization
```

only works *after* the SDK has had its say, and the include change moves it
from after to before. Both flags are overrides:

- `Makefile.defines:63` on the nanos SDK adds `-O$(OPTI_LVL) -g$(DBG_LVL)`,
  i.e. `-Oz -g0` on a release build. `-gdwarf-4` has to come after that `-g0`
  to win.
- `-Wno-unterminated-string-initialization` has to come after the SDK's
  `-Wall -Wextra`, or `-Wextra` turns the warning back on.

Left where it was, the nanos build lost its DWARF sections
(`app.elf` 337 020 → 152 852 bytes, `.debug_info` 58 995 → 3 966, `.debug_loc`
41 400 → 0) and started emitting ten
`-Wunterminated-string-initialization` warnings. Moving the line next to the
existing post-include `APP_LOAD_PARAMS += --apiLevel 0` block restores both.

## What was measured, and how

Six targets, built inside
`ghcr.io/ledgerhq/ledger-app-builder/ledger-app-builder:latest`, `sha256` of
`build/<target>/bin/app.elf`:

| Target | before | after |
|---|---|---|
| nanos  | `67a19f71b1cbd8f7f5cbe242515ffbdae7292e5dbf703b60fea83b590d0391ba` | same |
| nanox  | `a2cb231d5ccf8b7f43174be34fd60394b7999c99ffddd794b36b0936484ddc6c` | same |
| nanos+ | `02de1906c534d736499f114dd36bc868ad9bde5e5ba840c9672c058e0979e690` | same |
| stax   | `d474ddac6d9952bbe85eb64f680d6bac9ff8a58ec24ca7b11d4a94fad4065a42` | same |
| flex   | `04585e23a8569fca9592c81fd0ed074328242e550cc76984e46a6de11c0b2aba` | same |
| apex_p | `b75ad45e9d6fe4b24b066392f97024939479e2baa28dec9624c48d64d412dd0f` | same |

Four passes in all, alternating between the two versions of the `Makefile`.
`make clean` is **not** enough for this: it leaves the generated
`src/glyphs.c` / `src/glyphs.h` behind, and the nanos SDK does not rebuild
them the way the unified SDK does. Between every single build:

```bash
[ -d build ] && find build -mindepth 1 -delete
find src -maxdepth 1 -name 'glyphs.*' -delete
```

An intermediate version of this change — the include swapped but the nanos
`CFLAGS` left in place — was measured too, and is what turned up the
`-gdwarf-4` ordering above: five targets identical, nanos different. For
that version, `app.hex` and the `objcopy -O binary` output were still
identical (`.text` 40 704 bytes, `.bss` 2 684, `.data` 0 in both), so the
difference was debug information only. The version proposed here does not
have it.

## Not verified

- No run on a device, and none under Speculos. The claim is that the
  binaries are identical, which makes a behavioural test redundant, not that
  the application was exercised.
- Nothing was measured with any of the newly-usable variables actually set.
  Turning `ENABLE_NBGL_FOR_NANO_DEVICES` or LTO on is a separate question,
  deliberately not touched here.
- CI on this fork does not start the reusable workflows, so the conformity
  results for this change will only be visible after merge.
