### PR TITLE
build: hold the optimised unit test entries to the same warnings

### DIFF
--- a/.github/workflows/unit-tests-matrix.yml
+++ b/.github/workflows/unit-tests-matrix.yml
@@ -23,6 +23,15 @@ name: Unit test configuration matrix
 # default Debug build type would silently lose to that -O0 (the last -O
 # flag on the command line wins). Release sidesteps that line entirely.
 #
+# Sidestepping it used to cost the warning flags too, since they sat on that
+# same CMAKE_C_FLAGS_DEBUG line: these two entries, the only ones compiled
+# with optimisation and so the only ones where -Wmaybe-uninitialized and its
+# neighbours can say anything at all, were the two that reported no
+# diagnostic. tests/unit/CMakeLists.txt now carries the same warning list on
+# CMAKE_C_FLAGS_RELEASE, appending to it rather than replacing it, so the
+# -DCMAKE_C_FLAGS_RELEASE below still decides the -O level on its own and no
+# flag is repeated here.
+#
 # This sweep is heavier than unit_tests.yml (6 OpenSSL builds + 6 full test
 # builds), so it does not run on every pull request; it runs on push to the
 # integration branches and on demand.

--- a/tests/unit/CMakeLists.txt
+++ b/tests/unit/CMakeLists.txt
@@ -67,7 +67,24 @@ set(CMAKE_C_STANDARD_REQUIRED True)
 # repository cannot act on. ENABLE_SDK_WERROR defaults to 0 and is not
 # overridden here, so they would not break that build -- they would just bury
 # the app's own diagnostics.
-set(CMAKE_C_FLAGS_DEBUG "${CMAKE_C_FLAGS_DEBUG} -Wall -Wmissing-prototypes -Wstrict-prototypes -pedantic -g -O0 --coverage")
+# Held in a variable because two build types need the same list, and setting
+# one of the two says nothing about the other. The -O2 and -Os entries of
+# .github/workflows/unit-tests-matrix.yml build Release precisely so that the
+# -O0 on the line below cannot win over their -O level; that also puts them
+# past the only line that carried the warning flags. They are the only
+# optimised builds in the repository, so they are the only configurations
+# where -Wmaybe-uninitialized, an aliasing diagnostic or a dead-store
+# observation can fire at all -- which made the two entries most likely to
+# find something the only two that reported nothing.
+#
+# Deliberately not folded into CMAKE_C_FLAGS, which would cover both build
+# types in a single line: OPENSSL_CFLAGS further down is derived from
+# CMAKE_C_FLAGS, and the OpenSSL build is a third-party dependency this
+# repository does not diagnose and cannot act on. The per-build-type variables
+# do not reach it.
+set(APP_WARNING_FLAGS "-Wall -Wmissing-prototypes -Wstrict-prototypes -pedantic")
+set(CMAKE_C_FLAGS_DEBUG "${CMAKE_C_FLAGS_DEBUG} ${APP_WARNING_FLAGS} -g -O0 --coverage")
+set(CMAKE_C_FLAGS_RELEASE "${CMAKE_C_FLAGS_RELEASE} ${APP_WARNING_FLAGS}")
 
 # Hold src/ at zero, rather than trusting the comment above to be re-read.
 # Promoting -Wmissing-prototypes to an error globally is not an option: the


### PR DESCRIPTION
The unit test matrix sweeps six configurations. Four build Debug and pick up
`-Wall -Wmissing-prototypes -Wstrict-prototypes -pedantic` from
`CMAKE_C_FLAGS_DEBUG`. The `-O2` and `-Os` entries build Release, on purpose, so
that the `-O0` hardcoded on that same Debug line cannot win over their own `-O`
level — and stepping past that line is what left them with no warning flag at
all.

Those two are the only configurations compiled with optimisation, so the only
ones where `-Wmaybe-uninitialized`, an aliasing diagnostic or a dead-store
observation can fire. They were the two that reported nothing.

The list now lives in one variable and goes on `CMAKE_C_FLAGS_RELEASE` as well,
appended rather than assigned so the workflow still decides the `-O` level on
its own. Deliberately not folded into `CMAKE_C_FLAGS`, which would cover both
build types in a single line: `OPENSSL_CFLAGS` is derived from that variable,
and the OpenSSL build is a third-party dependency this repository does not
diagnose and cannot act on.

### Measured

Full replay of the matrix, before and after.

Before:

```
################ CONFIG: -O2 ################   --- warnings --- 0
################ CONFIG: -Os ################   --- warnings --- 0
```

After:

```
ASan             warnings=19   71/71
UBSan            warnings=19   71/71
-O2              warnings=19   71/71
-Os              warnings=19   71/71
-fsigned-char    warnings=19   71/71
-funsigned-char  warnings=19   71/71
```

The list on `-O2` and `-Os` is the same 19 as the other four, file for file —
set difference computed, empty in both directions. **No diagnostic specific to
an optimised build appears**, so this uncovers no follow-up work. All 19 are
pre-existing `-Wmissing-prototypes` on test stubs and two SDK files, plus the
`-Wunused-label` that `tests/unit/CMakeLists.txt` already documents as expected
from one target. None is in `src/`.

71 tests pass in all six configurations.

### Not covered

The application build is untouched. `tests/unit/CMakeLists.txt` already explains
why the two flags are not added there — measured at 120 warnings on stax and 151
on nanos, roughly half inside the SDK itself.
