### PR TITLE
ci: align the workflows and the manifest with Ledger's current tooling

### DIFF
--- a/.github/workflows/ci-workflow.yml
+++ b/.github/workflows/ci-workflow.yml
@@ -10,8 +10,6 @@ on:
     tags:
       - '**'
   pull_request:
-    paths-ignore:
-      - '.github/workflows/*.yml'
 
 jobs:
   ledger_app_build:

--- a/.github/workflows/ledger-rule-enforcer.yml
+++ b/.github/workflows/ledger-rule-enforcer.yml
@@ -10,8 +10,6 @@ on:
     tags:
       - '**'
   pull_request:
-    paths-ignore:
-      - '.github/workflows/*.yml'
 
 jobs:
   ledger_rule_enforcer:

--- a/.github/workflows/lint-workflow.yml
+++ b/.github/workflows/lint-workflow.yml
@@ -20,8 +20,6 @@ jobs:
     uses: LedgerHQ/ledger-app-workflows/.github/workflows/reusable_lint.yml@v1
     with:
       source: 'src'
-      extensions: 'h,c'
-      version: 11
 
   misspell:
     name: Check misspellings

--- a/.github/workflows/lint-workflow.yml
+++ b/.github/workflows/lint-workflow.yml
@@ -10,9 +10,6 @@ on:
     tags:
       - '**'
   pull_request:
-    paths-ignore:
-      - '.github/workflows/*.yml'
-      - 'tests/*'
 
 jobs:
   job_lint:

--- a/.github/workflows/lint-workflow.yml
+++ b/.github/workflows/lint-workflow.yml
@@ -23,15 +23,6 @@ jobs:
 
   misspell:
     name: Check misspellings
-    runs-on: ubuntu-latest
-    steps:
-    - name: Clone
-      uses: actions/checkout@v4
-      with:
-        fetch-depth: 0
-    - name: Check misspellings
-      uses: codespell-project/actions-codespell@v2
-      with:
-        builtin: clear,rare
-        check_filenames: true
-        ignore_words_list: ontop
+    uses: LedgerHQ/ledger-app-workflows/.github/workflows/reusable_spell_check.yml@v1
+    with:
+      ignore_words_list: ontop

--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -13,5 +13,3 @@ jobs:
     name: Call Ledger unit_test
     uses: LedgerHQ/ledger-app-workflows/.github/workflows/reusable_unit_tests.yml@v1
     secrets: inherit
-    with:
-      test_directory: tests/unit

--- a/ledger_app.toml
+++ b/ledger_app.toml
@@ -3,6 +3,8 @@ build_directory = "./"
 sdk = "C"
 devices = ["nanos", "nanox", "nanos+", "stax", "flex", "apex_p"]
 
-[tests]
-unit_directory = "./tests/unit"
-pytest_directory = "./tests/functional"
+[unit_tests]
+directory = "./tests/unit"
+
+[pytest.functional]
+directory = "./tests/functional"


### PR DESCRIPTION
## What

Four small alignments with Ledger's current tooling. None of them touches
the application binary.

1. `ledger_app.toml` moves from the legacy `[tests]` table to
   `[unit_tests]` + `[pytest.functional]`.
2. `unit_tests.yml` drops the deprecated `test_directory` input.
3. `lint-workflow.yml` drops the deprecated `extensions` and `version`
   inputs, and its hand-written `misspell` job becomes a call to
   `reusable_spell_check.yml@v1`.
4. `ledger-rule-enforcer.yml`, `ci-workflow.yml` and `lint-workflow.yml`
   lose their `paths-ignore` on `pull_request`.

`codeql-workflow.yml` keeps its `paths-ignore`, which is what
`app-boilerplate` does.

## 1 & 2 — the manifest is now the only source of the unit-test directory

`ledgered` 0.15.0 still reads `[tests]`, but only through a compatibility
path — its own source comments the parameter that accepts it with
`# keep the old tests name for backward compatibility`. The current schema,
and the one `app-boilerplate/ledger_app.toml` uses, is `[unit_tests]` with a
`directory` key plus one `[pytest.<name>]` table per suite.

Once the manifest is migrated, the `test_directory` input of
`reusable_unit_tests.yml` can go. It is tagged `[DEPRECATED]` there, and it
is already inert: the *Determine test directory* step overwrites
`TEST_DIRECTORY` unconditionally with

```yaml
echo "TEST_DIRECTORY=$(ledger-manifest -otu ledger_app.toml)" >> "${GITHUB_ENV}"
```

a few steps after reading it, and the step before prints

> :warning:Parameter 'test_directory' is deprecated. It will be automatically
> read from ledger_app.toml using ledger-manifest. Please remove this
> parameter from your workflow.

**Measured**, with `ledgered` 0.15.0 in
`ghcr.io/ledgerhq/ledger-app-builder/ledger-app-dev-tools:latest`:

| command | before | after |
|---|---|---|
| `ledger-manifest --check . ledger_app.toml` | `rc=0` | `rc=0` |
| `ledger-manifest -otu ledger_app.toml` | `tests/unit` | `tests/unit` |
| `ledger-manifest --output-pytest-directories -j --` | `{"pytest_directories": [{"name": "tests", "directory": "tests/functional"}]}` | `{"pytest_directories": [{"name": "functional", "directory": "tests/functional"}]}` |
| `ledger-manifest --output-tests-pytest-directory` | `tests/functional` | *(empty)* |

`-otu` still answers `tests/unit`, which is what the unit-test workflow now
depends on — the migration had to happen first, and it did.

The fourth line is the one behaviour that changes, and it is worth being
explicit about. `--output-tests-pytest-directory` reads the legacy table and
has nothing to answer under the new schema. It is used in exactly one place,
`_get_test_metadata.yml`, and only when that workflow's `pytest_directory`
input is left at `'None'`. `ci-workflow.yml` passes
`test_dir: tests/functional` explicitly, so the other branch is taken: the
value is used as given and merely checked against
`--output-pytest-directories -j`, which matches on `.directory`, not on the
suite name. `tests/functional` is still in that list, so no `::warning::`.
The practical consequence is that `test_dir` in `ci-workflow.yml` is now
load-bearing and must not be dropped.

## 3 — two deprecated inputs and a copied job

`reusable_lint.yml` tags `extensions` and `version` `[DEPRECATED]`, assigns
them to environment variables and never reads them again: the C lint step
hardcodes `find <source> -type f \( -name '*.c' -o -name '*.h' \)` and uses
the `clang-format` from the builder image. A *Check for deprecated inputs*
step emits a warning for each, which shows up as annotations on the *Lint
check* job of every run:

```
warning: Deprecated 'extensions' input — It can be removed from your workflow
warning: Deprecated 'version' input  — It can be removed from your workflow
```

The `misspell` job was a copy of `reusable_spell_check.yml`: same
`codespell-project/actions-codespell@v2`, same `builtin: clear,rare`
(hardcoded in the reusable workflow), same `check_filenames` (its default is
`true`, which is what the job passed). Checked input by input before
replacing it; `ignore_words_list: ontop` is the only local setting and is
kept.

The difference is the checkout. The local job pinned `actions/checkout@v4`,
and the runner says so on every run:

```
warning: Node.js 20 is deprecated. The following actions target Node.js 20
but are being forced to run on Node.js 24: actions/checkout@v4.
```

The reusable workflow is on `actions/checkout@v6`. Its checkout has no
`fetch-depth: 0`, which the local job asked for; codespell reads the working
tree, not the history.

## 4 — the mandatory checks were skippable

`reusable_guidelines_enforcer.yml` describes itself as *mandatory in all
applications*, and *the successful completion of the reusable workflow is a
mandatory step for an app to be available on the Ledger application store*.
`app-boilerplate` triggers its `guidelines_enforcer.yml` on `pull_request`
with no filter, and applies `paths-ignore` to CodeQL only.

Here the filter sat on the enforcer, on the build-and-test workflow and on
the linter, so a pull request touching nothing but
`.github/workflows/*.yml` was neither built, nor tested, nor checked against
the Ledger rules — which is exactly the kind of pull request that can break
CI. On a repository where those checks are required, a job that never starts
also leaves the pull request pending forever.

The linter additionally ignored `'tests/*'`; it only looks at `src`, so that
entry never selected anything either.

## Checks run

- The four `ledger-manifest` commands above, before and after, in
  `ledger-app-dev-tools:latest` (`ledgered` 0.15.0).
- `actionlint` 1.7.12 over all seven workflow files: clean.
- The annotations quoted above were read from the *Code style check* and
  *Unit testing* runs on the current head, not inferred from the YAML.

## Not verified

- No CI run of the changed workflows. Reusable workflows do not start on
  this fork, so the first real execution of the new `misspell` job will be
  after merge.
- The removal of `paths-ignore` was not exercised by a workflow-only pull
  request; the reasoning is from the trigger definitions.
- `--output-tests-pytest-directory` was only traced through
  `ledger-app-workflows@v1`; if something outside that repository calls it,
  it is not covered by the check above.
