### PR TITLE
tests: hold the duplicate member index guard, and correct a stale test header

### DIFF
--- a/src/common/sskr/seed_sskr.c
+++ b/src/common/sskr/seed_sskr.c
@@ -104,6 +104,14 @@ unsigned int bolos_ux_sskr_combine(unsigned char* sskr_shares_hex,
     // SSKR_METADATA_LENGTH_BYTES plus a SSKR_MIN_STRENGTH_BYTES..
     // SSKR_MAX_STRENGTH_BYTES value, so refuse anything else here, before
     // sskr_deserialize_shard() copies it into its fixed-size value field.
+    //
+    // Redundant since sskr_deserialize_shard() started validating value_len
+    // ahead of that copy: everything refused here is refused there too, and
+    // there strictly more (odd value_len). Kept deliberately as defence in
+    // depth -- this bounds data typed on the device before it crosses into
+    // sskr.c, which is kept diffable against upstream bc-sskr. Because it is
+    // redundant, no test can hold it on its own; see
+    // tests/unit/tests/sskr_share_len.c for the enumeration.
     if (sskr_share_len < SSKR_MIN_SERIALIZED_LENGTH_BYTES ||
         sskr_share_len > SSKR_METADATA_LENGTH_BYTES + SSKR_MAX_STRENGTH_BYTES) {
         memzero(sskr_shares_hex, sskr_shares_hex_length);

--- a/tests/unit/CMakeLists.txt
+++ b/tests/unit/CMakeLists.txt
@@ -417,6 +417,12 @@ add_executable(test_sskr_combine_invariants ./tests/sskr_combine_invariants.c ..
 target_include_directories(test_sskr_combine_invariants PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/../../src/common)
 target_link_libraries(test_sskr_combine_invariants PUBLIC cmocka gcov sskr sss testutils)
 
+# The duplicate member index guard, asserted on the error code itself rather
+# than on the 0 the wrapper reports for every failure alike.
+add_executable(test_sskr_duplicate_member_index ./tests/sskr_duplicate_member_index.c ../../src/common/bip39/seed_rom_variables.c ../../src/common/bip39/seed_bip39.c ../../src/common/sskr/seed_rom_variables.c ../../src/common/sskr/seed_sskr.c)
+target_include_directories(test_sskr_duplicate_member_index PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/../../src/common)
+target_link_libraries(test_sskr_duplicate_member_index PUBLIC cmocka gcov sskr sss testutils)
+
 # ---------------------------------------------------------------------------
 # The same Shamir tests, replayed against the TARGET_NANOS build of the GF(2^8)
 # arithmetic.

--- a/tests/unit/tests/sskr_duplicate_member_index.c
+++ b/tests/unit/tests/sskr_duplicate_member_index.c
@@ -1,0 +1,253 @@
+/*
+ * The duplicate member index guard in sskr_combine_shards_internal()
+ * (src/common/sskr/sskr.c:492-494, SSKR_ERROR_DUPLICATE_MEMBER_INDEX): two
+ * shards of the same group carrying the same member_index must be refused.
+ *
+ * The interesting part is that it was already covered, already exercised, and
+ * still not held. Replacing its condition with `if (0)` left the whole suite
+ * green. lcov showed its return line executed, and the test executing it is
+ * even named after it: test_combine_reports_duplicate_member_index, in
+ * sskr_combine_error.c. That file is a regression test for a different defect
+ * -- negative error codes swallowed by a uint16_t -- and uses a duplicate
+ * shard set only as a convenient way to make combination fail. It asserts
+ * bolos_ux_sskr_combine() == 0, and 0 is the answer whether the guard fires or
+ * not. A covered line, named in a test, holding nothing.
+ *
+ * So what is new here is not that the code path runs. It is that the exact
+ * error code is asserted, through sskr_combine_shards() where -10 and -104 are
+ * distinguishable, rather than through the wrapper where both become 0.
+ *
+ * What reaches the guard is the most ordinary mistake there is: the same share
+ * entered twice. bolos_ux_sskr_hex_check() does not catch it -- it checks the
+ * CBOR tag, that the first eight bytes agree across shares, and the CRC-32,
+ * and two copies of one valid share satisfy all three, so it answers 1. The
+ * guard in sskr.c is the only thing that distinguishes the case. The tests
+ * below assert that hex_check() accepts, deliberately: that is a statement
+ * about where the check lives, not a defect, and freezing it stops anyone
+ * later reading hex_check() as protecting against duplicates.
+ *
+ * What the guard is worth, measured by disabling it and re-running:
+ *
+ *              guard present            guard disabled
+ *   hex_check  1                        1
+ *   combine    0                        0
+ *   shards     -10 (DUPLICATE_MEMBER)   -104 (SSS_ERROR_CHECKSUM_FAILURE)
+ *
+ * So nothing unsafe gets through either way, and this is coverage on
+ * already-correct code rather than a bug fix. Two equal x coordinates make the
+ * Lagrange denominator xi[i]^xi[j] zero (sss/interpolate.c), its inverse is
+ * computed as denominator^254 and stays zero, every basis coefficient is zero,
+ * and the reconstruction comes out all zeros -- which the SLIP-39 digest then
+ * refuses. What the guard buys is the difference between a checksum failure
+ * and an error naming the actual mistake; the output buffer is left untouched
+ * in the first case and zeroed in the second.
+ *
+ * Shard-set invariants that are not about member_index live in
+ * sskr_combine_invariants.c; this file is only the duplicate guard, and it is
+ * built entirely from the real bc-sskr share pair rather than synthetic
+ * shards.
+ */
+
+#include <cmocka.h>
+#include <setjmp.h>
+#include <stdarg.h>
+#include <stdbool.h>
+#include <stddef.h>
+#include <stdint.h>
+#include <string.h>
+
+/* testutils.h has to come first: it defines WIDE, which the sskr headers use
+ * without defining. Not sorted, hence the clang-format exclusion. */
+// clang-format off
+#include "testutils.h"
+#include "sskr/common_sskr.h"
+#include "sskr/sskr-constants.h"
+#include "sskr/sskr.h"
+// clang-format on
+
+/* A real 2-of-3 share pair over a 128-bit secret, generated with Blockchain
+ * Commons' bc-sskr: 21-byte shards, member_index 0 and 1, genuine CRC-32s --
+ * which is what lets bolos_ux_sskr_hex_check() be exercised for real here.
+ * Same set as tests/sskr_share_len.c and tests/sskr_interop_bc128_bytewords.c.
+ */
+#define HEADER_LEN (4)
+#define SHARD_LEN (SSKR_MIN_SERIALIZED_LENGTH_BYTES) /* 21 */
+#define CRC_LEN (4)
+#define WIRE_LEN (HEADER_LEN + SHARD_LEN + CRC_LEN) /* 29 */
+
+/* Byte 4 of the shard is the reserved nibble plus member_index. */
+#define MEMBER_INDEX_OFFSET (HEADER_LEN + 4)
+
+static const uint8_t k_shares[2 * WIRE_LEN] = {
+    0xD9, 0x9D, 0x75, 0x55, 0x01, 0x00, 0x00, 0x01, 0x00, 0x72, 0x79, 0x90,
+    0x3D, 0xCB, 0x83, 0x3F, 0x4B, 0xF7, 0xD4, 0x33, 0xFD, 0xAE, 0x81, 0x59,
+    0x13, 0x5E, 0xF3, 0xB3, 0x38, 0xD9, 0x9D, 0x75, 0x55, 0x01, 0x00, 0x00,
+    0x01, 0x01, 0x1B, 0x3F, 0x98, 0x69, 0x92, 0x4E, 0x46, 0x03, 0x14, 0x4D,
+    0x4A, 0x40, 0x84, 0xF0, 0x90, 0xCC, 0xAE, 0x60, 0x76, 0x65};
+
+static const uint8_t k_secret[16] = {0x59, 0xF2, 0x29, 0x3A, 0x5B, 0xCE,
+                                     0x7D, 0x4D, 0xE5, 0x9E, 0x71, 0xB4,
+                                     0x20, 0x7A, 0xC5, 0xD2};
+
+/* CRC-32 (IEEE 802.3: reflected, polynomial 0xEDB88320, initial and final
+ * value 0xFFFFFFFF), written out here rather than calling the cx_crc32() the
+ * code under test uses. Sharing that implementation would make the resealed
+ * frames agree with hex_check() by construction, which is not the same thing
+ * as being correct; test_resealing_reproduces_the_published_crc() below pins
+ * this against the CRCs bc-sskr actually published. */
+static uint32_t crc32_ieee(const uint8_t* buf, size_t len) {
+    uint32_t crc = 0xFFFFFFFFu;
+
+    for (size_t i = 0; i < len; i++) {
+        crc ^= buf[i];
+        for (int bit = 0; bit < 8; bit++) {
+            crc = (crc >> 1) ^ (0xEDB88320u & (uint32_t)(-(int32_t)(crc & 1)));
+        }
+    }
+    return crc ^ 0xFFFFFFFFu;
+}
+
+/* Recomputes the trailing CRC-32 of one wire frame, in the byte order
+ * bolos_ux_sskr_hex_check() compares against: it takes crc32_nbo(), the
+ * checksum in network byte order, and memcmps the raw bytes, so the frame
+ * carries the big-endian form. Written out byte by byte rather than swapping a
+ * uint32_t, so it does not depend on the host's endianness. */
+static void reseal(uint8_t* wire) {
+    uint32_t crc = crc32_ieee(wire, WIRE_LEN - CRC_LEN);
+    uint8_t* out = wire + WIRE_LEN - CRC_LEN;
+
+    out[0] = (uint8_t)(crc >> 24);
+    out[1] = (uint8_t)(crc >> 16);
+    out[2] = (uint8_t)(crc >> 8);
+    out[3] = (uint8_t)crc;
+}
+
+/* How the pair is loaded into the caller's buffer. */
+typedef enum {
+    PAIR_AS_PUBLISHED, /* member_index 0 and 1 */
+    PAIR_DUPLICATED,   /* share 0 twice: the same share entered twice */
+    PAIR_SAME_INDEX    /* both shares, both relabelled member_index 0 */
+} pair_shape_t;
+
+/* Reloaded before every call, because bolos_ux_sskr_combine() memzeroes the
+ * buffer it was given on any failure path. */
+static void load(uint8_t wire[2 * WIRE_LEN], pair_shape_t shape) {
+    memcpy(wire, k_shares, 2 * WIRE_LEN);
+
+    if (shape == PAIR_DUPLICATED) {
+        memcpy(&wire[WIRE_LEN], &k_shares[0], WIRE_LEN);
+    } else if (shape == PAIR_SAME_INDEX) {
+        /* Keep the second shard's own Shamir payload, give it the first
+         * shard's member_index, then make the frame well-formed again so the
+         * only thing wrong with the pair is the collision itself. */
+        wire[WIRE_LEN + MEMBER_INDEX_OFFSET] = 0x00;
+        reseal(&wire[WIRE_LEN]);
+    }
+}
+
+/* Validates the helper the test below depends on: resealing a frame nobody
+ * touched must reproduce the CRC-32 bytes bc-sskr published. */
+static void test_resealing_reproduces_the_published_crc(void** state) {
+    (void)state;
+
+    uint8_t wire[2 * WIRE_LEN];
+
+    memcpy(wire, k_shares, sizeof(wire));
+    reseal(&wire[0]);
+    reseal(&wire[WIRE_LEN]);
+
+    assert_memory_equal(wire, k_shares, sizeof(wire));
+}
+
+/* The whole chain the device runs when one share is entered twice, in the
+ * order it runs it. */
+static void test_the_same_shard_entered_twice_is_refused(void** state) {
+    (void)state;
+
+    uint8_t wire[2 * WIRE_LEN];
+    uint8_t output[SSKR_MAX_STRENGTH_BYTES];
+
+    /* Two copies of one valid share agree on their first eight bytes and each
+     * carry a correct CRC-32, so the framing check has nothing to object to. */
+    load(wire, PAIR_DUPLICATED);
+    assert_int_equal(bolos_ux_sskr_hex_check(wire, sizeof(wire), 2), 1);
+
+    load(wire, PAIR_DUPLICATED);
+    assert_int_equal(bolos_ux_sskr_combine(wire, sizeof(wire), 2, output), 0);
+
+    /* The exact code, not merely a negative one: it is what tells the caller
+     * which mistake was made. */
+    load(wire, PAIR_DUPLICATED);
+    const uint8_t* shards[2] = {&wire[HEADER_LEN],
+                                &wire[WIRE_LEN + HEADER_LEN]};
+    assert_int_equal(
+        sskr_combine_shards(shards, SHARD_LEN, 2, output, sizeof(output)),
+        SSKR_ERROR_DUPLICATE_MEMBER_INDEX);
+}
+
+/* The case that isolates the guard. The duplicated pair above is two identical
+ * byte strings, so a plain memcmp between shares would be enough to catch it.
+ * Here the two shards keep their own distinct Shamir payloads and collide only
+ * on member_index, which nothing but this guard looks at -- and the frames are
+ * resealed, so they are well-formed all the way through hex_check(). */
+static void test_distinct_shards_sharing_a_member_index_are_refused(
+    void** state) {
+    (void)state;
+
+    uint8_t wire[2 * WIRE_LEN];
+    uint8_t output[SSKR_MAX_STRENGTH_BYTES];
+
+    load(wire, PAIR_SAME_INDEX);
+    assert_memory_not_equal(&wire[0], &wire[WIRE_LEN], WIRE_LEN);
+    assert_int_equal(wire[MEMBER_INDEX_OFFSET],
+                     wire[WIRE_LEN + MEMBER_INDEX_OFFSET]);
+
+    /* Nothing in the framing is wrong, so this too is accepted here. */
+    assert_int_equal(bolos_ux_sskr_hex_check(wire, sizeof(wire), 2), 1);
+
+    load(wire, PAIR_SAME_INDEX);
+    assert_int_equal(bolos_ux_sskr_combine(wire, sizeof(wire), 2, output), 0);
+
+    load(wire, PAIR_SAME_INDEX);
+    const uint8_t* shards[2] = {&wire[HEADER_LEN],
+                                &wire[WIRE_LEN + HEADER_LEN]};
+    assert_int_equal(
+        sskr_combine_shards(shards, SHARD_LEN, 2, output, sizeof(output)),
+        SSKR_ERROR_DUPLICATE_MEMBER_INDEX);
+}
+
+/* Non-regression: the same pair, left alone, still reconstructs. Without this
+ * the tests above would be satisfied by a guard that refused everything. */
+static void test_a_set_without_duplicates_still_combines(void** state) {
+    (void)state;
+
+    uint8_t wire[2 * WIRE_LEN];
+    uint8_t output[SSKR_MAX_STRENGTH_BYTES];
+
+    load(wire, PAIR_AS_PUBLISHED);
+    assert_int_equal(bolos_ux_sskr_hex_check(wire, sizeof(wire), 2), 1);
+
+    load(wire, PAIR_AS_PUBLISHED);
+    assert_int_equal(bolos_ux_sskr_combine(wire, sizeof(wire), 2, output),
+                     sizeof(k_secret));
+    assert_memory_equal(output, k_secret, sizeof(k_secret));
+
+    load(wire, PAIR_AS_PUBLISHED);
+    const uint8_t* shards[2] = {&wire[HEADER_LEN],
+                                &wire[WIRE_LEN + HEADER_LEN]};
+    assert_int_equal(
+        sskr_combine_shards(shards, SHARD_LEN, 2, output, sizeof(output)),
+        (int)sizeof(k_secret));
+    assert_memory_equal(output, k_secret, sizeof(k_secret));
+}
+
+int main(void) {
+    const struct CMUnitTest tests[] = {
+        cmocka_unit_test(test_resealing_reproduces_the_published_crc),
+        cmocka_unit_test(test_the_same_shard_entered_twice_is_refused),
+        cmocka_unit_test(
+            test_distinct_shards_sharing_a_member_index_are_refused),
+        cmocka_unit_test(test_a_set_without_duplicates_still_combines),
+    };
+    return cmocka_run_group_tests(tests, NULL, NULL);
+}

--- a/tests/unit/tests/sskr_share_len.c
+++ b/tests/unit/tests/sskr_share_len.c
@@ -1,35 +1,83 @@
 /*
- * The shard-length bound in bolos_ux_sskr_combine(), on both sides of both of
- * its edges, built with AddressSanitizer.
+ * The behaviour of bolos_ux_sskr_combine() at both edges of the shard length
+ * it reads out of the entered data, on both CBOR header forms.
  *
- * The function reads the length of each serialized shard straight out of the
- * CBOR header of the entered data:
+ * The function takes that length straight from the header:
  *
  *     uint8_t sskr_share_len = sskr_shares_hex[3] & 0x1F;
  *     if (sskr_share_len > 23) sskr_share_len = sskr_shares_hex[4];   // 0..255
  *
  * A serialized shard is SSKR_METADATA_LENGTH_BYTES plus a 16..32 byte value,
- * so anything outside 21..37 is not a shard. What makes the bound load-bearing
- * rather than tidy is what sits downstream: sskr_deserialize_shard() does
+ * so anything outside 21..37 is not a shard, and the wrapper refuses it
+ * (seed_sskr.c) before passing anything downstream.
  *
- *     shard->value_len = source_len - SSKR_METADATA_LENGTH_BYTES;
- *     memcpy(shard->value, source + 5, shard->value_len);
+ * What this header used to say, and why it is wrong
+ * -------------------------------------------------
  *
- * and only then validates the length -- the copy has already happened, reading
- * source_len bytes out of a share buffer that is nowhere near that long and
- * writing them into a fixed 32-byte field. Reordering that is a change to
- * sskr.c, which is kept diffable against upstream bc-sskr; the bound in this
- * wrapper is what keeps the reordering from being urgent, because here the
- * length comes from data typed on the device rather than from a library user.
+ * It described sskr_deserialize_shard() as copying first and validating
+ * afterwards, and presented the wrapper's bound as the only thing standing
+ * between a typed-in length and a 33-byte memcpy into a 32-byte field. That
+ * was true when this file was written. It is not true now: sskr.c validates
+ * value_len before the copy it governs, and says so in its own comment. The
+ * reordering landed after this file, and nothing flagged that the reasoning
+ * here had expired.
  *
- * That makes this test a memory-safety test, so it asserts on the sanitizer as
- * much as on the return value. The return value alone cannot hold this bound:
- * an out-of-range length also fails validation further down, so combine()
- * answers 0 either way and the assertion passes on unbounded code. Deleting
- * the bound and running the suite is how that was established, and it is why
- * the over-long cases below hand combine() a buffer sized to the share it
- * actually contains -- which is what the entry screens do -- instead of one
- * padded out to the declared length.
+ * The consequence is not small. The two over-long cases below were written as
+ * memory-safety cases and are no longer discriminating: with the copy now
+ * behind the check, deleting the wrapper's bound produces no out-of-bounds
+ * access and no change in any return value.
+ *
+ * The wrapper's bound is now redundant, and that is checkable
+ * -----------------------------------------------------------
+ *
+ * Enumerating both rejection sets over the whole 0..255 domain of
+ * sskr_share_len (it is a uint8_t read from the header, so that is all of it):
+ *
+ *   - the wrapper accepts exactly 21..37, i.e. 17 values;
+ *   - downstream, sskr_deserialize_shard() refuses source_len < 21 outright,
+ *     then hands source_len - 5 to sskr_check_secret_length(), which refuses
+ *     < 16, > 32 and odd. Since 5 is odd, "odd value_len" means "even
+ *     sskr_share_len". Downstream therefore accepts only the 9 odd values
+ *     21, 23, 25, 27, 29, 31, 33, 35, 37.
+ *
+ * Everything the wrapper refuses is refused downstream as well, so its
+ * rejected set is a strict subset -- it additionally lets through the eight
+ * even lengths 22..36, which downstream then rejects. No return value can
+ * separate the two: both paths end in bolos_ux_sskr_combine() answering 0. And
+ * since the reordering, neither can a sanitizer: the five header bytes read
+ * before validation stay inside the caller's buffer. The bound cannot be held
+ * alone by any test, and this file does not pretend to.
+ *
+ * Which guard holds memory safety, measured
+ * -----------------------------------------
+ *
+ * Removing each of the two guards, separately and together, and running the
+ * whole suite:
+ *
+ *   wrapper bound     sskr.c check     result
+ *   (seed_sskr.c)     before memcpy
+ *   -------------     --------------   --------------------------------------
+ *   present           present          70/70 green (the current tree)
+ *   REMOVED           present          70/70 green -- nothing goes red
+ *   present           REMOVED          red: test_sskr_deserialize_shard_bounds
+ *   REMOVED           REMOVED          red: test_sskr_share_len AND
+ *                                      test_sskr_deserialize_shard_bounds,
+ *                                      stack-buffer-overflow in memcpy (a
+ *                                      33-byte read past the source buffer and
+ *                                      a 33-byte write past shard->value)
+ *
+ * So memory safety is held, but by sskr.c's own check, and the test that holds
+ * it is test_sskr_deserialize_shard_bounds -- not this file.
+ *
+ * What this file is still for
+ * ---------------------------
+ *
+ * The behaviour of the entry point at the two exact bounds: 21 and 37 accepted
+ * and reconstructing the right secret, anything outside refused, across both
+ * the short-form CBOR header (length in the low five bits of byte 3) and the
+ * long form (0x58 plus a separate length byte). That is worth keeping whatever
+ * happens to the wrapper's bound, because it is a statement about the entry
+ * point rather than about which internal guard enforces it.
  */
 
 #include <cmocka.h>
@@ -133,10 +181,11 @@ static void test_combine_rejects_shard_length_below_minimum(void** state) {
      * 20-byte shard leaves a 15-byte value, under the 16-byte minimum. */
     wire[3] = 0x40 | (SHORT_SHARD_LEN - 1);
 
-    /* This edge documents the bound rather than holding it: too short is also
-     * refused by sskr_deserialize_shard()'s own first check, so this case
-     * still passes with the bound deleted. The two above the maximum are the
-     * ones that hold it, and they are the dangerous side. */
+    /* Like the two over-long cases, this one documents the entry point's
+     * answer rather than holding the wrapper's bound: too short is refused by
+     * sskr_deserialize_shard()'s own first check too, so it still passes with
+     * the bound deleted. See the header for why that is now true on both
+     * sides. */
     assert_int_equal(bolos_ux_sskr_combine(wire, sizeof(wire), 1, output), 0);
 }
 
@@ -151,9 +200,11 @@ static void test_combine_rejects_shard_length_above_maximum(void** state) {
 
     memcpy(wire, k_max_len_shares, sizeof(wire));
 
-    /* One above the maximum, in the long-form length byte. Without the bound
-     * the copy reads 33 bytes from 10 bytes in, one past the end of wire[],
-     * and writes them into a 32-byte field. */
+    /* One above the maximum, in the long-form length byte. The buffer holds
+     * exactly the share, not the declared length, so this is the shape the
+     * entry screens actually produce. sskr_check_secret_length() would refuse
+     * 33 anyway, before the copy; what is asserted here is the answer, not
+     * which of the two guards produced it. */
     wire[4] = LONG_SHARD_LEN + 1;
 
     assert_int_equal(bolos_ux_sskr_combine(wire, sizeof(wire), 1, output), 0);
@@ -170,9 +221,9 @@ static void test_combine_rejects_overlong_shard_length(void** state) {
     memcpy(wire, k_max_len_shares, sizeof(wire));
     wire[4] = OVERLONG_SHARD_LEN;
 
-    /* Must be refused before any copy. Without the bound,
-     * sskr_deserialize_shard() reads 195 bytes starting 10 bytes into a
-     * 42-byte buffer and writes them into a 32-byte field. */
+    /* A length that is not merely one too many must be refused just the same,
+     * and before any copy. Both guards refuse it independently; removing
+     * either one on its own leaves this assertion passing. */
     assert_int_equal(bolos_ux_sskr_combine(wire, sizeof(wire), 1, output), 0);
 }
 


### PR DESCRIPTION
Two related things about what the suite actually holds around
`bolos_ux_sskr_combine()` / `sskr_combine_shards()`. Both were established by
mutation. Neither is a code defect — the only `src/` change is one comment.

Two commits, each self-contained.

---

## 1. The duplicate member index guard was reached but not held

`sskr_combine_shards_internal()` refuses two shards of the same group carrying
the same `member_index` (`sskr.c:492-494`, `SSKR_ERROR_DUPLICATE_MEMBER_INDEX`,
`-10`). Replacing that condition with `if (0)` left the suite entirely green,
**69/69**.

Not because nothing ran it. `lcov` shows the return line executed, and the test
that executes it is *named after it*:
`test_combine_reports_duplicate_member_index`, in `sskr_combine_error.c`. That
file is a regression test for a different defect — negative error codes
swallowed by a `uint16_t` — and uses a duplicate shard set only as a convenient
way to make combination fail. It asserts `bolos_ux_sskr_combine() == 0`, and 0
is the answer whether the guard fires or not.

A covered line, named in a test, holding nothing. That is the part worth
reporting.

### What reaches it

Not a contrived shard set: the same share entered twice, which is an ordinary
user error.

`bolos_ux_sskr_hex_check()` does **not** catch it. It checks the CBOR tag, that
the first eight bytes agree across shares, and the CRC-32 — and two copies of
one valid share satisfy all three, so it answers 1. The guard in `sskr.c` is the
only thing that distinguishes the case. The new tests assert that
`hex_check()` accepts, deliberately: it is a statement about where the check
lives, not a defect, and freezing it stops anyone later reading `hex_check()` as
protecting against duplicates.

### What the tests add

The distinction between `-10` and everything else survives one level down, so
that is where they assert — through `sskr_combine_shards()`, not through the
wrapper where `-10` and `-104` both become 0. A new target,
`test_sskr_duplicate_member_index`, built entirely from the bc-sskr share pair
already in `sskr_share_len.c` and `sskr_interop_bc128_bytewords.c` rather than
from a new vector or from synthetic shards:

1. **the same shard twice** → `hex_check` 1, `combine` 0, `combine_shards`
   **-10**, the exact code and not merely a negative one;
2. **two shards keeping their own distinct Shamir payloads and colliding only
   on `member_index`** — the case a byte comparison between shares could not
   catch, so it is the one that isolates the guard. Its frame is resealed with
   a recomputed CRC-32, so it is well-formed all the way through `hex_check()`
   (which answers 1) and the collision is the only thing wrong with it;
3. **the CRC-32 helper that resealing depends on**, pinned against the
   checksums bc-sskr published. It is implemented in the test rather than
   borrowed from the code under test: sharing `cx_crc32()` would make the
   resealed frames agree with `hex_check()` by construction, which is not the
   same thing as being correct;
4. **non-regression**: the untouched pair still reconstructs the right secret.

These sit in their own file rather than in `sskr_combine_invariants.c`: that
file covers shard-set invariants generally and builds synthetic shards, while
this one is about a single guard and needs real frames with valid checksums to
exercise `hex_check()` at all. `sskr_combine_invariants.c` is untouched.

### Scope, stated no wider than it is

**There is no vulnerability here.** Disabling the guard and re-running the same
input gives `-104` (`SSS_ERROR_CHECKSUM_FAILURE`) instead of `-10`:

|  | guard present | guard `if (0)` |
|---|---|---|
| `bolos_ux_sskr_hex_check` | 1 | 1 |
| `bolos_ux_sskr_combine` | 0 | 0 |
| `sskr_combine_shards` | **-10** | **-104**, output zeroed |

Two equal x coordinates make the Lagrange denominator `xi[i]^xi[j]` zero
(`sss/interpolate.c`), its inverse is computed as `denominator^254` and stays
zero, every basis coefficient is zero, the reconstruction comes out all zeros,
and the SLIP-39 digest refuses it. What is lost without the guard is a
diagnostic, not safety.

### Discriminance

With the guard mutated to `if (0)`, `test_sskr_duplicate_member_index` is the
**only** target that goes red, on exactly the two duplicate cases, both
reporting `-104 != -10`. Restored and re-verified afterwards.

Coverage of the return line moves 1 → 5 executions; the file total does not
move, because the line already counted as covered. That is the point.

---

## 2. A header of ours claims a bound it no longer holds

This one corrects a previous contribution in this same series, so it is worth
saying plainly.

The header of `tests/unit/tests/sskr_share_len.c` describes
`sskr_deserialize_shard()` as copying the shard value first and validating its
length afterwards:

> ```
> shard->value_len = source_len - SSKR_METADATA_LENGTH_BYTES;
> memcpy(shard->value, source + 5, shard->value_len);
> ```
> and only then validates the length — the copy has already happened

and presents the shard-length bound in `bolos_ux_sskr_combine()` as the only
thing standing between a typed-in length and a 33-byte `memcpy` into a 32-byte
field.

**That was true when the file was written. It is not true now.** `sskr.c`
validates `value_len` before the copy it governs, with its own comment saying
so. The reordering landed after this test file, and nothing signalled that its
justification had expired — which also means its two over-long cases quietly
stopped discriminating anything, with no test failing to say so.

### The wrapper's bound is now entirely redundant

Enumerated over the whole `0..255` domain of `sskr_share_len` (it is a `uint8_t`
read from the CBOR header, so that is all of it):

- the wrapper accepts exactly **21..37**, 17 values;
- downstream, `sskr_deserialize_shard()` refuses `source_len < 21` outright,
  then hands `source_len - 5` to `sskr_check_secret_length()`, which refuses
  `< 16`, `> 32` and odd. Since 5 is odd, an odd `value_len` means an **even**
  `sskr_share_len`. Downstream therefore accepts only the **9 odd** lengths
  21, 23, 25, 27, 29, 31, 33, 35, 37.

The wrapper's rejected set is a **strict subset** of the downstream one — it
additionally lets through the eight even lengths 22..36, which downstream then
rejects. No return value can separate them, both paths ending in `combine()`
answering 0; and since the reordering, no sanitizer can either, because the
five header bytes read before validation stay inside the caller's buffer.

**So no test can hold that bound alone**, and none is added here that pretends
to. Trying to make the over-long cases discriminating again would produce a test
that tests something other than what it announces — which is the defect being
corrected.

### Which guard holds memory safety, measured

Removing each guard, separately and together, and running the whole suite:

| wrapper bound (`seed_sskr.c`) | `sskr.c` check before `memcpy` | result |
|---|---|---|
| present | present | 69/69 green (current tree) |
| **REMOVED** | present | **69/69 green — nothing goes red** |
| present | **REMOVED** | red: `test_sskr_deserialize_shard_bounds` |
| **REMOVED** | **REMOVED** | red: `test_sskr_share_len` **and** `test_sskr_deserialize_shard_bounds`, `stack-buffer-overflow` in `memcpy` — a 33-byte read past the source buffer and a 33-byte write past `shard->value` |

Memory safety is held, but by `sskr.c`'s own check, and the test that holds it
is `test_sskr_deserialize_shard_bounds` — not this file.

### What changed

The header, and three comments in the test bodies that repeated the same stale
claim. **No test is deleted and the guard is not removed**: what these tests
hold is the behaviour of the entry point at both exact bounds, on both CBOR
header forms, which stays useful whoever enforces it. Only the justification was
out of date.

The bound in `seed_sskr.c` now carries a comment saying it is redundant and
deliberately retained. **That comment is the only `src/` change in this branch.**

---

## A question for you

The shard-length bound in `bolos_ux_sskr_combine()` is today entirely redundant
with the validation in `sskr_deserialize_shard()`. Keep it as defence in depth,
or drop it?

I have deliberately not decided that here — it is a change on a path whose
length comes from data typed on the device, and it did not seem like something
to settle inside a tests PR. Happy either way.

## Verification

- `ctest -N` **69 → 70**; **70/70 green** on a full clean build. Registration
  is automatic from `add_executable()`; no list was edited.
- Warnings unchanged: 19, all pre-existing `-Wmissing-prototypes` in other test
  files; **none in the files touched here**.
- `clang-format --dry-run -Werror` clean on **every** file touched:
  `src/common/sskr/seed_sskr.c`, `tests/unit/tests/sskr_duplicate_member_index.c`
  and `tests/unit/tests/sskr_share_len.c`.
- Because `src/` is touched, all **six** targets of `ledger_app.toml` were built
  by hand, `nanos` included: all six clean, five `app.elf` **byte-identical** to
  the base, and the `nanos` one differing only in `.debug_info` / `.debug_line`
  (line numbers shifted by the added comment) — its loadable image and symbol
  table are identical.
- The first commit is green on its own, so the pair bisects.
