### PR TITLE
fix: trace the length of entered and generated secrets, never the content

### DIFF
--- a/.github/workflows/lint-workflow.yml
+++ b/.github/workflows/lint-workflow.yml
@@ -23,3 +23,33 @@ jobs:
     uses: LedgerHQ/ledger-app-workflows/.github/workflows/reusable_spell_check.yml@v1
     with:
       ignore_words_list: ontop
+
+  secret_free_traces:
+    name: No string conversion in a trace statement
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      # PRINTF is compiled out at DEBUG=0, which is the default and what is
+      # released -- but at DEBUG=1 it leaves the Nano targets over SEPROXYHAL,
+      # readable by whichever host the device is plugged into, and everything
+      # this application handles is the seed or a piece of it. The rule is
+      # that no secret reaches a trace at any debug level, so what is checked
+      # here is not the argument, which a grep cannot follow, but the
+      # conversion: %s and %.*s are the two that take a pointer to data the
+      # caller owns. Print a length instead, the way sskr_shares.c and
+      # bip39_mnemonic.c already do.
+      #
+      # No allowlist, because src/ needs none: there is no %s and no %.*s
+      # anywhere in it, in a trace or outside one. If a constant string ever
+      # has to be traced, add it here explicitly and keep the list short --
+      # every entry is a place secret content can come back unnoticed.
+      - name: Refuse %s and %.*s in src/
+        run: |
+          if grep -rnE '%\.\*s|%s' src/; then
+            echo "::error::a string conversion reached a trace statement in src/"
+            echo "::error::print a length instead; see src/nbgl/sskr_shares.c"
+            exit 1
+          fi
+          echo "src/ is clean: no %s, no %.*s"

--- a/src/bagl/ux_sskr.c
+++ b/src/bagl/ux_sskr.c
@@ -141,13 +141,15 @@ void generate_sskr(void) {
                G_bolos_ux_context.sskr_share_count);
         for (uint8_t share = 0; share < G_bolos_ux_context.sskr_share_count;
              share++) {
+            // A length, never the share itself. Any threshold of these
+            // reconstructs the seed, and on the Nano targets PRINTF leaves
+            // over SEPROXYHAL, which is whatever host the device is plugged
+            // into. The same shape as sskr_shares_from_bip39_mnemonic()
+            // (nbgl/sskr_shares.c), with %u rather than %zu because the two
+            // operands here are an unsigned int and a uint8_t, not size_t.
             PRINTF("SSKR share %d:\n", share + 1);
-            PRINTF("%.*s\n",
-                   G_bolos_ux_context.sskr_words_buffer_length /
-                       G_bolos_ux_context.sskr_share_count,
-                   G_bolos_ux_context.sskr_words_buffer +
-                       share * G_bolos_ux_context.sskr_words_buffer_length /
-                           G_bolos_ux_context.sskr_share_count);
+            PRINTF("(%u bytes)\n", G_bolos_ux_context.sskr_words_buffer_length /
+                                       G_bolos_ux_context.sskr_share_count);
         }
     }
     G_bolos_ux_context.sskr_share_index = 1;

--- a/src/nbgl/ui.c
+++ b/src/nbgl/ui.c
@@ -353,7 +353,9 @@ static void key_press_callback(const char touchedKey) {
         .suggestionButtons = suggestionButtons,
         .tuneId = TUNE_TAP_CASUAL,
     };
-    PRINTF("Current text is: '%s' (size '%d')\n", textToEnter, textLen);
+    // A length, never the text. Accumulated over an entry session these
+    // traces spell out the whole recovery phrase, or every share of it.
+    PRINTF("Current text is %zu characters\n", textLen);
 
     if (textLen < 2) {
         // Suggestions only when the word contains 2+ letters
@@ -396,8 +398,10 @@ static void bip39_keyboard_dispatcher(const int token, uint8_t index) {
             display_bip39_select_phrase_length_page();
         }
     } else if (token >= CHECK_FIRST_SUGGESTION_TOKEN) {
-        PRINTF("Selected word is '%s' (size '%d')\n",
-               buttonTexts[token - CHECK_FIRST_SUGGESTION_TOKEN],
+        // The length only, for the same reason as above. The word number is
+        // traced by bip39_mnemonic_word_add() on the very next line, so
+        // nothing is lost by leaving the word out.
+        PRINTF("Selected word is %zu characters\n",
                strlen(buttonTexts[token - CHECK_FIRST_SUGGESTION_TOKEN]));
         bip39_mnemonic_word_add(
             buttonTexts[token - CHECK_FIRST_SUGGESTION_TOKEN],
@@ -422,8 +426,8 @@ static void sskr_keyboard_dispatcher(const int token, uint8_t index) {
             display_select_tool_page();
         }
     } else if (token >= CHECK_FIRST_SUGGESTION_TOKEN) {
-        PRINTF("Selected word is '%s' (size '%d')\n",
-               buttonTexts[token - CHECK_FIRST_SUGGESTION_TOKEN],
+        // The length only, as above: these are the ByteWords of the shares.
+        PRINTF("Selected word is %zu characters\n",
                strlen(buttonTexts[token - CHECK_FIRST_SUGGESTION_TOKEN]));
         sskr_shares_word_add(buttonTexts[token - CHECK_FIRST_SUGGESTION_TOKEN]);
         if (sskr_shares_complete_check()) {


### PR DESCRIPTION
Four `PRINTF` sites printed secret content outright.

`src/bagl/ux_sskr.c` printed the full ByteWords of every SSKR share the device
had just generated, one line per share. Any threshold of those shares
reconstructs the seed, so that is the whole secret, in one place, in one pass.

`src/nbgl/ui.c` printed the word being typed on every keystroke, and the word
finally selected, on both the BIP39 and the SSKR entry screens. Individually
each is one word; accumulated over an entry session they are the phrase.

All four are compiled out at `DEBUG=0`, which is the default and what is
released — checked with `strings` on binaries built both ways. At `DEBUG=1` they
are present, and on the Nano targets `PRINTF` leaves over SEPROXYHAL, which any
attached USB host can read. Being absent from the released binary is not the
standard: no secret reaches a trace at any debug level.

Replaced with length-only traces, on the model `src/nbgl/sskr_shares.c` already
used for the same shares — `"SSKR share %d:"` then the byte count. The BAGL site
uses `%u` rather than `%zu` because its two operands are an `unsigned int` and a
`uint8_t`. Nothing is lost on the entry screens either: the word number is
already traced by `bip39_mnemonic_word_add()` and `sskr_shares_word_add()`.

The lint workflow gains a rule that refuses `%s` and `%.*s` anywhere under
`src/`. It checks the conversion rather than the argument, which is the only
part of this a grep can see, and it needs no allowlist: `src/` has neither, in a
trace or outside one.

### Measured

`DEBUG=1` builds of one target from each UI stack.

Before — nanos+ carried the ByteWords format string, stax both entry ones:

```
################ DEBUG=1 TARGET: NANOSP ################
256:%.*s
278:%.*s
################ DEBUG=1 TARGET: STAX ################
869:Current text is: '%s' (size '%d')
877:Selected word is '%s' (size '%d')
```

After — stax has no `%s`-bearing format string left at all. nanos+ has one
`%.*s`, and it is not the application's; attributed by object file rather than
assumed:

```
$ find obj build -name "*.o" | while read f; do
    strings "$f" | grep -q "^%\.\*s$" && echo "$f"; done
  build/nanos2/obj/sdk/lib_ux/src/ux_layout_paging.o
```

One object, in the SDK, where it is an `snprintf` into the screen buffer and not
a trace. Nothing under `src/`.

The new rule, run on both trees:

```
=== BEFORE ===
src/bagl/ux_sskr.c:145:            PRINTF("%.*s\n",
src/nbgl/ui.c:356:    PRINTF("Current text is: '%s' (size '%d')\n", textToEnter, textLen);
src/nbgl/ui.c:399:        PRINTF("Selected word is '%s' (size '%d')\n",
src/nbgl/ui.c:425:        PRINTF("Selected word is '%s' (size '%d')\n",
RULE: FAIL (exit 1)

=== AFTER ===
RULE: PASS -- src/ is clean: no %s, no %.*s
```

71 tests pass in all six matrix configurations; the six ARM targets build
without a warning.

### Not covered

A trace that printed a secret through some other conversion — a byte at a time
as `%02x`, say — would pass the rule. Nothing in `src/` does that today; the
rule is a ratchet, not a proof.
