### PR TITLE
docs: name the Base85 variant this application implements

### DIFF
--- a/src/common/bip85/base85.c
+++ b/src/common/bip85/base85.c
@@ -23,6 +23,15 @@
 /**
  * @brief Encodes 64 bytes of data into a Base85 string.
  *
+ * @details The grouping below is Ascii85's -- 4 bytes read big-endian into a
+ * 32-bit value, emitted as 5 base-85 digits, most significant first -- while
+ * the alphabet is RFC 1924's (`BASE85_TABLE`, seed_rom_variables.c, where the
+ * choice of alphabet is explained). Neither name describes this encoding on
+ * its own: RFC 1924 defines no chunking at all, encoding a whole 16-byte IPv6
+ * address as a single big number, and Ascii85 uses a different alphabet. The
+ * combination is what BIP-85's published password vector requires, and it is
+ * what this repository verifies against it.
+ *
  * @param[in]  src Pointer to the input data.
  * @param[out] dst Pointer to the output buffer.
  *

--- a/src/common/bip85/seed_rom_variables.c
+++ b/src/common/bip85/seed_rom_variables.c
@@ -22,6 +22,23 @@ unsigned const char BASE64_TABLE[] = {
     'n', 'o', 'p', 'q', 'r', 's', 't', 'u', 'v', 'w', 'x', 'y', 'z',
     '0', '1', '2', '3', '4', '5', '6', '7', '8', '9', '+', '/'};
 
+// The RFC 1924 alphabet, in RFC 1924 order.
+//
+// BIP-85 writes only "Base85 encode" and never names the variant, which is an
+// ambiguity in the specification rather than a detail left to the
+// implementation: Ascii85 (btoa), RFC 1924 and Z85 all encode 85 symbols and
+// all three use different alphabets. Only the password the specification
+// publishes for m/83696968'/707785'/12'/0' settles it. Encoding that vector's
+// entropy with each alphabet gives:
+//
+//   RFC 1924        _s`{TW89)i4`   <- what the specification publishes
+//   Ascii85 (btoa)  pWqr>A)*eM%q
+//   Z85             {S}@tw89!I4}
+//
+// So this table is not interchangeable with another 85-symbol alphabet, and
+// reordering it -- or "modernising" it to Z85 -- would silently produce
+// passwords no other BIP-85 implementation derives. tests/unit/tests/base85.c
+// pins the full 80-character encoding of that same vector.
 unsigned const char BASE85_TABLE[] = {
     '0', '1', '2', '3', '4', '5', '6', '7', '8', '9', 'A', 'B', 'C', 'D', 'E',
     'F', 'G', 'H', 'I', 'J', 'K', 'L', 'M', 'N', 'O', 'P', 'Q', 'R', 'S', 'T',


### PR DESCRIPTION
Comments only. No code changes anywhere — mechanically checked rather than
asserted: no line outside a comment is touched, and `text/data/bss` are
identical to the byte on all six devices.

## The problem

BIP-85 writes only "Base85 encode" and never says which variant. That is an
ambiguity in the specification rather than a detail left to the
implementation: Ascii85 (btoa), RFC 1924 and Z85 all encode 85 symbols and all
three use a different alphabet, so the choice is observable in every password
the application produces.

Only the password the specification publishes for `m/83696968'/707785'/12'/0'`
settles it. Encoding that vector's entropy with each alphabet gives:

```
RFC 1924        _s`{TW89)i4`   <- what the specification publishes
Ascii85 (btoa)  pWqr>A)*eM%q
Z85             {S}@tw89!I4}
```

`BASE85_TABLE` is the RFC 1924 alphabet, in RFC 1924 order, and nothing said
so. Reordering it — or "modernising" it to Z85, whose alphabet looks like the
tidier choice in isolation — would silently produce passwords no other BIP-85
implementation derives. The only thing standing in the way was a test whose
expected string carries no explanation of where it comes from.

## The grouping is a second, separate choice

`base85.c` reads 4 bytes big-endian into a 32-bit value and emits 5 digits,
most significant first, which is **Ascii85's** chunking. RFC 1924 defines no
chunking at all — it encodes a whole 16-byte IPv6 address as one big number.

So this encoding is RFC 1924's alphabet with Ascii85's grouping, and neither
name describes it on its own. Naming just one would have been worse than
naming none, which is why the two facts are documented separately: the
alphabet where the table is defined, the grouping where the loop is.

## Verification

- The three encodings above were produced from this repository's own
  `BASE85_TABLE`, extracted from the source rather than retyped, fed with
  entropy derived from the specification's master `xprv` down
  `m/83696968'/707785'/12'/0'` by a BIP-32/BIP-85 implementation written from
  the specification text.
- 71/71 unit tests green.
- Six ARM targets built, `nanos` included, 0 warnings; `text/data/bss`
  identical to the byte on all six against the base.
- `clang-format --dry-run -Werror` clean on both files;
  `pre-commit run --all-files` passes.
