### PR TITLE
fix: make the seed comparison verdict survive an injected fault

### DIFF
--- a/src/bagl/nanos_enter_phrase.c
+++ b/src/bagl/nanos_enter_phrase.c
@@ -373,7 +373,10 @@ void compare_recovery_phrase_and_display_result(void) {
     io_seproxyhal_general_status();
 
     bool reconstructed = true;
-    const bool match = compare_recovery_phrase(&reconstructed);
+    // Against VERDICT_MATCH, not "not zero": every other value, corrupted or
+    // not, is a mismatch. See common.h.
+    const bool match =
+        (compare_recovery_phrase(&reconstructed) == VERDICT_MATCH);
 
     if (!reconstructed) {
         // shards were well-formed but could not be combined: report them as

--- a/src/bagl/nanox_enter_phrase.c
+++ b/src/bagl/nanox_enter_phrase.c
@@ -433,7 +433,10 @@ void screen_onboarding_restore_word_validate(void) {
                 // Display loading icon to user
                 ux_flow_init(0, ux_load_flow, NULL);
                 bool reconstructed = true;
-                if (compare_recovery_phrase(&reconstructed)) {
+                // Against VERDICT_MATCH, not "not zero": every other value,
+                // corrupted or not, is a mismatch. See common.h.
+                if (compare_recovery_phrase(&reconstructed) ==
+                    VERDICT_MATCH) {
                     ux_flow_init(0, &ux_bip39_match_flow, NULL);
                 } else {
                     memzero(G_bolos_ux_context.words_buffer,
@@ -478,7 +481,10 @@ void screen_onboarding_restore_word_validate(void) {
                     // Display loading icon to user
                     ux_flow_init(0, ux_load_flow, NULL);
                     bool reconstructed = true;
-                    const bool match = compare_recovery_phrase(&reconstructed);
+                    // Against VERDICT_MATCH, as above.
+                    const bool match =
+                        (compare_recovery_phrase(&reconstructed) ==
+                         VERDICT_MATCH);
                     if (!reconstructed) {
                         // shards were well-formed but could not be combined
                         ux_flow_init(0, &ux_sskr_invalid_flow, NULL);

--- a/src/common/common.h
+++ b/src/common/common.h
@@ -28,14 +28,38 @@
 #endif
 
 /*
- * Compares the entered secret with the device's seed.
+ * The two values the seed comparison speaks in, and the reason it does not
+ * speak in a bool.
+ *
+ * This is the one decision in the application worth injecting a fault into:
+ * a false "no match" sends the user back to the entry screen, but a false
+ * "match" sends them away with a backup that will not open their device, and
+ * they find out when they need it. Compiled from a bool, that decision was two
+ * ARM instructions wide and the whole of it lived in bit 0 of one register --
+ * a single bit flip, in the direction that costs the funds.
+ *
+ * These two differ in all 32 bits, so no single bit flip on the path from
+ * compare_recovery_phrase_finish() to the screen turns one into the other,
+ * and neither is a value a register arrives at by accident: not zero, not one,
+ * not a small count, not an address in this application's map.
+ *
+ * Callers must test for VERDICT_MATCH and treat *everything* else as a
+ * mismatch, VERDICT_NO_MATCH included but not only -- a verdict that is
+ * neither is a corrupted one, and a corrupted verdict is not a match.
+ */
+#define VERDICT_MATCH    0xA5C3F00Du
+#define VERDICT_NO_MATCH 0x5A3C0FF2u
+
+/*
+ * Compares the entered secret with the device's seed. Returns VERDICT_MATCH
+ * and nothing else on agreement; see above.
  *
  * `reconstructed` is set to false when the input could not be turned into a
  * mnemonic at all (SSKR shards that pass their CRC but cannot be combined).
  * That is a distinct outcome from a seed mismatch and must not be reported as
  * one. It is always true for the BIP39 tool, which has nothing to reconstruct.
  */
-bool compare_recovery_phrase(bool *reconstructed);
+unsigned int compare_recovery_phrase(bool *reconstructed);
 
 /*
  * The tail of compare_recovery_phrase(): everything that happens once
@@ -45,6 +69,6 @@ bool compare_recovery_phrase(bool *reconstructed);
  * file that defines it, and the unit suite that drives it, are checked against
  * one declaration.
  */
-bool compare_recovery_phrase_finish(cx_err_t derivation_status,
-                                    uint8_t buffer[64],
-                                    uint8_t buffer_device[64]);
+unsigned int compare_recovery_phrase_finish(cx_err_t derivation_status,
+                                            uint8_t buffer[64],
+                                            uint8_t buffer_device[64]);

--- a/src/common/common_seed.c
+++ b/src/common/common_seed.c
@@ -16,6 +16,7 @@
  ********************************************************************************/
 
 #include <lcx_hmac.h>
+#include <lcx_rng.h>
 
 /* clang-format off */
 #include "constants.h"
@@ -28,6 +29,35 @@
 extern unsigned int tool_type;
 #endif
 
+// The second of the two comparisons the verdict rests on, and deliberately
+// not a second call to os_secure_memcmp(): a fault that lands on that
+// function's body, or on the register its result comes back in, would land on
+// both calls the same way, which is the one thing a redundant check must not
+// do. This reads the same bytes from the other end, accumulates every
+// difference rather than stopping at the first, and so takes the same time
+// whatever the data -- which is the property os_secure_memcmp() is chosen for
+// in the first place and must not be given up here.
+static uint8_t compare_reversed(const uint8_t* a, const uint8_t* b,
+                                size_t length) {
+    uint8_t diff = 0;
+
+    for (size_t i = length; i > 0; i--) {
+        diff |= (uint8_t)(a[i - 1] ^ b[i - 1]);
+    }
+
+    return diff;
+}
+
+// A short, unpredictable wait before the comparison. It is not a defence on
+// its own -- 255 iterations is microseconds -- and it does not try to be: what
+// it costs an attacker is the ability to fire a glitch at a fixed offset from
+// a trigger they can see, which is how a bench is calibrated. volatile so that
+// no optimisation level deletes a loop with no effect.
+static void verdict_jitter(void) {
+    for (volatile uint8_t spin = cx_rng_u8(); spin > 0; spin--) {
+    }
+}
+
 // Only the derivation status is a hardware-dependent input here --
 // os_derive_bip32_no_throw() itself (a BOLOS syscall) is not testable on
 // host, but everything that happens with its result is pure logic:
@@ -35,25 +65,92 @@ extern unsigned int tool_type;
 // way. Splitting it out lets that logic -- including the derivation-failure
 // path, never exercised anywhere until now -- be covered without the
 // syscall.
-bool compare_recovery_phrase_finish(cx_err_t derivation_status,
-                                    uint8_t buffer[64],
-                                    uint8_t buffer_device[64]) {
-    bool result = false;
+//
+// This is where the application decides whether the phrase in front of the
+// user is the one their device holds, so it is written against a fault
+// injected into that decision rather than against ordinary failure. Four
+// things carry that:
+//
+//   - the verdict is one of two constants 32 bits apart (common.h), not a
+//     bool, so no single bit flip between here and the screen converts one
+//     into the other;
+//   - two independent comparisons have to agree. os_secure_memcmp() is kept
+//     as it was; compare_reversed() above reads the same 64 bytes the other
+//     way. A fault that defeats one is not the same fault that defeats the
+//     other, and the unit suite holds this by making the first one lie;
+//   - the bytes are read a third time inside the branch that has already
+//     concluded "match", and a verdict that does not survive that re-reading
+//     is a fault, not a mismatch: there is nothing safe to display, so the
+//     application stops;
+//   - a counter is stepped at each point the function must pass through and
+//     checked at the end, so an instruction skip that jumps over the
+//     comparison arrives at a count that does not add up.
+//
+// None of the four is held by a test on its own except the second: a fault is
+// not something the host suite can produce. What the suite does hold is that
+// the verdict is one of the two sentinels and never an intermediate value,
+// which is what the four are there to protect.
+unsigned int compare_recovery_phrase_finish(cx_err_t derivation_status,
+                                            uint8_t buffer[64],
+                                            uint8_t buffer_device[64]) {
+    unsigned int verdict = VERDICT_NO_MATCH;
+    volatile unsigned int checkpoints = 0;
+    // Neither starts at zero: zero is what "the two agree" looks like, so a
+    // fault that skips the assignments below must not leave agreement behind.
+    unsigned char forward = 0xFF;
+    unsigned char reversed = 0xFF;
+
+    verdict_jitter();
+    checkpoints++;
 
     if (derivation_status == CX_OK) {
-        result = os_secure_memcmp(buffer, buffer_device, 64) ? false : true;
+        forward = (unsigned char)os_secure_memcmp(buffer, buffer_device, 64);
+        reversed = compare_reversed(buffer, buffer_device, 64);
     }
+    checkpoints++;
+
+    if (derivation_status == CX_OK && forward == 0 && reversed == 0) {
+        verdict = VERDICT_MATCH;
+    }
+    checkpoints++;
+
+    // Re-read after the branch, not before it. The point is not to compare
+    // again -- that already happened -- but to catch a decision that was
+    // reached on something other than what the buffers hold.
+    if (verdict == VERDICT_MATCH) {
+        if (derivation_status != CX_OK ||
+            os_secure_memcmp(buffer, buffer_device, 64) != 0 ||
+            compare_reversed(buffer, buffer_device, 64) != 0) {
+            LEDGER_ASSERT(false, "Seed verdict did not survive re-reading");
+        }
+    }
+    checkpoints++;
 
     memzero(buffer_device, 64);
     memzero(buffer, 64);
 
-    return result;
+    // After the erasures, so that a control-flow fault does not leave two root
+    // keys on the stack on its way out.
+    LEDGER_ASSERT(checkpoints == 4, "Seed verdict skipped a checkpoint");
+
+    // Nothing but VERDICT_MATCH leaves as anything but VERDICT_NO_MATCH:
+    // callers test for the former, and a third value has no business
+    // travelling any further than this line.
+    if (verdict != VERDICT_MATCH) {
+        verdict = VERDICT_NO_MATCH;
+    }
+
+    return verdict;
 }
 
-bool compare_recovery_phrase(bool* reconstructed) {
-    // convert mnemonic to hex-seed
-    uint8_t buffer[64];
-    bool result = false;
+unsigned int compare_recovery_phrase(bool* reconstructed) {
+    // convert mnemonic to hex-seed. Zeroed at the declaration because the two
+    // branches that fill it are both conditional: TOOL_TYPE_BIP85 is a third
+    // value of that enumeration (constants.h), no path reaches this function
+    // with it today, and an uninitialised 64-byte buffer going into the
+    // HMAC below is not a thing to leave resting on that.
+    uint8_t buffer[64] = {0};
+    unsigned int result = VERDICT_NO_MATCH;
 
     // declared up front so goto cleanup can reach it from every early exit
     uint8_t buffer_device[64];

--- a/src/nbgl/bip39_mnemonic.c
+++ b/src/nbgl/bip39_mnemonic.c
@@ -122,7 +122,9 @@ bool bip39_mnemonic_check(bool* match) {
     }
 
     bool reconstructed = true;
-    *match = compare_recovery_phrase(&reconstructed);
+    // Against VERDICT_MATCH, not "not zero": every other value, corrupted or
+    // not, is a mismatch. See common.h.
+    *match = (compare_recovery_phrase(&reconstructed) == VERDICT_MATCH);
     // Don't clear the mnemonic just yet as we may need it to generate SSKR
     // shares
     //    bip39_mnemonic_reset();

--- a/src/nbgl/sskr_shares.c
+++ b/src/nbgl/sskr_shares.c
@@ -177,7 +177,9 @@ bool sskr_shares_check(bool* match) {
     }
 
     bool reconstructed = true;
-    *match = compare_recovery_phrase(&reconstructed);
+    // Against VERDICT_MATCH, not "not zero": every other value, corrupted or
+    // not, is a mismatch. See common.h.
+    *match = (compare_recovery_phrase(&reconstructed) == VERDICT_MATCH);
     if (!reconstructed) {
         // shards were well-formed but could not be combined: report them as
         // invalid rather than as a seed mismatch

--- a/src/nbgl/ui.c
+++ b/src/nbgl/ui.c
@@ -516,6 +516,26 @@ static void display_home_page() {
 /*
  * Result page
  */
+/*
+ * This runs when the user taps to leave the result screen, and it calls
+ * bip39_mnemonic_check() / sskr_shares_check() a second time -- so
+ * compare_recovery_phrase(), the device-seed derivation and the whole verdict,
+ * all over again. That is a second derivation the application pays for, and it
+ * would be easy to remove by reading the seed_match the first call already
+ * left behind.
+ *
+ * Deliberately kept. It is a second, independent decision standing between a
+ * single glitched verdict and the screen the user is sent on to, taken on
+ * freshly derived bytes rather than on a stored flag. It was not put here for
+ * that -- it is where the navigation happens to lead -- but it is worth what
+ * it costs, and naming it here is what stops it being refactored away as
+ * duplicate work.
+ *
+ * It is not a substitute for the hardening in compare_recovery_phrase_finish()
+ * and must not be read as one: the result screen the user reads and acts on
+ * has already been painted on the strength of the first call, and the BAGL
+ * targets call once, not twice.
+ */
 static void check_result_callback(int token __attribute__((unused)),
                                   uint8_t index __attribute__((unused))) {
     if (tool_type == TOOL_TYPE_BIP39 && bip39_mnemonic_check(&seed_match) &&

--- a/tests/speculos/README.md
+++ b/tests/speculos/README.md
@@ -181,10 +181,12 @@ buffers are still erased on the same path); only where the two
 `explicit_bzero()` calls physically live moved. This also simplified the
 addressing: `compare_recovery_phrase_finish()` receives `buffer`/
 `buffer_device` as plain pointer arguments rather than declaring them as
-its own stack-local arrays, so its prologue is a bare `push
-{r4,r5,r6,lr}` with no `sub sp, #N` at all — the compiler keeps both
-pointers in call-preserved registers for the function's whole body instead
-of spilling them to the stack. That means this check no longer needs
+its own stack-local arrays — the compiler keeps both pointers in
+call-preserved registers for the function's whole body instead of
+spilling them to the stack. The function does now have a stack frame (the
+fault-resistance work gave it a volatile checkpoint counter and a
+volatile spin variable, both of which have to live in memory), but the
+two pointers are not in it. That means this check no longer needs
 gotcha 5's SP-relative-offset approach: it reads the two argument
 registers directly at each breakpoint (which register holds which buffer
 is read back from the disassembly, not hardcoded — see
@@ -546,9 +548,10 @@ the whole call.
 Since `compare_recovery_phrase()`'s tail (the two `explicit_bzero()` calls)
 was extracted into `compare_recovery_phrase_finish()` — see Check 2 above
 — `buffer`/`buffer_device` arrive there as plain pointer *arguments*
-rather than that function's own stack-local arrays, and its prologue
-(`push {r4,r5,r6,lr}`, no `sub sp, #N` at all) has no stack frame to be
-SP-relative *into* in the first place. The compiler instead keeps both
+rather than that function's own stack-local arrays. Whatever stack frame
+that function has holds its own volatile counters and nothing else, so
+there is no per-buffer offset to be SP-relative *into* in the first
+place. The compiler instead keeps both
 pointers in call-preserved registers for the whole function body — an
 even simpler case than the SP-relative one above: read the two argument
 registers directly at either breakpoint and dereference them, no offset

--- a/tests/speculos/verify_compare_recovery_phrase_cleanup.py
+++ b/tests/speculos/verify_compare_recovery_phrase_cleanup.py
@@ -169,11 +169,14 @@ def resolve_cleanup_breakpoints(link_addr, size):
       buffer_device as plain pointer arguments (not local stack arrays),
       so the compiler keeps them in call-preserved registers across both
       calls instead of spilling them to the stack -- confirmed by
-      disassembly, not assumed: this function's prologue is
-      `push {r4,r5,r6,lr}` with no `sub sp, #N` at all, so there is no
-      per-buffer SP offset to resolve here, unlike the SP-relative
-      approach Check 1/3's globals and this function's own former host
-      (compare_recovery_phrase()) need -- see README.md gotcha 5.
+      disassembly, not assumed. The function does now carry a stack frame
+      of its own (the fault-resistance work gave it a volatile checkpoint
+      counter and a volatile spin variable, both stack-resident), but the
+      two pointers are not part of it: they stay in registers, so there is
+      still no per-buffer SP offset to resolve here, unlike the
+      SP-relative approach Check 1/3's globals and this function's own
+      former host (compare_recovery_phrase()) need -- see README.md
+      gotcha 5.
 
     Nothing here is hardcoded as a raw address or register number --
     only the function's own resolved link_addr/size (from
@@ -306,8 +309,10 @@ class MemorySampler:
     itself), buffer/buffer_device arrive here as plain pointer arguments
     that the compiler keeps in two call-preserved registers for the whole
     function body (confirmed by disassembly, see
-    resolve_cleanup_breakpoints -- no stack frame at all, so no per-buffer
-    offset to add to anything): read those two registers directly at
+    resolve_cleanup_breakpoints -- the function's own stack frame holds
+    only its volatile counters, never the two pointers, so there is no
+    per-buffer offset to add to anything): read those two registers
+    directly at
     either breakpoint and dereference them, no SP/frame-base bookkeeping
     needed at all.
     """

--- a/tests/unit/CMakeLists.txt
+++ b/tests/unit/CMakeLists.txt
@@ -739,9 +739,11 @@ target_link_libraries(test_bip85_hex_vector PUBLIC cmocka gcov testutils)
 # compiles with -ffunction-sections/-fdata-sections and links with
 # --gc-sections so the linker drops compare_recovery_phrase() and
 # everything it alone pulls in before ever needing to resolve those
-# symbols -- verified with nm on the built test binary, not assumed: only
-# compare_recovery_phrase_finish() and its own gcov counters remain: the
-# defined text symbol for compare_recovery_phrase() itself is gone.
+# symbols -- verified with nm on the built test binary, not assumed: what
+# remains is compare_recovery_phrase_finish(), the two file-static helpers
+# it alone calls (compare_reversed() and verdict_jitter(), both part of the
+# fault resistance around the verdict) and their gcov counters. The defined
+# text symbol for compare_recovery_phrase() itself is gone.
 add_executable(test_compare_recovery_phrase_finish ./tests/compare_recovery_phrase_finish.c ../../src/common/common_seed.c)
 target_include_directories(test_compare_recovery_phrase_finish PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/../../src ${CMAKE_CURRENT_SOURCE_DIR}/../../src/common)
 # common_seed.c's untouched compare_recovery_phrase() body uses

--- a/tests/unit/tests/bip39_entry_bounds.c
+++ b/tests/unit/tests/bip39_entry_bounds.c
@@ -51,7 +51,7 @@
  * It is not on the entry path under test; this exists only so the object links,
  * and aborts if it is ever reached.
  */
-bool compare_recovery_phrase(bool* reconstructed) {
+unsigned int compare_recovery_phrase(bool* reconstructed) {
     (void)reconstructed;
     fail_msg("not on the entry path");
 }

--- a/tests/unit/tests/compare_recovery_phrase_finish.c
+++ b/tests/unit/tests/compare_recovery_phrase_finish.c
@@ -7,10 +7,34 @@
  * the derivation-failure path -- never exercised anywhere in this suite
  * until now, since nothing could force that syscall to fail in a
  * controlled way.
+ *
+ * It is also where the application decides whether the phrase in front of the
+ * user is the one their device holds, which makes it the one decision here
+ * worth injecting a fault into, and the reason the function is written the way
+ * it is. What this file can hold of that, and what it cannot:
+ *
+ *   - the verdict is one of two constants that differ in all 32 bits, and the
+ *     function returns one of those two and nothing else. Held, by asserting
+ *     equality with the constants rather than truthiness, and by asserting the
+ *     distance between them.
+ *   - two independent comparisons have to agree. Held, by overriding
+ *     os_secure_memcmp() for this target and making it report agreement on two
+ *     root keys that differ in every byte -- which is what a glitch landing on
+ *     that call looks like from here.
+ *   - the third reading inside the "match" branch, and the checkpoint counter
+ *     checked before the return. Not held, and not holdable here: both fire
+ *     only on a fault, and a host process cannot be made to skip an
+ *     instruction. They are written to be read, and the erasure of both
+ *     buffers is asserted on every path so that neither can quietly stop
+ *     happening.
  */
 
 #include <cmocka.h>
 #include <cx.h>
+/* for the os_secure_memcmp() prototype: this file defines it, and a
+ * definition with no declaration in sight is exactly what
+ * -Wmissing-prototypes is here to report. */
+#include <os_utils.h>
 #include <setjmp.h>
 #include <stdarg.h>
 #include <stddef.h>
@@ -25,6 +49,34 @@ static void assert_all_zero(const uint8_t* data, size_t len) {
     }
 }
 
+/*
+ * os_secure_memcmp() again, overriding the one testutils.c exports for every
+ * other target, so that one test can make it lie. This is the whole point of
+ * the second comparison: a fault landing on that call, or on the register its
+ * result comes back in, is the cheapest single-glitch way to turn "this is not
+ * your seed" into "this is". Nothing else in this file changes behaviour --
+ * s_memcmp_lies is false everywhere but inside the one test that sets it, and
+ * that test puts it back.
+ *
+ * The body when it is not lying is the SDK's own (src/os.c), byte for byte:
+ * two counters run down together, every byte XOR-accumulated, no early exit.
+ */
+static bool s_memcmp_lies = false;
+
+char os_secure_memcmp(const void* src1, const void* src2, size_t length) {
+    const unsigned char* a = (const unsigned char*)src1;
+    const unsigned char* b = (const unsigned char*)src2;
+    unsigned char xoracc = 0;
+
+    if (s_memcmp_lies) {
+        return 0;
+    }
+    for (size_t i = 0; i < length; i++) {
+        xoracc |= a[i] ^ b[i];
+    }
+    return (char)xoracc;
+}
+
 static void test_finish_matching_keys_succeeds_and_erases(void** state) {
     (void)state;
 
@@ -33,9 +85,10 @@ static void test_finish_matching_keys_succeeds_and_erases(void** state) {
     memset(buffer, 0x42, sizeof(buffer));
     memset(buffer_device, 0x42, sizeof(buffer_device));
 
-    bool result = compare_recovery_phrase_finish(CX_OK, buffer, buffer_device);
+    const unsigned int result =
+        compare_recovery_phrase_finish(CX_OK, buffer, buffer_device);
 
-    assert_true(result);
+    assert_int_equal(result, VERDICT_MATCH);
     assert_all_zero(buffer, sizeof(buffer));
     assert_all_zero(buffer_device, sizeof(buffer_device));
 }
@@ -48,9 +101,10 @@ static void test_finish_mismatched_keys_fails_and_erases(void** state) {
     memset(buffer, 0x42, sizeof(buffer));
     memset(buffer_device, 0x24, sizeof(buffer_device));
 
-    bool result = compare_recovery_phrase_finish(CX_OK, buffer, buffer_device);
+    const unsigned int result =
+        compare_recovery_phrase_finish(CX_OK, buffer, buffer_device);
 
-    assert_false(result);
+    assert_int_equal(result, VERDICT_NO_MATCH);
     assert_all_zero(buffer, sizeof(buffer));
     assert_all_zero(buffer_device, sizeof(buffer_device));
 }
@@ -71,19 +125,81 @@ static void test_finish_derivation_failure_fails_and_erases(void** state) {
     memset(buffer, 0x11, sizeof(buffer));
     memset(buffer_device, 0x99, sizeof(buffer_device));
 
-    bool result = compare_recovery_phrase_finish(CX_INTERNAL_ERROR, buffer,
-                                                 buffer_device);
+    const unsigned int result = compare_recovery_phrase_finish(
+        CX_INTERNAL_ERROR, buffer, buffer_device);
 
-    assert_false(result);
+    assert_int_equal(result, VERDICT_NO_MATCH);
     assert_all_zero(buffer, sizeof(buffer));
     assert_all_zero(buffer_device, sizeof(buffer_device));
 }
 
+/*
+ * The mutation the second comparison exists for: os_secure_memcmp() reports
+ * agreement on two root keys that differ in all 64 bytes. That is what a
+ * successful glitch on that call looks like from here, and it is the error
+ * direction that costs the user their funds -- a false "no match" sends them
+ * back to the entry screen, a false "match" sends them away with a backup that
+ * does not open their device.
+ *
+ * A second call to os_secure_memcmp() would not catch this: the stub lies to
+ * every caller, exactly as a fault on the function's own body would. What
+ * catches it has to read the bytes itself.
+ */
+static void test_finish_a_defeated_comparison_is_still_a_mismatch(
+    void** state) {
+    (void)state;
+
+    uint8_t buffer[64];
+    uint8_t buffer_device[64];
+    memset(buffer, 0x42, sizeof(buffer));
+    memset(buffer_device, 0x24, sizeof(buffer_device));
+
+    s_memcmp_lies = true;
+    const unsigned int result =
+        compare_recovery_phrase_finish(CX_OK, buffer, buffer_device);
+    s_memcmp_lies = false;
+
+    assert_int_equal(result, VERDICT_NO_MATCH);
+    assert_all_zero(buffer, sizeof(buffer));
+    assert_all_zero(buffer_device, sizeof(buffer_device));
+}
+
+/*
+ * What makes the two verdicts worth carrying around as 32-bit values rather
+ * than as a bool: no single bit flip anywhere between this function and the
+ * screen turns one into the other, and neither is a value a register arrives
+ * at by accident. Asserted rather than left to whoever next edits common.h --
+ * two constants that merely look unusual are not the same as two constants a
+ * fault cannot bridge.
+ */
+static void test_the_two_verdicts_cannot_be_bridged_by_one_bit(void** state) {
+    (void)state;
+
+    const unsigned int difference = VERDICT_MATCH ^ VERDICT_NO_MATCH;
+    unsigned int differing_bits = 0;
+
+    for (unsigned int bit = 0; bit < 32; bit++) {
+        differing_bits += (difference >> bit) & 1u;
+    }
+
+    assert_int_equal(differing_bits, 32);
+
+    /* and neither is a value a cleared, incremented or short-counting
+     * register lands on */
+    assert_int_not_equal(VERDICT_MATCH, 0u);
+    assert_int_not_equal(VERDICT_MATCH, 1u);
+    assert_int_not_equal(VERDICT_NO_MATCH, 0u);
+    assert_int_not_equal(VERDICT_NO_MATCH, 1u);
+}
+
 int main(void) {
     const struct CMUnitTest tests[] = {
+        cmocka_unit_test(test_the_two_verdicts_cannot_be_bridged_by_one_bit),
         cmocka_unit_test(test_finish_matching_keys_succeeds_and_erases),
         cmocka_unit_test(test_finish_mismatched_keys_fails_and_erases),
         cmocka_unit_test(test_finish_derivation_failure_fails_and_erases),
+        cmocka_unit_test(
+            test_finish_a_defeated_comparison_is_still_a_mismatch),
     };
     return cmocka_run_group_tests(tests, NULL, NULL);
 }

--- a/tests/unit/tests/sskr_byteword_sentinel.c
+++ b/tests/unit/tests/sskr_byteword_sentinel.c
@@ -42,7 +42,7 @@ extern unsigned char const SSKR_WORDLIST[];
 char *bip39_mnemonic_get(void) { fail_msg("not on the entry path"); }
 size_t bip39_mnemonic_length_get(void) { fail_msg("not on the entry path"); }
 uint8_t bip39_mnemonic_final_size_get(void) { fail_msg("not on the entry path"); }
-bool compare_recovery_phrase(void) { fail_msg("not on the entry path"); }
+unsigned int compare_recovery_phrase(void) { fail_msg("not on the entry path"); }
 
 /* ByteWord whose decoded value is `b`; the table holds 256 four-letter words. */
 static const char *word_for(uint8_t b)

--- a/tests/unit/tests/sskr_cbor_additional_info.c
+++ b/tests/unit/tests/sskr_cbor_additional_info.c
@@ -62,7 +62,7 @@ extern unsigned char const SSKR_WORDLIST[];
 char *bip39_mnemonic_get(void) { fail_msg("not on the entry path"); }
 size_t bip39_mnemonic_length_get(void) { fail_msg("not on the entry path"); }
 uint8_t bip39_mnemonic_final_size_get(void) { fail_msg("not on the entry path"); }
-bool compare_recovery_phrase(void) { fail_msg("not on the entry path"); }
+unsigned int compare_recovery_phrase(void) { fail_msg("not on the entry path"); }
 
 /* Largest a serialized share can be on the wire: CBOR long-form header
  * (tag + 0x58 + length byte), the shard itself, and the CRC32. Also the

--- a/tests/unit/tests/sskr_entry_bounds.c
+++ b/tests/unit/tests/sskr_entry_bounds.c
@@ -63,7 +63,7 @@ extern unsigned char const SSKR_WORDLIST[];
 char *bip39_mnemonic_get(void) { fail_msg("not on the entry path"); }
 size_t bip39_mnemonic_length_get(void) { fail_msg("not on the entry path"); }
 uint8_t bip39_mnemonic_final_size_get(void) { fail_msg("not on the entry path"); }
-bool compare_recovery_phrase(void) { fail_msg("not on the entry path"); }
+unsigned int compare_recovery_phrase(void) { fail_msg("not on the entry path"); }
 
 /* Largest a serialized share can be on the wire: CBOR long-form header
  * (tag + 0x58 + length byte), the shard itself, and the CRC32. */

--- a/tests/unit/tests/sskr_entry_lifecycle.c
+++ b/tests/unit/tests/sskr_entry_lifecycle.c
@@ -70,7 +70,7 @@ size_t bip39_mnemonic_length_get(void) { fail_msg("not on the removal path"); }
 size_t bip39_mnemonic_final_size_get(void) {
     fail_msg("not on the removal path");
 }
-bool compare_recovery_phrase(bool* reconstructed) {
+unsigned int compare_recovery_phrase(bool* reconstructed) {
     (void)reconstructed;
     fail_msg("not on the removal path");
 }

--- a/tests/unit/tests/sskr_multi_share_entry.c
+++ b/tests/unit/tests/sskr_multi_share_entry.c
@@ -72,7 +72,7 @@ size_t bip39_mnemonic_length_get(void) { fail_msg("not on the entry path"); }
 size_t bip39_mnemonic_final_size_get(void) {
     fail_msg("not on the entry path");
 }
-bool compare_recovery_phrase(bool* reconstructed) {
+unsigned int compare_recovery_phrase(bool* reconstructed) {
     (void)reconstructed;
     fail_msg("not on the entry path");
 }


### PR DESCRIPTION
Whether the phrase in front of the user is the one the device holds is the
decision this application exists to make, and it is the one worth injecting a
fault into. In the production ARM binary it came down to two instructions:

```
c0de0a08: bl    <os_secure_memcmp>
c0de0a0c: clz   r0, r0
c0de0a10: lsrs  r6, r0, #0x5
```

Flip bit 0 of `r0` after that shift and "this is not your seed" becomes "this
is". The two error directions are not equal: a false mismatch sends the user
back to the entry screen, a false match sends them away with a backup that will
not open their device, and they find out when they need it. The code treated
them identically, through the same bit.

## Kept, deliberately

`os_secure_memcmp()` — constant time, no early exit, over all 64 bytes of the
HMAC-SHA512 rather than over the words — and the two unconditional erasures,
which survive optimisation on every target. Neither is degraded here.

## Added

**A verdict that is a value, not a flag.** `VERDICT_MATCH` and
`VERDICT_NO_MATCH` differ in all 32 bits, so no single bit flip between the
comparison and the screen turns one into the other, and neither is a value a
cleared, incremented or short-counting register arrives at. All five call sites
test for `VERDICT_MATCH` and treat everything else as a mismatch — not just
`VERDICT_NO_MATCH`, because a corrupted verdict is not a match either.

**Two independent comparisons that must agree.** `compare_reversed()` reads the
same 64 bytes from the other end and accumulates every difference. It is
deliberately not a second call to `os_secure_memcmp()`: a fault on that
function's body would land on both calls the same way, which is the one thing a
redundant check must not do. It is constant time for the same reason the first
one is.

**A third reading inside the branch that already concluded "match".** A verdict
that does not survive that re-reading was not reached from what the buffers
hold, so there is nothing safe to display and the application stops.

**A checkpoint counter**, stepped at each point the function must pass through
and checked after the erasures, so an instruction skip across the comparison
arrives at a count that does not add up.

**A short random wait** before the comparison. Not a defence on its own; what it
costs an attacker is firing at a fixed offset from a visible trigger.

`buffer[64]` is zeroed at its declaration. Both branches that fill it are
conditional on `tool_type`, the enumeration has a third value, and no path
reaches this function with it today — but an uninitialised 64-byte buffer going
into an HMAC is not a thing to leave resting on that.

## `check_result_callback()`

It runs the whole comparison a second time when the user leaves the result
screen, which is a second seed derivation the application pays for. **Kept**, and
now commented as kept: it is a second independent decision on freshly derived
bytes rather than on a stored flag. It is not a substitute for any of the above
and must not be read as one — the screen the user acts on has already been
painted on the strength of the first call, and the BAGL targets call once.
Naming it is what stops it being removed as duplicate work.

## Measured

The test that holds the second comparison was written first, against the
unchanged `bool` API, by overriding `os_secure_memcmp()` for that target and
making it report agreement on two root keys that differ in every byte — which is
what a glitch landing on that call looks like from here. On the unfixed tree:

```
[ RUN      ] test_finish_a_defeated_comparison_is_still_a_mismatch
[  ERROR   ] --- result is not false
 1 FAILED TEST(S)
```

After:

```
[ RUN      ] test_the_two_verdicts_cannot_be_bridged_by_one_bit      [ OK ]
[ RUN      ] test_finish_matching_keys_succeeds_and_erases           [ OK ]
[ RUN      ] test_finish_mismatched_keys_fails_and_erases            [ OK ]
[ RUN      ] test_finish_derivation_failure_fails_and_erases         [ OK ]
[ RUN      ] test_finish_a_defeated_comparison_is_still_a_mismatch   [ OK ]
```

The disassembly, on flex:

```
c0de0a16: bl   <cx_rng_no_throw>          @ the jitter
c0de0a30: ldr  r0, [sp, #0x4]             @ checkpoint 1
c0de0a48: bl   <OUTLINED_FUNCTION_0>      @ os_secure_memcmp(buffer, dev, 0x40)
c0de0a52: bl   <compare_reversed>         @ the second, independent comparison
c0de0a58: orrs r0, r7                     @ both results, no branch between
c0de0a66: bne  ...                        @ any difference -> no match
c0de0a68: bl   <OUTLINED_FUNCTION_0>      @ third reading, inside the match branch
c0de0a6c: cbnz r0, ...                    @ -> LEDGER_ASSERT
c0de0a72: bl   <compare_reversed>
c0de0a76: cbnz r0, ...                    @ -> LEDGER_ASSERT
c0de0a78: ldr  r6, [pc, #0x40]            @ VERDICT_MATCH, from a literal
c0de0a84: bl   <explicit_bzero>           @ buffer_device
c0de0a8c: bl   <explicit_bzero>           @ buffer
c0de0a92: cmp  r0, #0x4                   @ the checkpoint count
c0de0a94: bne  ...                        @ -> LEDGER_ASSERT
c0de0a9c: cmp  r0, r1                     @ stack canary
c0de0a9e: ittt eq
c0de0aa0: moveq r0, r6                    @ the verdict reaches r0 only here
```

No two instructions carry the decision. `OUTLINED_FUNCTION_0` is the compiler
outlining the shared call — `movs r2, #0x40` then `b.w <os_secure_memcmp>`, so
still 64 bytes, still the SDK's constant-time implementation, tail-called.

The Speculos buffer-erasure check was replayed end to end on a flex build: full
12-word entry, genuine match path, both buffers holding the independently
recomputed root key right before erasure and reading all-zero after. It also
confirms the added jitter and third reading push nothing past its timeouts.

71 tests pass in all six matrix configurations; the six ARM targets build without
a warning.

## Not covered

* **The third reading and the checkpoint counter are not held by any test.** Both
  fire only on a fault, and a host process cannot be made to skip an instruction.
  They are written to be read, and the file says so.
* **No hardware validation.** What is claimed is that the decision no longer fits
  in two instructions, which the disassembly shows — not that any particular
  bench fails.
* **The jitter is a no-op in the unit suite**: the host `cx_rng_no_throw` stub
  returns zeros, so the loop runs zero times there. It is real on device.
* **The re-reading branch is timing-visible.** It runs only when the verdict is
  "match", so its duration reveals the verdict — which is the value the screen is
  about to display anyway. The constant-time property of the comparisons
  themselves is untouched.
