### PR TITLE
tests: record which layer refuses a multi-group SSKR shard set, per CBOR form

### DIFF
--- a/tests/unit/CMakeLists.txt
+++ b/tests/unit/CMakeLists.txt
@@ -423,6 +423,21 @@ add_executable(test_sskr_duplicate_member_index ./tests/sskr_duplicate_member_in
 target_include_directories(test_sskr_duplicate_member_index PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/../../src/common)
 target_link_libraries(test_sskr_duplicate_member_index PUBLIC cmocka gcov sskr sss testutils)
 
+# Which layer refuses a multi-group shard set, per CBOR form of the entered
+# shares. Same source list and same sanitizer setup as
+# test_sskr_multi_group_refusal above, and for the same reason: with the
+# `next_group < group_threshold` guard removed, the long-form set this file
+# pushes through bolos_ux_sskr_hex_check() and bolos_ux_sskr_combine() reads
+# past gx[SSKR_MAX_GROUP_COUNT] inside sss_recover_secret(), which has no
+# observable form without the sanitizer. sskr.c, sss.c and interpolate.c are
+# compiled into the target rather than linked from libsskr/libsss so their
+# stack frames are instrumented too.
+add_executable(test_sskr_hex_check_long_form ./tests/sskr_hex_check_long_form.c ../../src/common/sskr/sskr.c ../../src/common/sskr/sss/sss.c ../../src/common/sskr/sss/interpolate.c ../../src/common/bip39/seed_rom_variables.c ../../src/common/bip39/seed_bip39.c ../../src/common/sskr/seed_rom_variables.c ../../src/common/sskr/seed_sskr.c)
+target_include_directories(test_sskr_hex_check_long_form PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/../../src/common ${CMAKE_CURRENT_SOURCE_DIR}/../../src/common/sskr ${CMAKE_CURRENT_SOURCE_DIR}/../../src/common/sskr/sss)
+target_compile_options(test_sskr_hex_check_long_form PRIVATE -fsanitize=address -fno-omit-frame-pointer)
+target_link_options(test_sskr_hex_check_long_form PRIVATE -fsanitize=address)
+target_link_libraries(test_sskr_hex_check_long_form PUBLIC cmocka gcov testutils)
+
 # The ByteWords table itself, against BCR-2020-012. Data, not behaviour: the
 # only source besides the test is seed_rom_variables.c, and nothing that reads
 # the table is linked in, so a failure here can only be the table.

--- a/tests/unit/tests/sskr_hex_check_long_form.c
+++ b/tests/unit/tests/sskr_hex_check_long_form.c
@@ -1,0 +1,359 @@
+/*
+ * Where the group index sits in each of the two CBOR forms a share can be
+ * entered in, and what bolos_ux_sskr_hex_check() therefore does with a set of
+ * shares drawn from more than one group.
+ *
+ * That function checks three things about each entered share: the three CBOR
+ * tag bytes, the CRC-32, and -- from the second share on -- that the first 8
+ * bytes are the same as the first share's. The third one is what refuses a
+ * set built from two different groups, because the group index is one of the
+ * bytes the shards of a set do not agree on.
+ *
+ * It only reaches that byte in the short CBOR form. A wire record is the tag
+ * (3 bytes), a byte-string header, the serialized shard, then the CRC-32; the
+ * shard's own byte 3 is the group-index/member-threshold pair. Byte strings
+ * shorter than 24 bytes carry their length in the header byte itself, longer
+ * ones need one more byte, and that extra byte shifts everything after it:
+ *
+ *   seed   share_len  byte-string header  index of the group-index byte
+ *   128    21         0x55                3 + 4 = 7   inside the window
+ *   192    29         0x58 0x1D           3 + 5 = 8   outside the window
+ *   256    37         0x58 0x25           3 + 5 = 8   outside the window
+ *
+ * Measured, not deduced: the first test below runs all three through the
+ * function and asserts the verdict each one actually gives. For 12 words the
+ * mixed set is refused; for 18 and 24 words it is accepted. The bytes those
+ * two forms do compare -- tag, byte-string length, share identifier, group
+ * threshold and group count -- are the same across a set drawn from two
+ * groups of one backup, so nothing in the window distinguishes them.
+ *
+ * What follows from that is the point of this file. A multi-group set for an
+ * 18- or 24-word seed goes past the entry screen and into
+ * bolos_ux_sskr_combine(), so for those two sizes the refusals inside
+ * sskr_combine_shards() are not defence in depth behind an input check --
+ * they are the only thing left:
+ *
+ *   - `next_group >= SSKR_MAX_GROUP_COUNT` -> SSKR_ERROR_INVALID_SHARD_SET,
+ *     for shards naming two different groups. SSKR_MAX_GROUP_COUNT is 1 in
+ *     this port, so `sskr_group_t groups[SSKR_MAX_GROUP_COUNT]` has one
+ *     element and this is what stops a write to groups[1].
+ *   - `next_group < group_threshold` -> SSKR_ERROR_NOT_ENOUGH_GROUPS, for a
+ *     set whose header asks for two groups when the shards of only one were
+ *     entered. gx and gy are SSKR_MAX_GROUP_COUNT long too, and without this
+ *     one sss_recover_secret() is called with the entered group threshold of
+ *     2 and reads gx[1].
+ *
+ * The second guard is the one this file demonstrates is load-bearing on this
+ * path. Turning it into `else if (0)` and building this target with
+ * -fsanitize=address gives, from the entered wire records and not from a
+ * direct library call:
+ *
+ *     ERROR: AddressSanitizer: stack-buffer-overflow ... READ of size 1
+ *     #0 interpolate interpolate.c:168
+ *     #1 sss_recover_secret sss.c:181
+ *     #2 sskr_combine_shards_internal sskr.c:563
+ *     #3 sskr_combine_shards sskr.c:617
+ *     #4 bolos_ux_sskr_combine seed_sskr.c:127
+ *     #5 test_long_form_multi_group_set_stops_in_the_library
+ *     [48, 49) 'gx' <== Memory access at offset 49 overflows this variable
+ *
+ * which is why this target is built with the sanitizer. That mutant fails
+ * sskr_multi_group_refusal.c as well, which reaches the same guard by calling
+ * sskr_combine_shards() directly; what is new here is the frame at #4, an
+ * entered share set that bolos_ux_sskr_hex_check() had just accepted.
+ *
+ * Nothing here is a live defect and nothing in src/ changes for it: both
+ * refusals are present and correct, and the set is refused in the end. What
+ * this records is which layer does the refusing, which is not what the width
+ * of the comparison suggests. Widening that window, or having it parse the
+ * byte-string header to find the group-index byte, would change the set of
+ * inputs the entry screens accept -- a decision for the maintainer, not for a
+ * test.
+ *
+ * Vectors
+ * -------
+ * The 128-bit set is the worked example of BCR-2020-011,
+ *     https://github.com/BlockchainCommons/Research/blob/master/papers/bcr-2020-011-sskr.md
+ * whose published wire form for one of these shards,
+ * d99d75554bbf1101025abd490ee65b6084859854ee67736e75, is what authenticates
+ * the framing used for all three sets here.
+ *
+ * The 192-bit and 256-bit sets here are NOT published. Published SSKR vectors
+ * do exist for both a 128- and a 256-bit seed, but the only multi-group one
+ * among them is the 128-bit worked example above: the 256-bit vector in
+ * Blockchain Commons' test vectors, the one tests/unit/tests/sskr.c uses, is a
+ * single 2-of-3 group and so cannot exercise any of this.
+ * They were generated outside this repository with a GF(2^8) implementation
+ * written from the specification (controlled on gmul(0x57,0x83) == 0xC1, and
+ * checked by reproducing the published 128-bit example above, master secret
+ * included), and each was verified before being written down here: the CRC-32
+ * of every record recomputed, the group secret recovered from the two group-0
+ * shards with its SLIP-39 share digest checked, and the group-level digest
+ * checked against the master secret. Both have group threshold 2, group 0
+ * 2-of-3 and group 1 3-of-5, the same shape as the published example.
+ *
+ *   192-bit master secret fd550f55cb41782192752c300f4b4f3d122948c280cfb9e5,
+ *                         identifier 6aa1
+ *   256-bit master secret
+ *       e3955cda0d8b5e2f9a1c47b6803df2e1a5c9017d4462fb38e0a7c51936d2b8f4,
+ *                         identifier 4a7c
+ *
+ * The `_other_id` records are the group-1 share of each long-form set with
+ * one bit of the identifier flipped and the CRC-32 recomputed over it. They
+ * are controls, not backups: they carry a byte that differs inside the
+ * compared window, which is how the first test tells "the window is not
+ * checked in the long form" apart from "the byte it would have caught is no
+ * longer in it".
+ */
+
+#include <cmocka.h>
+#include <setjmp.h>
+#include <stdarg.h>
+#include <stddef.h>
+#include <stdint.h>
+#include <string.h>
+
+/* testutils.h has to come first: it defines WIDE, which
+ * sskr/seed_rom_variables.h uses without defining. Not sorted, hence the
+ * clang-format exclusion. */
+// clang-format off
+#include "testutils.h"
+#include "sskr.h"
+#include "sskr-constants.h"
+#include "sskr/common_sskr.h"
+// clang-format on
+
+#define MAX_WIRE_LEN (46)
+#define CRC_LEN (4)
+
+/* BCR-2020-011, 128-bit: shard 21 bytes, short-form header 0x55. */
+static const uint8_t k_128_g0m0[29] = {
+    0xD9, 0x9D, 0x75, 0x55, 0x4B, 0xBF, 0x11, 0x01, 0x00, 0x3E,
+    0x99, 0x0C, 0x1F, 0x04, 0x35, 0xE2, 0xB3, 0x3C, 0x72, 0x15,
+    0x35, 0xC7, 0x46, 0x03, 0xD0, 0x52, 0x3C, 0xDA, 0x82};
+
+static const uint8_t k_128_g0m1[29] = {
+    0xD9, 0x9D, 0x75, 0x55, 0x4B, 0xBF, 0x11, 0x01, 0x01, 0x0C,
+    0x8B, 0xA3, 0x9A, 0x75, 0x02, 0xA3, 0x25, 0xED, 0x07, 0xB8,
+    0xD5, 0x97, 0xD1, 0xB8, 0x0F, 0x47, 0xF4, 0x7B, 0x79};
+
+static const uint8_t k_128_g1m0[29] = {
+    0xD9, 0x9D, 0x75, 0x55, 0x4B, 0xBF, 0x11, 0x12, 0x00, 0x44,
+    0xEF, 0x45, 0x3F, 0x66, 0x92, 0x3D, 0x32, 0x65, 0x3B, 0x37,
+    0x7D, 0xE5, 0xC9, 0x4B, 0x39, 0xBE, 0xD9, 0x49, 0x68};
+
+/* 192-bit: shard 29 bytes, long-form header 0x58 0x1D. */
+static const uint8_t k_192_g0m0[38] = {
+    0xD9, 0x9D, 0x75, 0x58, 0x1D, 0x6A, 0xA1, 0x11, 0x01, 0x00,
+    0x0B, 0x2E, 0x54, 0xCB, 0x8A, 0xD4, 0x8A, 0x6D, 0xF3, 0x08,
+    0xB9, 0x5B, 0xC6, 0x67, 0x57, 0x55, 0x6A, 0x58, 0xC3, 0x44,
+    0x40, 0xB5, 0xA6, 0x4F, 0x47, 0x58, 0x64, 0xB8};
+
+static const uint8_t k_192_g0m1[38] = {
+    0xD9, 0x9D, 0x75, 0x58, 0x1D, 0x6A, 0xA1, 0x11, 0x01, 0x01,
+    0xBE, 0x14, 0xBA, 0xF4, 0x86, 0x2D, 0x28, 0x0A, 0xE1, 0x00,
+    0xAA, 0xA9, 0x3B, 0x02, 0x2A, 0xD0, 0xA2, 0x98, 0x08, 0x36,
+    0x77, 0xE1, 0x0E, 0x11, 0x5F, 0x33, 0xBC, 0x84};
+
+static const uint8_t k_192_g1m0[38] = {
+    0xD9, 0x9D, 0x75, 0x58, 0x1D, 0x6A, 0xA1, 0x11, 0x12, 0x00,
+    0x33, 0xCE, 0x18, 0x2F, 0xBC, 0x46, 0x08, 0x4E, 0xE7, 0x1F,
+    0xAC, 0x57, 0x99, 0xF2, 0x43, 0x1F, 0xCD, 0x6D, 0xCB, 0x74,
+    0x0D, 0xA7, 0x01, 0x83, 0x7D, 0x80, 0x7C, 0xC5};
+
+static const uint8_t k_192_g1m0_other_id[38] = {
+    0xD9, 0x9D, 0x75, 0x58, 0x1D, 0x6A, 0xA0, 0x11, 0x12, 0x00,
+    0x33, 0xCE, 0x18, 0x2F, 0xBC, 0x46, 0x08, 0x4E, 0xE7, 0x1F,
+    0xAC, 0x57, 0x99, 0xF2, 0x43, 0x1F, 0xCD, 0x6D, 0xCB, 0x74,
+    0x0D, 0xA7, 0x01, 0x83, 0x7C, 0x35, 0x81, 0xD8};
+
+/* 256-bit: shard 37 bytes, long-form header 0x58 0x25. */
+static const uint8_t k_256_g0m0[46] = {
+    0xD9, 0x9D, 0x75, 0x58, 0x25, 0x4A, 0x7C, 0x11, 0x01, 0x00, 0x21, 0xC6,
+    0xEF, 0x19, 0x29, 0x43, 0x45, 0x3F, 0x66, 0x51, 0x06, 0x08, 0xA9, 0xBC,
+    0xA8, 0x9C, 0xB9, 0x11, 0xDC, 0xE6, 0x50, 0xC9, 0xCD, 0x6D, 0xED, 0x90,
+    0x33, 0x88, 0x5C, 0x90, 0x97, 0x61, 0xB2, 0xBE, 0xB1, 0x20};
+
+static const uint8_t k_256_g0m1[46] = {
+    0xD9, 0x9D, 0x75, 0x58, 0x25, 0x4A, 0x7C, 0x11, 0x01, 0x01, 0xC7, 0xCF,
+    0xF3, 0x0B, 0xA7, 0x33, 0x1B, 0xB2, 0xB7, 0x3D, 0x80, 0x5B, 0x2C, 0xBA,
+    0xC1, 0x2D, 0x61, 0x1B, 0x66, 0xEC, 0xF8, 0xC9, 0xA7, 0x60, 0x22, 0x05,
+    0x9B, 0xC5, 0xA5, 0x9F, 0xBF, 0x22, 0x0C, 0x16, 0x94, 0x97};
+
+static const uint8_t k_256_g1m0[46] = {
+    0xD9, 0x9D, 0x75, 0x58, 0x25, 0x4A, 0x7C, 0x11, 0x12, 0x00, 0xB4, 0x9A,
+    0xBD, 0x10, 0xFF, 0xE6, 0xED, 0x38, 0xA2, 0xDA, 0x67, 0x12, 0x97, 0xDC,
+    0xAD, 0x35, 0xA5, 0xCF, 0x99, 0x0A, 0x20, 0x11, 0x80, 0xE8, 0x9A, 0xD9,
+    0xE5, 0x09, 0xB2, 0x67, 0xBC, 0xC3, 0xBA, 0x6C, 0x29, 0xD9};
+
+static const uint8_t k_256_g1m0_other_id[46] = {
+    0xD9, 0x9D, 0x75, 0x58, 0x25, 0x4A, 0x7D, 0x11, 0x12, 0x00, 0xB4, 0x9A,
+    0xBD, 0x10, 0xFF, 0xE6, 0xED, 0x38, 0xA2, 0xDA, 0x67, 0x12, 0x97, 0xDC,
+    0xAD, 0x35, 0xA5, 0xCF, 0x99, 0x0A, 0x20, 0x11, 0x80, 0xE8, 0x9A, 0xD9,
+    0xE5, 0x09, 0xB2, 0x67, 0xBC, 0xC3, 0x2F, 0x1C, 0xFD, 0x4C};
+
+struct wire_form {
+    unsigned int secret_len; /* 16, 24 or 32 bytes of seed entropy */
+    unsigned int wire_len;
+    unsigned int header_len; /* CBOR tag plus byte-string header */
+    const uint8_t* g0m0;
+    const uint8_t* g0m1;
+    const uint8_t* g1m0;
+    /* NULL for the short form, where the point it controls does not arise */
+    const uint8_t* g1m0_other_id;
+    /* what bolos_ux_sskr_hex_check() returns for the mixed-group set */
+    unsigned int mixed_verdict;
+};
+
+static const struct wire_form k_forms[] = {
+    /* 12 words, short form */
+    {16, 29, 4, k_128_g0m0, k_128_g0m1, k_128_g1m0, NULL, 0},
+    /* 18 words, long form */
+    {24, 38, 5, k_192_g0m0, k_192_g0m1, k_192_g1m0, k_192_g1m0_other_id, 1},
+    /* 24 words, long form */
+    {32, 46, 5, k_256_g0m0, k_256_g0m1, k_256_g1m0, k_256_g1m0_other_id, 1},
+};
+
+#define FORM_COUNT (sizeof(k_forms) / sizeof(k_forms[0]))
+
+/* bolos_ux_sskr_hex_check() wipes what it rejects, and bolos_ux_sskr_combine()
+ * wipes what it cannot combine, so every call works on a fresh copy. */
+static void load(uint8_t* buffer, const struct wire_form* form,
+                 const uint8_t* first, const uint8_t* second) {
+    memcpy(buffer, first, form->wire_len);
+    if (second != NULL) {
+        memcpy(buffer + form->wire_len, second, form->wire_len);
+    }
+}
+
+static unsigned int hex_check_pair(const struct wire_form* form,
+                                   const uint8_t* first,
+                                   const uint8_t* second) {
+    uint8_t buffer[2 * MAX_WIRE_LEN];
+    const unsigned int count = (second == NULL) ? 1u : 2u;
+
+    load(buffer, form, first, second);
+
+    return bolos_ux_sskr_hex_check(buffer, count * form->wire_len, count);
+}
+
+/*
+ * The whole of the measurement, one row of the table in the header per
+ * iteration.
+ *
+ * The controls come first and are not decoration: this function rejects on a
+ * wrong CRC-32 or a wrong tag too, so a set of records with a bad CRC would
+ * be refused for a reason that has nothing to do with the group index, and
+ * the 128-bit row below would pass while proving nothing. Each group of each
+ * set is accepted on its own, in all three forms, which leaves the byte
+ * comparison as the only check that can be deciding anything here.
+ *
+ * The `_other_id` control closes the other reading: in the long form the
+ * comparison is still performed and still rejects -- it is the position of
+ * the group-index byte that has moved out of its reach, not the comparison
+ * that has stopped happening.
+ */
+static void test_hex_check_verdict_by_cbor_form(void** state) {
+    (void)state;
+
+    for (size_t i = 0; i < FORM_COUNT; i++) {
+        const struct wire_form* form = &k_forms[i];
+        /* tag(3) + byte-string header + shard + CRC-32 */
+        const unsigned int shard_len =
+            form->wire_len - form->header_len - CRC_LEN;
+        /* byte 3 of the shard holds group-index and member-threshold */
+        const unsigned int group_index_byte = form->header_len + 3;
+
+        assert_int_equal(shard_len,
+                         SSKR_METADATA_LENGTH_BYTES + form->secret_len);
+        assert_int_equal(form->header_len, (shard_len < 24) ? 4 : 5);
+        assert_int_equal(group_index_byte, (shard_len < 24) ? 7 : 8);
+
+        /* the two shares really do come from different groups, and differ
+         * nowhere before that byte */
+        assert_memory_equal(form->g0m0, form->g1m0, group_index_byte);
+        assert_int_equal(form->g0m0[group_index_byte] >> 4, 0);
+        assert_int_equal(form->g1m0[group_index_byte] >> 4, 1);
+
+        /* controls: each group, on its own, is well-formed in this form */
+        assert_int_equal(hex_check_pair(form, form->g0m0, NULL), 1);
+        assert_int_equal(hex_check_pair(form, form->g1m0, NULL), 1);
+        assert_int_equal(hex_check_pair(form, form->g0m0, form->g0m1), 1);
+
+        /* the measurement */
+        assert_int_equal(hex_check_pair(form, form->g0m0, form->g1m0),
+                         form->mixed_verdict);
+
+        /* control: a byte that differs inside the compared window is still
+         * caught in this form */
+        if (form->g1m0_other_id != NULL) {
+            assert_int_equal(hex_check_pair(form, form->g1m0_other_id, NULL),
+                             1);
+            assert_int_not_equal(memcmp(form->g0m0, form->g1m0_other_id, 8), 0);
+            assert_int_equal(
+                hex_check_pair(form, form->g0m0, form->g1m0_other_id), 0);
+        }
+    }
+}
+
+/*
+ * Where a long-form multi-group set stops, once the entry screen has let it
+ * through. Both cases go through bolos_ux_sskr_combine() -- the entry point
+ * the device reaches next -- and both are refused there; the error codes
+ * underneath name which of the two guards did it, since that wrapper turns
+ * every failure alike into 0.
+ */
+static void test_long_form_multi_group_set_stops_in_the_library(void** state) {
+    (void)state;
+
+    for (size_t i = 0; i < FORM_COUNT; i++) {
+        const struct wire_form* form = &k_forms[i];
+
+        /* the short form is refused at entry and never gets here */
+        if (form->header_len == 4) {
+            continue;
+        }
+
+        const unsigned int shard_len =
+            form->wire_len - form->header_len - CRC_LEN;
+        uint8_t buffer[2 * MAX_WIRE_LEN];
+        uint8_t output[SSKR_MAX_STRENGTH_BYTES];
+
+        /* shards of two different groups: accepted at entry, refused here */
+        assert_int_equal(hex_check_pair(form, form->g0m0, form->g1m0), 1);
+
+        load(buffer, form, form->g0m0, form->g1m0);
+        assert_int_equal(
+            bolos_ux_sskr_combine(buffer, 2 * form->wire_len, 2, output), 0);
+
+        const uint8_t* mixed[2] = {form->g0m0 + form->header_len,
+                                   form->g1m0 + form->header_len};
+        assert_int_equal(sskr_combine_shards(mixed, (uint8_t)shard_len, 2,
+                                             output, sizeof(output)),
+                         SSKR_ERROR_INVALID_SHARD_SET);
+
+        /* the shards of one group of a two-group set: enough to recover that
+         * group's own secret, and the group threshold of 2 read out of the
+         * entered shards is what refuses them. Without that guard this is the
+         * call that reads gx[1]. */
+        assert_int_equal(hex_check_pair(form, form->g0m0, form->g0m1), 1);
+
+        load(buffer, form, form->g0m0, form->g0m1);
+        assert_int_equal(
+            bolos_ux_sskr_combine(buffer, 2 * form->wire_len, 2, output), 0);
+
+        const uint8_t* one_group[2] = {form->g0m0 + form->header_len,
+                                       form->g0m1 + form->header_len};
+        assert_int_equal(sskr_combine_shards(one_group, (uint8_t)shard_len, 2,
+                                             output, sizeof(output)),
+                         SSKR_ERROR_NOT_ENOUGH_GROUPS);
+    }
+}
+
+int main(void) {
+    const struct CMUnitTest tests[] = {
+        cmocka_unit_test(test_hex_check_verdict_by_cbor_form),
+        cmocka_unit_test(test_long_form_multi_group_set_stops_in_the_library),
+    };
+    return cmocka_run_group_tests(tests, NULL, NULL);
+}

--- a/tests/unit/tests/sskr_multi_group_refusal.c
+++ b/tests/unit/tests/sskr_multi_group_refusal.c
@@ -201,9 +201,19 @@ static unsigned int hex_check_copy(const uint8_t* frames,
  * The path the user actually reaches: the shares are typed in, and
  * bolos_ux_sskr_hex_check() runs before sskr_combine_shards() ever sees
  * them. Its "the first 8 bytes of every share must match" test is what
- * refuses a set drawn from two groups, one byte earlier than the group
- * index itself -- D9 9D 75 55 4B BF 11 01 against ... 11 12, differing at
- * byte 7, the group-count/group-index boundary.
+ * refuses this set, because for a 128-bit secret the byte carrying the group
+ * index falls inside those 8 -- D9 9D 75 55 4B BF 11 01 against
+ * ... 11 12, differing at byte 7.
+ *
+ * That is a property of this vector's wire form, not a general property of
+ * the function, and the difference is the whole of tests/unit/tests/
+ * sskr_hex_check_long_form.c: a 21-byte shard takes a one-byte CBOR
+ * byte-string header (0x55) and puts the group index at byte 7, while the
+ * 29- and 37-byte shards of an 18- or 24-word seed take a two-byte one
+ * (0x58 0x1D, 0x58 0x25) and push it to byte 8, out of the compared window.
+ * The assertion below holds for what it is given; it does not generalize to
+ * the other two seed sizes, where the same mixed-group set is accepted here
+ * and refused later, by sskr_combine_shards().
  *
  * The three controls come first and are not decoration: this function
  * rejects on a bad CRC-32 too, and a wrong CRC in the frames above would
@@ -211,7 +221,7 @@ static unsigned int hex_check_copy(const uint8_t* frames,
  * is accepted, so the CRCs are right and the tag is right, and the only
  * thing left to reject the mixed set is the byte comparison.
  */
-static void test_hex_check_refuses_shares_from_two_groups(void** state) {
+static void test_hex_check_refuses_two_groups_in_the_short_form(void** state) {
     (void)state;
 
     /* controls: each group, on its own, is well-formed */
@@ -220,8 +230,8 @@ static void test_hex_check_refuses_shares_from_two_groups(void** state) {
     assert_int_equal(hex_check_copy(&k_group0_wire[0][0], 1), 1);
     assert_int_equal(hex_check_copy(&k_group1_wire[0][0], 1), 1);
 
-    /* the frames differ for the first time at byte 7, inside the 8 bytes
-     * compared, and nowhere earlier */
+    /* the frames differ for the first time at byte 7 -- the group index of a
+     * 21-byte shard -- inside the 8 bytes compared, and nowhere earlier */
     assert_memory_equal(k_group0_wire[0], k_group1_wire[0], 7);
     assert_int_not_equal(k_group0_wire[0][7], k_group1_wire[0][7]);
 
@@ -237,7 +247,7 @@ int main(void) {
         cmocka_unit_test(test_combine_refuses_shards_from_two_groups),
         cmocka_unit_test(
             test_combine_refuses_a_single_group_of_a_two_group_set),
-        cmocka_unit_test(test_hex_check_refuses_shares_from_two_groups),
+        cmocka_unit_test(test_hex_check_refuses_two_groups_in_the_short_form),
     };
     return cmocka_run_group_tests(tests, NULL, NULL);
 }


### PR DESCRIPTION
Two tests, no `src/` change. What they record is that the entry check does not refuse a multi-group shard set for an 18- or 24-word seed — only for a 12-word one — so for those two sizes the guards inside `sskr_combine_shards()` are the only thing refusing it, not defence in depth behind an input check.

## Where the group index sits

`bolos_ux_sskr_hex_check()` checks three things per entered share: the three CBOR tag bytes, the CRC-32, and — from the second share on — that the **first 8 bytes** match the first share's. That third check is what refuses a set drawn from two groups, because the group index is one of the bytes such a set does not agree on.

It only reaches that byte in the short CBOR form. A wire record is the tag (3 bytes), a byte-string header, the shard, then the CRC-32; the shard's own byte 3 carries group-index/member-threshold. A byte string under 24 bytes carries its length in the header byte, longer ones need one more byte — and that byte shifts the whole shard along:

| seed | shard | byte-string header | index of the group-index byte | in the 8-byte window? | `hex_check()` on a mixed-group set |
|---|---|---|---|---|---|
| 128-bit (12 words) | 21 | `0x55` | 3 + 4 = **7** | yes | **0 — refused** |
| 192-bit (18 words) | 29 | `0x58 0x1D` | 3 + 5 = **8** | no | **1 — accepted** |
| 256-bit (24 words) | 37 | `0x58 0x25` | 3 + 5 = **8** | no | **1 — accepted** |

Every row is measured by the first test, not deduced. The bytes the long form *does* compare — tag, byte-string length, share identifier, group threshold, group count — are identical across shards drawn from two groups of one backup, so nothing inside the window separates them.

Two sets of controls keep the verdicts from meaning something else:

- each group of each set is accepted on its own, in all three forms. Without this a wrong CRC or a wrong tag would refuse everything, and the 128-bit row would pass while proving nothing;
- a long-form record whose identifier differs **inside** the window (CRC recomputed) is still refused. That separates "the comparison is not performed in the long form" from "the byte it would have caught is no longer inside it". It is the second.

## What that leaves standing

A long-form multi-group set reaches `bolos_ux_sskr_combine()` and then `sskr_combine_shards()`, where two refusals remain. The second test drives both from the entered records:

- `next_group >= SSKR_MAX_GROUP_COUNT` → `SSKR_ERROR_INVALID_SHARD_SET` (−8), for shards naming two different groups. `SSKR_MAX_GROUP_COUNT` is 1 here, so `sskr_group_t groups[SSKR_MAX_GROUP_COUNT]` holds one element and this is what stops a write to `groups[1]`;
- `next_group < group_threshold` → `SSKR_ERROR_NOT_ENOUGH_GROUPS` (−14), for the shards of one group of a two-group set. `gx` and `gy` are `SSKR_MAX_GROUP_COUNT` long too.

The second one is load-bearing on this path, and the target is built with AddressSanitizer to show it. Turning it into `else if (0)`:

```
ERROR: AddressSanitizer: stack-buffer-overflow ... READ of size 1
    #0 interpolate                    interpolate.c:168
    #1 sss_recover_secret             sss.c:181
    #2 sskr_combine_shards_internal   sskr.c:563
    #3 sskr_combine_shards            sskr.c:617
    #4 bolos_ux_sskr_combine          seed_sskr.c:127
    #5 test_long_form_multi_group_set_stops_in_the_library
  [48, 49) 'gx' <== Memory access at offset 49 overflows this variable
```

Frame #4 is the point: this starts from a set of entered wire records that `bolos_ux_sskr_hex_check()` had just accepted, not from a direct library call. `sskr_multi_group_refusal.c` fails under the same mutant, reaching that guard through `sskr_combine_shards()` directly; what is new here is the path in front of it.

## There is no live defect here

Both refusals are present and correct, and a multi-group set is refused in the end whatever the seed size. What changes is which layer does the refusing, which is not what the width of the comparison suggests.

**No line of `src/` changes** — confirmed with `git diff --name-only`, not by eye. The obvious fix would be to have `hex_check()` read the byte-string header and compare the group-index byte where it actually is, or to widen the window past it. Either one changes the set of inputs the entry screens accept, which is a maintainer's decision rather than a test's, so this PR only reports it.

## Vectors

The 128-bit set is the worked example of [BCR-2020-011](https://github.com/BlockchainCommons/Research/blob/master/papers/bcr-2020-011-sskr.md), whose published wire form for one of these shards, `d99d75554bbf1101025abd490ee65b6084859854ee67736e75`, authenticates the framing used for all three sets.

**The 192-bit and 256-bit sets are not published.** Published SSKR vectors exist for a 128- and a 256-bit seed, but the only multi-group one is the 128-bit example above — the 256-bit vector in Blockchain Commons' test vectors, the one `tests/unit/tests/sskr.c` already uses, is a single 2-of-3 group and cannot exercise any of this. The two long-form sets were generated outside this repository with a GF(2^8) implementation written from the specification, controlled on `gmul(0x57,0x83) == 0xC1` and checked by reproducing the published 128-bit example, master secret and CRCs included. Each was then verified: every record's CRC-32 recomputed, the group secret recovered from the two group-0 shards with its SLIP-39 share digest checked, and the group-level digest checked against the master secret. The file header says all of this, including that they are not published.

## Verification

- 72/72 in the default configuration, and 72/72 in each of the six configurations of `unit-tests-matrix.yml` (ASan, UBSan, `-O2`, `-Os`, `-fsigned-char`, `-funsigned-char`).
- With the `next_group < group_threshold` mutant: 2 red out of 72 (this target and `sskr_multi_group_refusal`); guard restored: 72/72.
- Line coverage of `seed_sskr.c` and `sskr.c` is **unchanged** by this PR. The lines were already reached; what these tests pin is which of them decides, which coverage cannot see.
- `clang-format --dry-run -Werror` clean on both files.
- No cross-compilation needed: nothing under `src/` changes.

The second commit corrects the header comment of the test merged earlier, without touching its assertion. It read as a property of the function rather than of the 128-bit vector it is given, and it described byte 7 as the group-count/group-index boundary — byte 7 *is* the group-index byte, its high nibble being the group index; the group count is in byte 6.
