### PR TITLE
tests: hold the BIP-85 DICE and DRNG vectors, and the BIP-39 lengths

### DIFF
--- a/src/common/bip85/bip85_internal.h
+++ b/src/common/bip85/bip85_internal.h
@@ -63,6 +63,7 @@ bool bip85_dice_sides_valid(uint32_t sides);
 bool bip85_dice_rolls_valid(uint32_t rolls);
 
 // Entropy and output shaping.
+uint8_t bip85_bip39_entropy_len(uint8_t words);
 bool bip85_entropy_from_key(const uint8_t key[32], uint8_t *out, size_t out_len);
 bool bolos_ux_bip85_drng_with_seed(uint8_t *seed,
                                    size_t seed_length,

--- a/src/common/bip85/seed_bip85.c
+++ b/src/common/bip85/seed_bip85.c
@@ -413,20 +413,39 @@ unsigned int bip85_path_dice(unsigned int* path, uint32_t sides, uint32_t rolls,
 }
 
 /**
- * @brief Reports whether `words` is a mnemonic length the BIP39 application
- * accepts.
+ * @brief Reports whether `words` is a mnemonic length this application offers.
  *
- * @details The `LEDGER_ASSERT` that enforces this still terminates the
- * process on a violation exactly as before; only the condition moved here, so
- * that both sides of each bound can be checked by a unit test.
+ * @details Deliberately narrower than BIP-85. The specification's Words Table
+ * defines five lengths -- 12, 15, 18, 21 and 24 words, for 128, 160, 192, 224
+ * and 256 bits of entropy -- and the truncation this file applies
+ * (`bip85_bip39_entropy_len()` below) is correct for all five. This
+ * application exposes only three: `src/nbgl/ui.c` sets the mnemonic size to
+ * `BIP39_MNEMONIC_SIZE_12`, `_18` or `_24` and nothing else, and that is the
+ * only source of `words`.
+ *
+ * The narrower condition is the point. This backs a `LEDGER_ASSERT` in
+ * `bolos_ux_bip85_bip39()`, whose job is to stop a programming error before a
+ * secret is derived, and nothing downstream would catch one:
+ * `bolos_ux_bip39_mnemonic_encode()` accepts any entropy length that is a
+ * multiple of 4 from 16 to 32 bytes, so the 20 or 28 bytes a 15 or 21 would
+ * produce still yield a perfectly valid mnemonic -- of a length the rest of
+ * the application never asked for.
+ *
+ * Do not widen this back to the Words Table without also exposing 15 and 21
+ * in the UI: the divergence is intentional.
+ *
+ * The `LEDGER_ASSERT` that enforces this still terminates the process on a
+ * violation exactly as before; the condition lives here so that both sides of
+ * it can be checked by a unit test.
  *
  * @param[in] words Number of mnemonic words requested.
  *
- * @return `true` if the value is in range.
+ * @return `true` if this application offers that length.
  */
 bool bip85_bip39_words_valid(uint8_t words) {
-    return (words >= BIP39_MNEMONIC_SIZE_12) && (words % 3 == 0) &&
-           (words <= BIP39_MNEMONIC_SIZE_24);
+    return (words == BIP39_MNEMONIC_SIZE_12) ||
+           (words == BIP39_MNEMONIC_SIZE_18) ||
+           (words == BIP39_MNEMONIC_SIZE_24);
 }
 
 /**

--- a/src/common/bip85/seed_bip85.c
+++ b/src/common/bip85/seed_bip85.c
@@ -430,6 +430,28 @@ bool bip85_bip39_words_valid(uint8_t words) {
 }
 
 /**
+ * @brief Returns the number of entropy bytes a `words`-word BIP39 mnemonic is
+ * built from, i.e. how much of the 64-byte BIP85 output the BIP39 application
+ * keeps.
+ *
+ * @details BIP-85's Words Table pairs each mnemonic length with an entropy
+ * size -- 12 words / 128 bits, 15 / 160, 18 / 192, 21 / 224, 24 / 256 -- which
+ * is `words * 4 / 3` bytes throughout. That expression used to be spelled out
+ * three times inside `bolos_ux_bip85_bip39()`, below the `HAVE_NBGL` guard,
+ * where no test target compiles it. Here it has external linkage and sits
+ * outside the guard, for the same reason `bip85_dice_bits_per_roll()` above
+ * does: so a unit test can hold it against the table.
+ *
+ * @param[in] words Number of mnemonic words. `bip85_bip39_words_valid()`
+ * above says which values reach this.
+ *
+ * @return The entropy length, in bytes.
+ */
+uint8_t bip85_bip39_entropy_len(uint8_t words) {
+    return (uint8_t)(words * 4 / 3);
+}
+
+/**
  * @brief Reports whether `num_bytes` is an output length the HEX application
  * accepts. See `bip85_bip39_words_valid()` for why this is a separate
  * function.
@@ -590,11 +612,13 @@ uint8_t bolos_ux_bip85_bip39(uint8_t* hex_out, uint8_t language, uint8_t words,
         LEDGER_ASSERT(false, "BIP85 entropy failed");
     }
 
-    memcpy(hex_out, buffer, words * 4 / 3);
+    uint8_t entropy_len = bip85_bip39_entropy_len(words);
+
+    memcpy(hex_out, buffer, entropy_len);
     memzero(buffer, BIP85_ENTROPY_LENGTH);
 
-    PRINTF("BIP85 BIP39 hex output: %u bytes\n", words * 4 / 3);
-    return words * 4 / 3;
+    PRINTF("BIP85 BIP39 hex output: %u bytes\n", entropy_len);
+    return entropy_len;
 }
 
 void bolos_ux_bip85_hex(uint8_t* hex_out, uint8_t num_bytes,

--- a/src/common/bip85/seed_bip85.c
+++ b/src/common/bip85/seed_bip85.c
@@ -493,6 +493,11 @@ bool bip85_hex_num_bytes_valid(uint8_t num_bytes) {
  * @return `true` if the value is in range.
  */
 bool bip85_pwd_base64_len_valid(uint8_t pwd_len) {
+    // `BASE64_ENCODE_LENGTH - 2` is 86, the upper bound BIP-85 states:
+    // Base64-encoding 64 bytes yields 88 characters, of which the last two
+    // are `=` padding and carry nothing. `bip85_pwd_base85_len_valid()` below
+    // needs no such correction -- Base85 has no padding, so all 80 of its
+    // characters are usable.
     return (pwd_len >= 20) && (pwd_len <= BASE64_ENCODE_LENGTH - 2);
 }
 
@@ -518,6 +523,14 @@ bool bip85_pwd_base85_len_valid(uint8_t pwd_len) {
  * @return `true` if the value is in range.
  */
 bool bip85_dice_sides_valid(uint32_t sides) {
+    // BIP-85 writes `2 <= sides <= 2^32 - 1`, but its own derivation path
+    // makes the top half of that range unrepresentable: every component is
+    // hardened, `0x80000000 | sides`, which leaves 31 usable bits. A `sides`
+    // of 2^31 would derive from the same path as a `sides` of 0. Allowing the
+    // upper half would mean two different parameters deriving the same secret.
+    // The bound below is therefore intentional: the inconsistency is in the
+    // specification, not here. Same reasoning for `bip85_dice_rolls_valid()`
+    // below.
     return (sides >= 2) && (sides <= (UINT32_MAX >> 1));
 }
 
@@ -566,6 +579,11 @@ bool bolos_ux_bip85_entropy(uint8_t* entropy, const unsigned int* path,
     if (os_derive_bip32_no_throw(CX_CURVE_256K1, path, path_len, entropy,
                                  entropy + 32) != CX_OK) {
         PRINTF("An error occurred while generating BIP85 entropy\n");
+        // All five callers do wipe `entropy` before their LEDGER_ASSERT, so
+        // nothing leaks today. Wiped here as well because the syscall may
+        // have written part of the buffer before failing, and the function
+        // that owns the secret should be the one that clears it.
+        memzero(entropy, BIP85_ENTROPY_LENGTH);
         return 0;
     }
     PRINTF("Root key from device: 32 bytes\n");

--- a/tests/unit/tests/bip85_derivation_path.c
+++ b/tests/unit/tests/bip85_derivation_path.c
@@ -360,6 +360,32 @@ static void test_bip39_words_valid(void** state) {
     assert_false(bip85_bip39_words_valid(255));
 }
 
+// ---------------------------------------------------------------------------
+// BIP39 truncation length
+//
+// bip85_bip39_entropy_len() decides how much of the 64-byte BIP85 output the
+// BIP39 application keeps. Until it was extracted it lived inside
+// bolos_ux_bip85_bip39(), below the HAVE_NBGL guard, so no test target
+// compiled it -- and tests/bip85_bip39_entropy.c does not reach it either:
+// that file supplies the length itself, from its own table.
+//
+// Expected values are read off BIP-85's Words Table, as the bit counts it
+// prints divided by 8, rather than recomputed with the expression under
+// test -- which would only check the formula against a copy of itself.
+//
+// Only the three lengths this application offers are pinned. The formula is
+// generic and the table has five entries, but src/nbgl/ui.c only ever sets
+// BIP39_MNEMONIC_SIZE_12, _18 or _24, and asserting 15 or 21 here would
+// suggest a support that does not exist.
+// ---------------------------------------------------------------------------
+
+static void test_bip39_entropy_len(void** state) {
+    (void)state;
+    assert_int_equal(bip85_bip39_entropy_len(12), 128 / 8);
+    assert_int_equal(bip85_bip39_entropy_len(18), 192 / 8);
+    assert_int_equal(bip85_bip39_entropy_len(24), 256 / 8);
+}
+
 static void test_hex_num_bytes_valid(void** state) {
     (void)state;
     assert_false(bip85_hex_num_bytes_valid(0));
@@ -427,6 +453,7 @@ int main(void) {
         cmocka_unit_test(test_hardening_survives_large_parameters),
         cmocka_unit_test(test_purpose_is_common_to_all_paths),
         cmocka_unit_test(test_bip39_words_valid),
+        cmocka_unit_test(test_bip39_entropy_len),
         cmocka_unit_test(test_hex_num_bytes_valid),
         cmocka_unit_test(test_pwd_base64_len_valid),
         cmocka_unit_test(test_pwd_base85_len_valid),

--- a/tests/unit/tests/bip85_derivation_path.c
+++ b/tests/unit/tests/bip85_derivation_path.c
@@ -129,7 +129,11 @@ static void test_path_bip39(void** state) {
     // values guard the position of the parameter in the path, not a feature.
     check_bip39(0, 12, 0);
     check_bip39(0, 24, 0);
-    // The full set of mnemonic lengths the application accepts.
+    // 15 and 21 are BIP-85 Words Table lengths this application does not
+    // offer -- test_bip39_words_valid() below expects them to be refused.
+    // They belong here all the same: a path builder must place whatever value
+    // it is handed at the right component, and that is all these check. They
+    // say nothing about which lengths are supported.
     check_bip39(0, 15, 1);
     check_bip39(0, 18, 2);
     check_bip39(0, 21, 3);
@@ -335,26 +339,37 @@ static void test_purpose_is_common_to_all_paths(void** state) {
 // as literals rather than recomputed from the same expression.
 // ---------------------------------------------------------------------------
 
+// This guard is deliberately narrower than BIP-85: the Words Table defines
+// five lengths (12, 15, 18, 21, 24) and this application offers three --
+// src/nbgl/ui.c sets the mnemonic size to BIP39_MNEMONIC_SIZE_12, _18 or _24
+// and nothing else, and that is the only source of `words`. It backs a
+// LEDGER_ASSERT meant to stop a programming error before a secret is derived,
+// and nothing downstream would stop one: bolos_ux_bip39_mnemonic_encode()
+// accepts any entropy length that is a multiple of 4 from 16 to 32 bytes, so
+// the 20 or 28 bytes a 15 or 21 would produce still yield a valid mnemonic.
+// 15 and 21 are therefore expected to be refused here.
 static void test_bip39_words_valid(void** state) {
     (void)state;
-    // Accepted: 12, 15, 18, 21, 24.
+    // Accepted: the three lengths the application offers.
     assert_true(bip85_bip39_words_valid(12));
-    assert_true(bip85_bip39_words_valid(15));
     assert_true(bip85_bip39_words_valid(18));
-    assert_true(bip85_bip39_words_valid(21));
     assert_true(bip85_bip39_words_valid(24));
 
-    // Below the lower bound, including multiples of 3.
+    // Defined by BIP-85's Words Table, not offered by this application.
+    assert_false(bip85_bip39_words_valid(15));
+    assert_false(bip85_bip39_words_valid(21));
+
+    // Below 12, including a multiple of 3 and the value just under.
     assert_false(bip85_bip39_words_valid(0));
     assert_false(bip85_bip39_words_valid(9));
     assert_false(bip85_bip39_words_valid(11));
 
-    // In range but not a multiple of 3.
+    // Between the accepted lengths.
     assert_false(bip85_bip39_words_valid(13));
     assert_false(bip85_bip39_words_valid(14));
     assert_false(bip85_bip39_words_valid(23));
 
-    // Above the upper bound, including a multiple of 3.
+    // Above 24, including a multiple of 3 and the value just over.
     assert_false(bip85_bip39_words_valid(25));
     assert_false(bip85_bip39_words_valid(27));
     assert_false(bip85_bip39_words_valid(255));

--- a/tests/unit/tests/bip85_dice_roll.c
+++ b/tests/unit/tests/bip85_dice_roll.c
@@ -21,6 +21,109 @@ static const uint8_t seed[BIP85_ENTROPY_LENGTH] = {
     0x2d, 0x2e, 0x2f, 0x30, 0x31, 0x32, 0x33, 0x34, 0x35, 0x36, 0x37,
     0x38, 0x39, 0x3a, 0x3b, 0x3c, 0x3d, 0x3e, 0x3f, 0x40};
 
+// The DICE test vector BIP-85 publishes, transcribed from the specification
+// (bip-0085.mediawiki, "DICE"), for:
+//
+//   MASTER BIP32 ROOT KEY: xprv9s21ZrQH143K2LBWUUQRFXhucrQqBpKdRRxNVq2zBq
+//                          sx8HVqFk2uYo8kmbaLLHRdqtQpUm98uKfu3vca1LqdGhU
+//                          tyoFnCNkfmXRyPXLjbKb
+//   PATH:                  m/83696968'/89101'/6'/10'/0'
+//   DERIVED ENTROPY:       5e41f8f5...4b6f6cd2  (the 64 bytes below)
+//   DERIVED ROLLS:         1,0,0,2,0,1,5,5,2,4
+//
+// The specification prints the derived entropy next to the rolls, which is
+// what makes this vector reachable here at all: the 64 bytes below are
+// exactly what bolos_ux_bip85_dice() would hand bip85_dice_roll() for that
+// path, so the whole vector is checkable without any BIP32 derivation and
+// without os_derive_bip32_no_throw(), the BOLOS syscall that has no host
+// equivalent. The derivation boundary was never the reason this vector was
+// missing.
+static const uint8_t dice_vector_entropy[BIP85_ENTROPY_LENGTH] = {
+    0x5e, 0x41, 0xf8, 0xf5, 0xd5, 0xd9, 0xac, 0x09, 0xa2, 0x0b, 0x8a,
+    0x57, 0x97, 0xa3, 0x17, 0x2b, 0x28, 0xc8, 0x06, 0xae, 0xad, 0x00,
+    0xd2, 0x7e, 0x36, 0x60, 0x9e, 0x2d, 0xd1, 0x16, 0xa5, 0x91, 0x76,
+    0xa7, 0x38, 0x80, 0x42, 0x36, 0x58, 0x6f, 0x66, 0x8d, 0xa8, 0xa5,
+    0x1b, 0x90, 0xc7, 0x08, 0xa4, 0x22, 0x6d, 0x7f, 0x92, 0x25, 0x9c,
+    0x69, 0xf6, 0x4c, 0x51, 0x12, 0x4b, 0x6f, 0x6c, 0xd2};
+
+// The published rolls, written out as the specification prints them. Not
+// recomputed here from anything this repository owns: an expected value that
+// the code under test could have produced is not an oracle.
+static const uint32_t dice_vector_rolls[] = {1, 0, 0, 2, 0, 1, 5, 5, 2, 4};
+
+#define DICE_VECTOR_SIDES 6
+#define DICE_VECTOR_ROLLS (sizeof(dice_vector_rolls) / sizeof(uint32_t))
+
+// The only test in this suite that pins a produced roll value.
+//
+// Everything else here asserts a count (`produced == 257`, `== 10`, `== -1`,
+// `== -3`) or a self-consistency -- and a self-consistency compares two runs
+// of the same binary, so it keeps agreeing when that binary is wrong. Two
+// rules the specification states in so many words are only visible in the
+// values:
+//
+//   "Trim any bits in excess of bits_per_roll (retain the most significant
+//    bits)"  -- keeping the low bits instead yields 3,2,5,0,3,5,4,1,1,1 on
+//    this very vector, a perfectly plausible sequence of ten valid d6 rolls;
+//
+//   "If the trial is greater than or equal to the number of sides, skip it"
+//    -- rejecting on `> sides` instead yields 6,1,0,0,2,0,1,6,5,5, which
+//    opens with a 6 on a six-sided die.
+//
+// Neither is reachable at sides = 2, which is all the tests above use: at
+// one bit per roll the shift direction is immaterial, and `< 2` and `<= 2`
+// accept exactly the same values, so the rejection step never fires.
+static void test_dice_roll_matches_bip85_vector(void** state) {
+    (void)state;
+
+    uint32_t out[DICE_VECTOR_ROLLS];
+    int32_t produced =
+        bip85_dice_roll(out, DICE_VECTOR_ROLLS, DICE_VECTOR_SIDES,
+                        DICE_VECTOR_ROLLS, dice_vector_entropy);
+
+    assert_int_equal(produced, (int32_t)DICE_VECTOR_ROLLS);
+
+    for (size_t i = 0; i < DICE_VECTOR_ROLLS; i++) {
+        // Redundant with the equality below, but it is the invariant the
+        // specification states -- "an N-sided die produces values in the
+        // range [0, N-1]" -- and failing on it says so directly.
+        assert_true(out[i] < DICE_VECTOR_SIDES);
+        assert_int_equal(out[i], dice_vector_rolls[i]);
+    }
+}
+
+// The vector above pins one case; this pins the rule behind it.
+//
+// Rejection only does anything when `sides` is not a power of two, so the
+// sizes swept here are chosen to make it bite: three just above 2, two just
+// above a power of two (129 and 257, the worst cases at 8 and 9 bits per
+// roll, where barely half the draws are accepted), and two in between.
+// Measured on the seed below at 50 rolls each, every one of them discards
+// draws -- from 11 rejected at sides = 100 up to 37 at sides = 129. A power
+// of two, or sides = 2, would make this test vacuous, which is exactly the
+// trap the rest of the file falls into.
+//
+// The seed is the same arbitrary one the d2 tests use; here it is arbitrary
+// for a different reason -- the property asserted holds for every seed, so
+// no particular one is privileged.
+static void test_dice_roll_never_exceeds_sides(void** state) {
+    (void)state;
+
+    static const uint32_t sides_sweep[] = {3, 5, 6, 20, 100, 129, 257};
+    const uint32_t rolls = 50;
+
+    for (size_t s = 0; s < sizeof(sides_sweep) / sizeof(uint32_t); s++) {
+        uint32_t out[50];
+        int32_t produced = bip85_dice_roll(out, sizeof(out) / sizeof(uint32_t),
+                                           sides_sweep[s], rolls, seed);
+
+        assert_int_equal(produced, (int32_t)rolls);
+        for (uint32_t i = 0; i < rolls; i++) {
+            assert_true(out[i] < sides_sweep[s]);
+        }
+    }
+}
+
 // With bytes_per_roll = 1 and a fixed BIP85_DRNG_MAX_DIGEST_SIZE = 256
 // byte digest, no more than 256 rolls can ever come out of a single,
 // non-extended digest -- even at the 100% acceptance rate d2 gives here,
@@ -113,6 +216,8 @@ static void test_dice_roll_reports_drng_exhaustion(void** state) {
 
 int main(void) {
     const struct CMUnitTest tests[] = {
+        cmocka_unit_test(test_dice_roll_matches_bip85_vector),
+        cmocka_unit_test(test_dice_roll_never_exceeds_sides),
         cmocka_unit_test(test_dice_roll_extends_past_256_bytes),
         cmocka_unit_test(test_dice_roll_exact_when_well_under_capacity),
         cmocka_unit_test(test_dice_roll_extension_preserves_prior_rolls),

--- a/tests/unit/tests/bip85_drng_with_seed.c
+++ b/tests/unit/tests/bip85_drng_with_seed.c
@@ -36,6 +36,68 @@ static void test_drng_with_seed_matches_cx_shake256_hash(void** state) {
     assert_memory_equal(digest, expected, sizeof(digest));
 }
 
+// The BIP85-DRNG-SHAKE256 test vector the specification publishes, for:
+//
+//   MASTER BIP32 ROOT KEY: xprv9s21ZrQH143K2LBWUUQRFXhucrQqBpKdRRxNVq2zBq
+//                          sx8HVqFk2uYo8kmbaLLHRdqtQpUm98uKfu3vca1LqdGhU
+//                          tyoFnCNkfmXRyPXLjbKb
+//   PATH:                  m/83696968'/0'/0'
+//   DERIVED ENTROPY:       efecfbcc...e48618f7  (the 64 bytes below)
+//   DRNG(80 bytes):        b78b1ee6...02991111
+//
+// Same reason this is reachable as for the DICE vector: the specification
+// prints the 64-byte derived entropy, which is precisely the input
+// bolos_ux_bip85_drng_test() hands this function, so the vector needs no
+// BIP32 derivation and no BOLOS syscall.
+//
+// This is the assertion the two tests above cannot make. Checking the
+// function against cx_shake256_hash() shows the wrapper forwards its
+// arguments correctly, and that is worth having, but it would hold just as
+// well if BIP-85's DRNG were something other than SHAKE256 seeded with the
+// 64 entropy bytes. Only an externally published value establishes that it
+// is not.
+//
+// Do not reach for `bipsea` 3.2.0 to reproduce this: its `derive -a drng`
+// builds m/83696968'/0'/0'/{index}', a four-component path, where the
+// vector's is the three-component m/83696968'/0'/0' -- bipsea.py appends
+// "/0'/{index}'" to a path that already ends in the application number 0'.
+// It therefore disagrees with the specification's own vector on the entropy
+// it feeds the DRNG. The discrepancy is in the path, not in SHAKE256:
+// SHAKE256 over the entropy the specification publishes reproduces the
+// published 80 bytes exactly. The expected bytes below come from the BIP.
+//
+// Not const, for the same reason `seed` above is not: the function takes a
+// non-const `uint8_t *`.
+static uint8_t drng_vector_entropy[] = {
+    0xef, 0xec, 0xfb, 0xcc, 0xff, 0xea, 0x31, 0x32, 0x14, 0x23, 0x2d,
+    0x29, 0xe7, 0x15, 0x63, 0xd9, 0x41, 0x22, 0x9a, 0xfb, 0x43, 0x38,
+    0xc2, 0x1f, 0x95, 0x17, 0xc4, 0x1a, 0xaa, 0x0d, 0x16, 0xf0, 0x0b,
+    0x83, 0xd2, 0xa0, 0x9e, 0xf7, 0x47, 0xe7, 0xa6, 0x4e, 0x8e, 0x2b,
+    0xd5, 0xa1, 0x48, 0x69, 0xe6, 0x93, 0xda, 0x66, 0xce, 0x94, 0xac,
+    0x2d, 0xa5, 0x70, 0xab, 0x7e, 0xe4, 0x86, 0x18, 0xf7};
+
+static const uint8_t drng_vector_output[80] = {
+    0xb7, 0x8b, 0x1e, 0xe6, 0xb3, 0x45, 0xea, 0xe6, 0x83, 0x6c, 0x2d, 0x53,
+    0xd3, 0x3c, 0x64, 0xcd, 0xaf, 0x9a, 0x69, 0x64, 0x87, 0xbe, 0x81, 0xb0,
+    0x3e, 0x82, 0x2d, 0xc8, 0x4b, 0x3f, 0x1c, 0xd8, 0x83, 0xd7, 0x55, 0x9e,
+    0x53, 0xd1, 0x75, 0xf2, 0x43, 0xe4, 0xc3, 0x49, 0xe8, 0x22, 0xa9, 0x57,
+    0xbb, 0xff, 0x92, 0x24, 0xbc, 0x5d, 0xde, 0x94, 0x92, 0xef, 0x54, 0xe8,
+    0xa4, 0x39, 0xf6, 0xbc, 0x8c, 0x73, 0x55, 0xb8, 0x7a, 0x92, 0x5a, 0x37,
+    0xee, 0x40, 0x5a, 0x75, 0x02, 0x99, 0x11, 0x11};
+
+static void test_drng_with_seed_matches_bip85_vector(void** state) {
+    (void)state;
+
+    uint8_t digest[sizeof(drng_vector_output)];
+
+    bool ok = bolos_ux_bip85_drng_with_seed(drng_vector_entropy,
+                                            sizeof(drng_vector_entropy), digest,
+                                            sizeof(digest));
+    assert_true(ok);
+
+    assert_memory_equal(digest, drng_vector_output, sizeof(digest));
+}
+
 // digest_length == BIP85_DRNG_MAX_DIGEST_SIZE is the upper bound the
 // LEDGER_ASSERT allows (`digest_length <= BIP85_DRNG_MAX_DIGEST_SIZE`) --
 // exercised here rather than only an arbitrary smaller length, since it is
@@ -68,6 +130,7 @@ static void test_drng_with_seed_accepts_max_digest_size(void** state) {
 int main(void) {
     const struct CMUnitTest tests[] = {
         cmocka_unit_test(test_drng_with_seed_matches_cx_shake256_hash),
+        cmocka_unit_test(test_drng_with_seed_matches_bip85_vector),
         cmocka_unit_test(test_drng_with_seed_accepts_max_digest_size),
     };
     return cmocka_run_group_tests(tests, NULL, NULL);


### PR DESCRIPTION
**No defect was found, and no behaviour changes.** The implementation already
reproduces every test vector BIP-85 publishes, byte for byte. What was missing
were the tests that hold it there.

## What the suite let through

`tests/unit/tests/bip85_dice_roll.c` only ever used `sides = 2`, and the file
justifies that choice — at `bits_per_roll = 1` the acceptance rate is exactly
100%, which makes the tests deterministic. The goal was met. But the same
choice neutralises the two DICE rules the specification states in so many
words:

* **"Trim any bits in excess of `bits_per_roll` (retain the most significant
  bits)"** — at one bit per roll, keeping the high bit or the low bit gives a
  valid value either way.
* **"If the trial is greater than or equal to the number of sides, skip it"**
  — at `sides = 2`, `roll_result < 2` and `roll_result <= 2` are true for
  exactly the same values, so the rejection step never fires at all.

Two mutations therefore left the whole suite green:

| Mutation in `src/common/bip85/seed_bip85.c` | Suite before | Suite after |
|---|---|---|
| `roll_result >>= shift_amount;` → `roll_result &= (1u << bits_per_roll) - 1u;` | green | **red** |
| `if (roll_result < sides)` → `if (roll_result <= sides)` | green | **red** |

Neither is equivalent. On the specification's own DICE vector:

```
intact implementation   : 1,0,0,2,0,1,5,5,2,4    <- matches the specification
low-bits mutant         : 3,2,5,0,3,5,4,1,1,1
`<=` rejection mutant   : 6,1,0,0,2,0,1,6,5,5    <- a 6 on a six-sided die
```

The second produces a value the specification explicitly forbids: "an N-sided
die produces values in the range `[0, N-1]`".

The reason the mutants survived is that the five existing tests assert only
**counts** (`produced == 257`, `== 10`, `== -1`, `== -3`) or a
**self-consistency** — `test_dice_roll_extension_preserves_prior_rolls`
compares two runs of the *same* binary, so it keeps agreeing when that binary
is wrong. No test in the repository asserted a single dice value.

## The official vectors need no syscall

BIP-85 publishes, for both DICE and the DRNG, the **64-byte input entropy**
alongside the expected output. Both vectors are therefore testable with no
BIP-32 derivation and no BOLOS syscall: feed the published entropy to
functions that are already exported and already linked into existing targets.
The `os_derive_bip32_no_throw()` boundary was never the reason they were
missing.

* **DICE**, `m/83696968'/89101'/6'/10'/0'`: entropy `5e41f8f5…4b6f6cd2`,
  rolls `1,0,0,2,0,1,5,5,2,4`, asserted value by value plus the explicit
  `out[i] < sides` invariant.
* **DRNG**, `m/83696968'/0'/0'`: entropy `efecfbcc…e48618f7`,
  `DRNG(80 bytes)` = `b78b1ee6…02991111`.

A second DICE test generalises the rejection rule over seven die sizes chosen
so that rejection actually bites — non-powers of two, including 129 and 257
just above a power of two, where barely half the draws survive. On the fixed
seed used, each size discards between 11 and 37 draws at 50 rolls. A power of
two would have made the test vacuous, which is precisely how the existing ones
came to be.

`bip85_drng_with_seed.c` previously took `cx_shake256_hash()` as its oracle —
the function under test wraps it. That is defensible for checking the wrapper,
and the file says so, but it does not establish that BIP-85's DRNG *is*
SHAKE256 seeded with the 64 entropy bytes. Only the published vector does.

**`bipsea` 3.2.0 does not reproduce the DRNG vector, and the expected value
here comes from the BIP, never from `bipsea`.** Its `derive -a drng` builds
`m/83696968'/0'/0'/{index}'` — a **four**-component path — where the official
vector has **three**: it appends `/0'/{index}'` to a path that already ends in
the application number `0'`. The discrepancy is in the path, not in SHAKE256 —
SHAKE256 over the entropy the specification publishes reproduces the published
80 bytes exactly. This is written into the test so the next reader does not
repeat the investigation.

All expected values in this pull request are transcribed from the
specification, not recomputed from the code under test.

## Two smaller blind spots in the same area

**The BIP-39 truncation.** `words * 4 / 3` was spelled out three times inside
`bolos_ux_bip85_bip39()`, below the `HAVE_NBGL` guard, so no test target
compiled it — and `bip85_bip39_entropy.c` does not exercise it either: it
supplies the length itself, from its own table. It moves out of the guard as
`bip85_bip39_entropy_len()`, a pure function with external linkage declared in
`bip85_internal.h`, following the pattern already used there. Mechanical, no
behaviour change. The test pins it against the Words Table's bit counts
divided by 8, rather than recomputing it with the expression under test.

**The BIP-39 length guard was laxer than the product.**
`bip85_bip39_words_valid()` read `words >= 12 && words % 3 == 0 && words <= 24`
and so accepted 12, 15, 18, 21 and 24 — BIP-85's five Words Table lengths.
**This application offers three**: `src/nbgl/ui.c` sets the mnemonic size to
`BIP39_MNEMONIC_SIZE_12`, `_18` or `_24` and nothing else, and that is the only
source of `words` (`bip85_app.c` passes `bip39_mnemonic_final_size_get()`).

The guard backs a `LEDGER_ASSERT` whose job is to stop a programming error
before a secret is derived, and nothing downstream would report one:
`bolos_ux_bip39_mnemonic_encode()` accepts any entropy length that is a
multiple of 4 from 16 to 32 bytes, so the 20 or 28 bytes a 15 or 21 produces
still yields a perfectly valid mnemonic — of a length the rest of the
application never asked for. It is now narrowed to the three lengths the
interface exposes. **No user path changes: 15 and 21 were already
unreachable.** The divergence from the specification is written into the
function's comment on purpose, so the bound is not later reopened to the Words
Table by a reader who takes it for an oversight.

## Also included

Three changes with no functional effect, in their own commit:
`bolos_ux_bip85_entropy()` now wipes `entropy` before returning 0 on a failed
derivation (all five callers already do, and the return code was propagated
correctly — but the function that owns the secret should be the one that
clears it); and two comments explaining bounds that read like mistakes —
`BASE64_ENCODE_LENGTH - 2` (the two `=` padding characters, which Base85 does
not have) and `sides <= UINT32_MAX >> 1` (a hardened path component has 31
usable bits, so `sides = 2^31` would derive from the same path as `sides = 0`,
and allowing the upper half would mean two different parameters deriving the
same secret; the inconsistency is the specification's).

## Verification

* Both DICE mutations above, and `words * 4 / 3` → `words * 4 / 4`, go from
  **surviving to killed**. Restoration checked by digest after each.
* All seven build configurations green, 71/71: default, ASan, UBSan, `-O2`,
  `-Os`, `-fsigned-char`, `-funsigned-char`.
* **No new CMake target** — `ctest -N` is unchanged. Everything attaches to
  `test_bip85_dice_roll`, `test_bip85_drng_with_seed` and
  `test_bip85_derivation_path`.
* Each of the five commits is green on its own; the series bisects.
* Six ARM targets built, `nanos` included, 0 warnings. `text/data/bss`
  identical to the byte on all six; `nanos` loadable image and symbol table
  identical; `nanox` and `nanos+` ELFs bit-identical.
* `clang-format --dry-run -Werror` clean on all five files touched;
  `pre-commit run --all-files` passes.
