### PR TITLE
fix: stop discarding the error code of the seed derivation

### DIFF
--- a/src/bagl/nanos_enter_phrase.c
+++ b/src/bagl/nanos_enter_phrase.c
@@ -373,7 +373,10 @@ void compare_recovery_phrase_and_display_result(void) {
     io_seproxyhal_general_status();
 
     bool reconstructed = true;
-    const bool match = compare_recovery_phrase(&reconstructed);
+    // Against VERDICT_MATCH, not "not zero": every other value, corrupted or
+    // not, is a mismatch. See common.h.
+    const bool match =
+        (compare_recovery_phrase(&reconstructed) == VERDICT_MATCH);
 
     if (!reconstructed) {
         // shards were well-formed but could not be combined: report them as

--- a/src/bagl/nanox_enter_phrase.c
+++ b/src/bagl/nanox_enter_phrase.c
@@ -433,7 +433,10 @@ void screen_onboarding_restore_word_validate(void) {
                 // Display loading icon to user
                 ux_flow_init(0, ux_load_flow, NULL);
                 bool reconstructed = true;
-                if (compare_recovery_phrase(&reconstructed)) {
+                // Against VERDICT_MATCH, not "not zero": every other value,
+                // corrupted or not, is a mismatch. See common.h.
+                if (compare_recovery_phrase(&reconstructed) ==
+                    VERDICT_MATCH) {
                     ux_flow_init(0, &ux_bip39_match_flow, NULL);
                 } else {
                     memzero(G_bolos_ux_context.words_buffer,
@@ -478,7 +481,10 @@ void screen_onboarding_restore_word_validate(void) {
                     // Display loading icon to user
                     ux_flow_init(0, ux_load_flow, NULL);
                     bool reconstructed = true;
-                    const bool match = compare_recovery_phrase(&reconstructed);
+                    // Against VERDICT_MATCH, as above.
+                    const bool match =
+                        (compare_recovery_phrase(&reconstructed) ==
+                         VERDICT_MATCH);
                     if (!reconstructed) {
                         // shards were well-formed but could not be combined
                         ux_flow_init(0, &ux_sskr_invalid_flow, NULL);

--- a/src/common/bip39/common_bip39.h
+++ b/src/common/bip39/common_bip39.h
@@ -45,7 +45,13 @@ unsigned int bolos_ux_bip39_mnemonic_check(const unsigned char *mnemonic,
                                            unsigned int mnemonic_length);
 
 // passphrase will be prefixed with "MNEMONIC" from BIP39, the passphrase content shall start @ 8
-void bolos_ux_bip39_mnemonic_to_seed(const unsigned char *mnemonic,
+//
+// Returns false, with the 64 bytes of `seed` zeroed, when the PBKDF2 call
+// underneath reports an error. That call fills its output block by block, so a
+// failure part way through leaves a partly derived buffer that nothing
+// downstream could tell from a real seed; refusing here is what keeps it from
+// being HMAC'd and compared as one.
+bool bolos_ux_bip39_mnemonic_to_seed(const unsigned char *mnemonic,
                                      const unsigned int mnemonic_length,
                                      unsigned char *seed /*, unsigned char *workBuffer*/);
 

--- a/src/common/bip39/seed_bip39.c
+++ b/src/common/bip39/seed_bip39.c
@@ -33,7 +33,7 @@ unsigned int bolos_ux_bip39_mnemonic_to_seed_hash_length128(
     return mnemonic_length;
 }
 
-void bolos_ux_bip39_mnemonic_to_seed(const unsigned char* mnemonic,
+bool bolos_ux_bip39_mnemonic_to_seed(const unsigned char* mnemonic,
                                      unsigned int mnemonic_length,
                                      unsigned char* seed) {
     // Need to keep BIP39 mnemonic in case we want to generate SSKR from it
@@ -44,10 +44,38 @@ void bolos_ux_bip39_mnemonic_to_seed(const unsigned char* mnemonic,
     mnemonic_length = bolos_ux_bip39_mnemonic_to_seed_hash_length128(
         mnemonic_hash, mnemonic_length);
     memcpy(passphrase, BIP39_MNEMONIC, BIP39_MNEMONIC_LENGTH);
-    cx_pbkdf2_sha512(mnemonic_hash, mnemonic_length, passphrase,
-                     BIP39_MNEMONIC_LENGTH, BIP39_PBKDF2_ROUNDS, seed, 64);
+
+    // cx_pbkdf2_sha512 reads as a void call and is not one: it is a macro
+    // (lcx_pbkdf2.h) over cx_pbkdf2_no_throw(CX_SHA512, ...), which returns a
+    // cx_err_t. The SDK header says outright, above that prototype, that it
+    // does not mark the return WARN_UNUSED_RESULT because "return value is
+    // never checked", so no compiler and no conformance tool will point at
+    // this. It is the seed derivation of the whole application.
+    //
+    // The only error the SDK documents is CX_INVALID_PARAMETER, for a NULL
+    // password, salt or output -- none of which this call site can produce,
+    // all three being stack arrays. What a non-CX_OK return actually reports
+    // here is a failure inside the 2048 rounds of HMAC-SHA512, i.e. the
+    // hardware, which is exactly the condition a fault-injection attempt
+    // creates on purpose.
+    const cx_err_t derivation_status =
+        cx_pbkdf2_sha512(mnemonic_hash, mnemonic_length, passphrase,
+                         BIP39_MNEMONIC_LENGTH, BIP39_PBKDF2_ROUNDS, seed, 64);
+
     memzero(mnemonic_hash, sizeof(mnemonic_hash));
+
+    if (derivation_status != CX_OK) {
+        // cx_pbkdf2_hmac() fills the output block by block, so a failure part
+        // way through leaves some of it derived and the rest untouched. That
+        // is not a seed and must not reach the HMAC as one -- the caller
+        // cannot tell the difference by looking at it.
+        memzero(seed, 64);
+        PRINTF("BIP39 seed derivation failed\n");
+        return false;
+    }
+
     PRINTF("BIP39 seed computed: 64 bytes\n");
+    return true;
 }
 
 unsigned int bolos_ux_bip39_mnemonic_decode(const unsigned char* mnemonic,

--- a/src/common/common.h
+++ b/src/common/common.h
@@ -28,14 +28,38 @@
 #endif
 
 /*
- * Compares the entered secret with the device's seed.
+ * The two values the seed comparison speaks in, and the reason it does not
+ * speak in a bool.
+ *
+ * This is the one decision in the application worth injecting a fault into:
+ * a false "no match" sends the user back to the entry screen, but a false
+ * "match" sends them away with a backup that will not open their device, and
+ * they find out when they need it. Compiled from a bool, that decision was two
+ * ARM instructions wide and the whole of it lived in bit 0 of one register --
+ * a single bit flip, in the direction that costs the funds.
+ *
+ * These two differ in all 32 bits, so no single bit flip on the path from
+ * compare_recovery_phrase_finish() to the screen turns one into the other,
+ * and neither is a value a register arrives at by accident: not zero, not one,
+ * not a small count, not an address in this application's map.
+ *
+ * Callers must test for VERDICT_MATCH and treat *everything* else as a
+ * mismatch, VERDICT_NO_MATCH included but not only -- a verdict that is
+ * neither is a corrupted one, and a corrupted verdict is not a match.
+ */
+#define VERDICT_MATCH    0xA5C3F00Du
+#define VERDICT_NO_MATCH 0x5A3C0FF2u
+
+/*
+ * Compares the entered secret with the device's seed. Returns VERDICT_MATCH
+ * and nothing else on agreement; see above.
  *
  * `reconstructed` is set to false when the input could not be turned into a
  * mnemonic at all (SSKR shards that pass their CRC but cannot be combined).
  * That is a distinct outcome from a seed mismatch and must not be reported as
  * one. It is always true for the BIP39 tool, which has nothing to reconstruct.
  */
-bool compare_recovery_phrase(bool *reconstructed);
+unsigned int compare_recovery_phrase(bool *reconstructed);
 
 /*
  * The tail of compare_recovery_phrase(): everything that happens once
@@ -45,6 +69,6 @@ bool compare_recovery_phrase(bool *reconstructed);
  * file that defines it, and the unit suite that drives it, are checked against
  * one declaration.
  */
-bool compare_recovery_phrase_finish(cx_err_t derivation_status,
-                                    uint8_t buffer[64],
-                                    uint8_t buffer_device[64]);
+unsigned int compare_recovery_phrase_finish(cx_err_t derivation_status,
+                                            uint8_t buffer[64],
+                                            uint8_t buffer_device[64]);

--- a/src/common/common_seed.c
+++ b/src/common/common_seed.c
@@ -16,6 +16,7 @@
  ********************************************************************************/
 
 #include <lcx_hmac.h>
+#include <lcx_rng.h>
 
 /* clang-format off */
 #include "constants.h"
@@ -28,6 +29,35 @@
 extern unsigned int tool_type;
 #endif
 
+// The second of the two comparisons the verdict rests on, and deliberately
+// not a second call to os_secure_memcmp(): a fault that lands on that
+// function's body, or on the register its result comes back in, would land on
+// both calls the same way, which is the one thing a redundant check must not
+// do. This reads the same bytes from the other end, accumulates every
+// difference rather than stopping at the first, and so takes the same time
+// whatever the data -- which is the property os_secure_memcmp() is chosen for
+// in the first place and must not be given up here.
+static uint8_t compare_reversed(const uint8_t* a, const uint8_t* b,
+                                size_t length) {
+    uint8_t diff = 0;
+
+    for (size_t i = length; i > 0; i--) {
+        diff |= (uint8_t)(a[i - 1] ^ b[i - 1]);
+    }
+
+    return diff;
+}
+
+// A short, unpredictable wait before the comparison. It is not a defence on
+// its own -- 255 iterations is microseconds -- and it does not try to be: what
+// it costs an attacker is the ability to fire a glitch at a fixed offset from
+// a trigger they can see, which is how a bench is calibrated. volatile so that
+// no optimisation level deletes a loop with no effect.
+static void verdict_jitter(void) {
+    for (volatile uint8_t spin = cx_rng_u8(); spin > 0; spin--) {
+    }
+}
+
 // Only the derivation status is a hardware-dependent input here --
 // os_derive_bip32_no_throw() itself (a BOLOS syscall) is not testable on
 // host, but everything that happens with its result is pure logic:
@@ -35,25 +65,92 @@ extern unsigned int tool_type;
 // way. Splitting it out lets that logic -- including the derivation-failure
 // path, never exercised anywhere until now -- be covered without the
 // syscall.
-bool compare_recovery_phrase_finish(cx_err_t derivation_status,
-                                    uint8_t buffer[64],
-                                    uint8_t buffer_device[64]) {
-    bool result = false;
+//
+// This is where the application decides whether the phrase in front of the
+// user is the one their device holds, so it is written against a fault
+// injected into that decision rather than against ordinary failure. Four
+// things carry that:
+//
+//   - the verdict is one of two constants 32 bits apart (common.h), not a
+//     bool, so no single bit flip between here and the screen converts one
+//     into the other;
+//   - two independent comparisons have to agree. os_secure_memcmp() is kept
+//     as it was; compare_reversed() above reads the same 64 bytes the other
+//     way. A fault that defeats one is not the same fault that defeats the
+//     other, and the unit suite holds this by making the first one lie;
+//   - the bytes are read a third time inside the branch that has already
+//     concluded "match", and a verdict that does not survive that re-reading
+//     is a fault, not a mismatch: there is nothing safe to display, so the
+//     application stops;
+//   - a counter is stepped at each point the function must pass through and
+//     checked at the end, so an instruction skip that jumps over the
+//     comparison arrives at a count that does not add up.
+//
+// None of the four is held by a test on its own except the second: a fault is
+// not something the host suite can produce. What the suite does hold is that
+// the verdict is one of the two sentinels and never an intermediate value,
+// which is what the four are there to protect.
+unsigned int compare_recovery_phrase_finish(cx_err_t derivation_status,
+                                            uint8_t buffer[64],
+                                            uint8_t buffer_device[64]) {
+    unsigned int verdict = VERDICT_NO_MATCH;
+    volatile unsigned int checkpoints = 0;
+    // Neither starts at zero: zero is what "the two agree" looks like, so a
+    // fault that skips the assignments below must not leave agreement behind.
+    unsigned char forward = 0xFF;
+    unsigned char reversed = 0xFF;
+
+    verdict_jitter();
+    checkpoints++;
 
     if (derivation_status == CX_OK) {
-        result = os_secure_memcmp(buffer, buffer_device, 64) ? false : true;
+        forward = (unsigned char)os_secure_memcmp(buffer, buffer_device, 64);
+        reversed = compare_reversed(buffer, buffer_device, 64);
     }
+    checkpoints++;
+
+    if (derivation_status == CX_OK && forward == 0 && reversed == 0) {
+        verdict = VERDICT_MATCH;
+    }
+    checkpoints++;
+
+    // Re-read after the branch, not before it. The point is not to compare
+    // again -- that already happened -- but to catch a decision that was
+    // reached on something other than what the buffers hold.
+    if (verdict == VERDICT_MATCH) {
+        if (derivation_status != CX_OK ||
+            os_secure_memcmp(buffer, buffer_device, 64) != 0 ||
+            compare_reversed(buffer, buffer_device, 64) != 0) {
+            LEDGER_ASSERT(false, "Seed verdict did not survive re-reading");
+        }
+    }
+    checkpoints++;
 
     memzero(buffer_device, 64);
     memzero(buffer, 64);
 
-    return result;
+    // After the erasures, so that a control-flow fault does not leave two root
+    // keys on the stack on its way out.
+    LEDGER_ASSERT(checkpoints == 4, "Seed verdict skipped a checkpoint");
+
+    // Nothing but VERDICT_MATCH leaves as anything but VERDICT_NO_MATCH:
+    // callers test for the former, and a third value has no business
+    // travelling any further than this line.
+    if (verdict != VERDICT_MATCH) {
+        verdict = VERDICT_NO_MATCH;
+    }
+
+    return verdict;
 }
 
-bool compare_recovery_phrase(bool* reconstructed) {
-    // convert mnemonic to hex-seed
-    uint8_t buffer[64];
-    bool result = false;
+unsigned int compare_recovery_phrase(bool* reconstructed) {
+    // convert mnemonic to hex-seed. Zeroed at the declaration because the two
+    // branches that fill it are both conditional: TOOL_TYPE_BIP85 is a third
+    // value of that enumeration (constants.h), no path reaches this function
+    // with it today, and an uninitialised 64-byte buffer going into the
+    // HMAC below is not a thing to leave resting on that.
+    uint8_t buffer[64] = {0};
+    unsigned int result = VERDICT_NO_MATCH;
 
     // declared up front so goto cleanup can reach it from every early exit
     uint8_t buffer_device[64];

--- a/src/common/common_seed.c
+++ b/src/common/common_seed.c
@@ -161,39 +161,62 @@ unsigned int compare_recovery_phrase(bool* reconstructed) {
 
     *reconstructed = true;
 
+    // Whether the PBKDF2 that turns the mnemonic into the 64-byte seed ran to
+    // completion. True on the branch neither tool takes, which is the same
+    // reason buffer[] is zeroed above: nothing here should depend on a value
+    // no path sets.
+    bool derived = true;
+
 #if defined(HAVE_BAGL)
     if (G_bolos_ux_context.tool_type == TOOL_TYPE_BIP39) {
-        bolos_ux_bip39_mnemonic_to_seed(
+        derived = bolos_ux_bip39_mnemonic_to_seed(
             (unsigned char*)G_bolos_ux_context.words_buffer,
             G_bolos_ux_context.words_buffer_length, buffer);
     } else if (G_bolos_ux_context.tool_type == TOOL_TYPE_SSKR) {
         G_bolos_ux_context.words_buffer_length =
             sizeof(G_bolos_ux_context.words_buffer);
-        bolos_ux_sskr_to_seed_convert(
+        derived = bolos_ux_sskr_to_seed_convert(
             (unsigned char*)G_bolos_ux_context.sskr_words_buffer,
             G_bolos_ux_context.sskr_words_buffer_length,
             G_bolos_ux_context.sskr_share_count,
             (unsigned char*)&G_bolos_ux_context.words_buffer,
             &G_bolos_ux_context.words_buffer_length, buffer);
         if (G_bolos_ux_context.words_buffer_length == 0) {
-            // shards accepted by the CRC check but not combinable
+            // shards accepted by the CRC check but not combinable. Checked
+            // ahead of `derived` on purpose: shards that never became a
+            // mnemonic are what the user has to act on, and the derivation
+            // that ran on the empty mnemonic afterwards says nothing.
             *reconstructed = false;
             goto cleanup;
         }
     }
 #elif defined(HAVE_NBGL)
     if (tool_type == TOOL_TYPE_BIP39) {
-        bolos_ux_bip39_mnemonic_to_seed(
+        derived = bolos_ux_bip39_mnemonic_to_seed(
             (const unsigned char*)bip39_mnemonic_get(),
             bip39_mnemonic_length_get(), buffer);
     } else if (tool_type == TOOL_TYPE_SSKR) {
-        if (!bip39_mnemonic_from_sskr_shares(buffer)) {
-            // shards accepted by the CRC check but not combinable
+        if (!bip39_mnemonic_from_sskr_shares(buffer, &derived)) {
+            // shards accepted by the CRC check but not combinable, as above
             *reconstructed = false;
             goto cleanup;
         }
     }
 #endif
+
+    if (!derived) {
+        // The seed derivation reported an error, so `buffer` is 64 zeroes and
+        // not a seed. Treated exactly as a failed device derivation is a few
+        // lines below -- no match, the phrase is left alone, both buffers are
+        // erased -- because that is what it is: an outcome the comparison
+        // cannot be run on. This was already the reported result before the
+        // error was noticed, since a wrong seed does not match; what changes
+        // is that it is now a decision rather than a coincidence, and that no
+        // partly-derived buffer reaches the HMAC.
+        PRINTF("An error occurred while deriving the seed from the input\n");
+        goto cleanup;
+    }
+
     PRINTF("Input seed: 64 bytes\n");
 
     // get rootkey from hex-seed

--- a/src/common/sskr/common_sskr.h
+++ b/src/common/sskr/common_sskr.h
@@ -91,7 +91,12 @@ bool bolos_ux_sskr_share_slice(size_t buffer_length,
 bool bolos_ux_sskr_byteword_to_hex(const unsigned char *byteword, uint8_t *value);
 
 // Combine hex value SSKR shares into seed
-void bolos_ux_sskr_to_seed_convert(unsigned char *sskr_shares_hex,
+//
+// Returns what bolos_ux_bip39_mnemonic_to_seed() returned: whether the seed
+// derivation itself succeeded, and nothing else. Whether the shards combined
+// is still reported by *words_buffer_length, which is zero when they did not.
+// The two are distinct outcomes and reach the user as different screens.
+bool bolos_ux_sskr_to_seed_convert(unsigned char *sskr_shares_hex,
                                    unsigned int sskr_shares_hex_length,
                                    unsigned int sskr_shares_count,
                                    unsigned char *words_buffer,

--- a/src/common/sskr/seed_sskr.c
+++ b/src/common/sskr/seed_sskr.c
@@ -137,7 +137,7 @@ unsigned int bolos_ux_sskr_combine(unsigned char* sskr_shares_hex,
     return (unsigned int)output_len;
 }
 
-void bolos_ux_sskr_to_seed_convert(unsigned char* sskr_shares_hex,
+bool bolos_ux_sskr_to_seed_convert(unsigned char* sskr_shares_hex,
                                    unsigned int sskr_shares_hex_length,
                                    unsigned int sskr_shares_count,
                                    unsigned char* words_buffer,
@@ -154,7 +154,15 @@ void bolos_ux_sskr_to_seed_convert(unsigned char* sskr_shares_hex,
         bolos_ux_bip39_mnemonic_encode(seed_buffer, (uint8_t)seed_buffer_len,
                                        words_buffer, *words_buffer_length);
     memzero(seed_buffer, sizeof(seed_buffer));
-    bolos_ux_bip39_mnemonic_to_seed(words_buffer, *words_buffer_length, seed);
+
+    // Only the seed derivation is reported here. Whether the shards combined
+    // at all is a separate question, and the answer is still
+    // *words_buffer_length: a set that could not be combined encodes to an
+    // empty mnemonic, and deriving a seed from an empty mnemonic succeeds --
+    // it just does not mean anything. Callers read both, and they mean
+    // different things to the user.
+    return bolos_ux_bip39_mnemonic_to_seed(words_buffer, *words_buffer_length,
+                                           seed);
 }
 
 unsigned int bolos_ux_sskr_generate(uint8_t groups_threshold,

--- a/src/nbgl/bip39_mnemonic.c
+++ b/src/nbgl/bip39_mnemonic.c
@@ -122,7 +122,9 @@ bool bip39_mnemonic_check(bool* match) {
     }
 
     bool reconstructed = true;
-    *match = compare_recovery_phrase(&reconstructed);
+    // Against VERDICT_MATCH, not "not zero": every other value, corrupted or
+    // not, is a mismatch. See common.h.
+    *match = (compare_recovery_phrase(&reconstructed) == VERDICT_MATCH);
     // Don't clear the mnemonic just yet as we may need it to generate SSKR
     // shares
     //    bip39_mnemonic_reset();

--- a/src/nbgl/bip39_mnemonic.c
+++ b/src/nbgl/bip39_mnemonic.c
@@ -132,7 +132,7 @@ bool bip39_mnemonic_check(bool* match) {
     return true;
 }
 
-bool bip39_mnemonic_from_sskr_shares(unsigned char* seed) {
+bool bip39_mnemonic_from_sskr_shares(unsigned char* seed, bool* derived) {
     // mnemonic.length is a size_t, like every other field of this struct,
     // while every length in the common bolos_ux_* API is an unsigned int.
     // They are the same type on the 32-bit ARM targets, which is why handing
@@ -142,7 +142,11 @@ bool bip39_mnemonic_from_sskr_shares(unsigned char* seed) {
     // convention.
     unsigned int words_buffer_length = BIP39_MNEMONIC_MAX_LENGTH;
 
-    bolos_ux_sskr_to_seed_convert(
+    // Two outcomes, not one: *derived says whether the seed derivation ran to
+    // completion, the return value says whether the shards combined. A caller
+    // that folded them together would report a failed derivation as unusable
+    // shares, which is the wrong thing to tell the user and the wrong screen.
+    *derived = bolos_ux_sskr_to_seed_convert(
         (unsigned char*)sskr_shares_get(), sskr_shares_length_get(),
         sskr_sharecount_get(), (unsigned char*)bip39_mnemonic_get(),
         &words_buffer_length, seed);

--- a/src/nbgl/bip39_mnemonic.h
+++ b/src/nbgl/bip39_mnemonic.h
@@ -67,8 +67,13 @@ size_t bip39_mnemonic_word_add(const char *const buffer, const size_t size);
 
 /*
  * Generate BIP39 mnemonic from SSKR shares
+ *
+ * Returns whether the shards combined into a mnemonic. `derived` is set to
+ * whether the seed derivation that follows succeeded, which is a different
+ * question with a different answer for the user: unusable shares on one side,
+ * a derivation that did not complete on the other.
  */
-bool bip39_mnemonic_from_sskr_shares(unsigned char *seed);
+bool bip39_mnemonic_from_sskr_shares(unsigned char *seed, bool *derived);
 
 /*
  * Encode BIP39 mnemonic from hex input

--- a/src/nbgl/sskr_shares.c
+++ b/src/nbgl/sskr_shares.c
@@ -177,7 +177,9 @@ bool sskr_shares_check(bool* match) {
     }
 
     bool reconstructed = true;
-    *match = compare_recovery_phrase(&reconstructed);
+    // Against VERDICT_MATCH, not "not zero": every other value, corrupted or
+    // not, is a mismatch. See common.h.
+    *match = (compare_recovery_phrase(&reconstructed) == VERDICT_MATCH);
     if (!reconstructed) {
         // shards were well-formed but could not be combined: report them as
         // invalid rather than as a seed mismatch

--- a/src/nbgl/ui.c
+++ b/src/nbgl/ui.c
@@ -516,6 +516,26 @@ static void display_home_page() {
 /*
  * Result page
  */
+/*
+ * This runs when the user taps to leave the result screen, and it calls
+ * bip39_mnemonic_check() / sskr_shares_check() a second time -- so
+ * compare_recovery_phrase(), the device-seed derivation and the whole verdict,
+ * all over again. That is a second derivation the application pays for, and it
+ * would be easy to remove by reading the seed_match the first call already
+ * left behind.
+ *
+ * Deliberately kept. It is a second, independent decision standing between a
+ * single glitched verdict and the screen the user is sent on to, taken on
+ * freshly derived bytes rather than on a stored flag. It was not put here for
+ * that -- it is where the navigation happens to lead -- but it is worth what
+ * it costs, and naming it here is what stops it being refactored away as
+ * duplicate work.
+ *
+ * It is not a substitute for the hardening in compare_recovery_phrase_finish()
+ * and must not be read as one: the result screen the user reads and acts on
+ * has already been painted on the strength of the first call, and the BAGL
+ * targets call once, not twice.
+ */
 static void check_result_callback(int token __attribute__((unused)),
                                   uint8_t index __attribute__((unused))) {
     if (tool_type == TOOL_TYPE_BIP39 && bip39_mnemonic_check(&seed_match) &&

--- a/tests/speculos/README.md
+++ b/tests/speculos/README.md
@@ -181,10 +181,12 @@ buffers are still erased on the same path); only where the two
 `explicit_bzero()` calls physically live moved. This also simplified the
 addressing: `compare_recovery_phrase_finish()` receives `buffer`/
 `buffer_device` as plain pointer arguments rather than declaring them as
-its own stack-local arrays, so its prologue is a bare `push
-{r4,r5,r6,lr}` with no `sub sp, #N` at all — the compiler keeps both
-pointers in call-preserved registers for the function's whole body instead
-of spilling them to the stack. That means this check no longer needs
+its own stack-local arrays — the compiler keeps both pointers in
+call-preserved registers for the function's whole body instead of
+spilling them to the stack. The function does now have a stack frame (the
+fault-resistance work gave it a volatile checkpoint counter and a
+volatile spin variable, both of which have to live in memory), but the
+two pointers are not in it. That means this check no longer needs
 gotcha 5's SP-relative-offset approach: it reads the two argument
 registers directly at each breakpoint (which register holds which buffer
 is read back from the disassembly, not hardcoded — see
@@ -546,9 +548,10 @@ the whole call.
 Since `compare_recovery_phrase()`'s tail (the two `explicit_bzero()` calls)
 was extracted into `compare_recovery_phrase_finish()` — see Check 2 above
 — `buffer`/`buffer_device` arrive there as plain pointer *arguments*
-rather than that function's own stack-local arrays, and its prologue
-(`push {r4,r5,r6,lr}`, no `sub sp, #N` at all) has no stack frame to be
-SP-relative *into* in the first place. The compiler instead keeps both
+rather than that function's own stack-local arrays. Whatever stack frame
+that function has holds its own volatile counters and nothing else, so
+there is no per-buffer offset to be SP-relative *into* in the first
+place. The compiler instead keeps both
 pointers in call-preserved registers for the whole function body — an
 even simpler case than the SP-relative one above: read the two argument
 registers directly at either breakpoint and dereference them, no offset

--- a/tests/speculos/verify_compare_recovery_phrase_cleanup.py
+++ b/tests/speculos/verify_compare_recovery_phrase_cleanup.py
@@ -169,11 +169,14 @@ def resolve_cleanup_breakpoints(link_addr, size):
       buffer_device as plain pointer arguments (not local stack arrays),
       so the compiler keeps them in call-preserved registers across both
       calls instead of spilling them to the stack -- confirmed by
-      disassembly, not assumed: this function's prologue is
-      `push {r4,r5,r6,lr}` with no `sub sp, #N` at all, so there is no
-      per-buffer SP offset to resolve here, unlike the SP-relative
-      approach Check 1/3's globals and this function's own former host
-      (compare_recovery_phrase()) need -- see README.md gotcha 5.
+      disassembly, not assumed. The function does now carry a stack frame
+      of its own (the fault-resistance work gave it a volatile checkpoint
+      counter and a volatile spin variable, both stack-resident), but the
+      two pointers are not part of it: they stay in registers, so there is
+      still no per-buffer SP offset to resolve here, unlike the
+      SP-relative approach Check 1/3's globals and this function's own
+      former host (compare_recovery_phrase()) need -- see README.md
+      gotcha 5.
 
     Nothing here is hardcoded as a raw address or register number --
     only the function's own resolved link_addr/size (from
@@ -306,8 +309,10 @@ class MemorySampler:
     itself), buffer/buffer_device arrive here as plain pointer arguments
     that the compiler keeps in two call-preserved registers for the whole
     function body (confirmed by disassembly, see
-    resolve_cleanup_breakpoints -- no stack frame at all, so no per-buffer
-    offset to add to anything): read those two registers directly at
+    resolve_cleanup_breakpoints -- the function's own stack frame holds
+    only its volatile counters, never the two pointers, so there is no
+    per-buffer offset to add to anything): read those two registers
+    directly at
     either breakpoint and dereference them, no SP/frame-base bookkeeping
     needed at all.
     """

--- a/tests/unit/CMakeLists.txt
+++ b/tests/unit/CMakeLists.txt
@@ -583,6 +583,16 @@ target_compile_options(test_bip39 PRIVATE -fsanitize=address -fno-omit-frame-poi
 target_link_options(test_bip39 PRIVATE -fsanitize=address)
 target_link_libraries(test_bip39 PUBLIC cmocka gcov testutils)
 
+# The seed derivation's own failure path. Same sources as test_bip39 above,
+# but a separate target rather than more cases in tests/bip39.c: this one
+# defines cx_pbkdf2_no_throw() itself, overriding the SDK build of it that
+# libtestutils exports, and that override applies to every test in the
+# executable. tests/bip39.c has to keep the real one -- it checks published
+# vectors -- so the two cannot share a binary.
+add_executable(test_bip39_seed_derivation_failure ./tests/bip39_seed_derivation_failure.c ../../src/common/bip39/seed_rom_variables.c ../../src/common/bip39/seed_bip39.c)
+target_include_directories(test_bip39_seed_derivation_failure PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/../../src/common)
+target_link_libraries(test_bip39_seed_derivation_failure PUBLIC cmocka gcov testutils)
+
 add_executable(test_roundtrip ./tests/roundtrip.c ../../src/common/bip39/seed_rom_variables.c ../../src/common/bip39/seed_bip39.c ../../src/common/sskr/seed_rom_variables.c ../../src/common/sskr/seed_sskr.c)
 target_include_directories(test_roundtrip PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/../../src ${CMAKE_CURRENT_SOURCE_DIR}/../../src/common)
 target_link_libraries(test_roundtrip PUBLIC cmocka gcov testutils sskr sss)
@@ -759,13 +769,16 @@ target_compile_options(test_compare_recovery_phrase_finish PRIVATE -include cx.h
 target_compile_definitions(test_compare_recovery_phrase_finish PRIVATE HAVE_ECC_WEIERSTRASS HAVE_SECP256K1_CURVE)
 target_link_options(test_compare_recovery_phrase_finish PRIVATE -Wl,--gc-sections)
 target_link_libraries(test_compare_recovery_phrase_finish PUBLIC cmocka gcov testutils)
-# Expected, harmless compiler warning from this target only: with neither
-# HAVE_BAGL nor HAVE_NBGL defined (a combination the real app build never
-# hits -- one of the two is always set), the two `goto cleanup;` sites
-# inside compare_recovery_phrase()'s UI-specific block are preprocessed
-# out, leaving its `cleanup:` label with no remaining jump to it:
-#   common_seed.c:126:1: warning: label 'cleanup' defined but not used
-#     [-Wunused-label]
+# This target used to be the one place a `-Wunused-label` warning appeared:
+# with neither HAVE_BAGL nor HAVE_NBGL defined (a combination the real app
+# build never hits -- one of the two is always set), both `goto cleanup;`
+# sites inside compare_recovery_phrase()'s UI-specific block were
+# preprocessed out, leaving its `cleanup:` label with no remaining jump to
+# it. The seed-derivation failure check added since sits outside that block
+# and jumps to the same label unconditionally, so the warning is gone. It is
+# recorded here rather than deleted because its absence is now load-bearing:
+# it reappearing would mean that check was moved back inside the guards,
+# where a failed derivation on the other UI stack would stop being handled.
 
 # bip85_finalize_pwd() (also outside the HAVE_NBGL guard) is the
 # memcpy-and-terminate tail shared by bolos_ux_bip85_pwd_base64()/

--- a/tests/unit/CMakeLists.txt
+++ b/tests/unit/CMakeLists.txt
@@ -739,9 +739,11 @@ target_link_libraries(test_bip85_hex_vector PUBLIC cmocka gcov testutils)
 # compiles with -ffunction-sections/-fdata-sections and links with
 # --gc-sections so the linker drops compare_recovery_phrase() and
 # everything it alone pulls in before ever needing to resolve those
-# symbols -- verified with nm on the built test binary, not assumed: only
-# compare_recovery_phrase_finish() and its own gcov counters remain: the
-# defined text symbol for compare_recovery_phrase() itself is gone.
+# symbols -- verified with nm on the built test binary, not assumed: what
+# remains is compare_recovery_phrase_finish(), the two file-static helpers
+# it alone calls (compare_reversed() and verdict_jitter(), both part of the
+# fault resistance around the verdict) and their gcov counters. The defined
+# text symbol for compare_recovery_phrase() itself is gone.
 add_executable(test_compare_recovery_phrase_finish ./tests/compare_recovery_phrase_finish.c ../../src/common/common_seed.c)
 target_include_directories(test_compare_recovery_phrase_finish PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/../../src ${CMAKE_CURRENT_SOURCE_DIR}/../../src/common)
 # common_seed.c's untouched compare_recovery_phrase() body uses

--- a/tests/unit/tests/bip39.c
+++ b/tests/unit/tests/bip39.c
@@ -25,8 +25,8 @@ const unsigned char seed[] = {
 static void test_bip39(void** state) {
     uint8_t buffer[64] = {0};
 
-    bolos_ux_bip39_mnemonic_to_seed(bip39_mnemonic, sizeof(bip39_mnemonic) - 1,
-                                    buffer);
+    assert_true(bolos_ux_bip39_mnemonic_to_seed(
+        bip39_mnemonic, sizeof(bip39_mnemonic) - 1, buffer));
 
     assert_memory_equal(buffer, seed, sizeof(seed));
 }
@@ -55,8 +55,9 @@ static void test_bip39_seed_short_mnemonic(void** state) {
         0x19, 0xef, 0xdf, 0xd2, 0x61, 0x7b, 0x49, 0xeb, 0xe3};
     uint8_t out_seed[64];
 
-    bolos_ux_bip39_mnemonic_to_seed((unsigned char*)mnemonic,
-                                    sizeof(mnemonic) - 1, out_seed);
+    assert_true(bolos_ux_bip39_mnemonic_to_seed((unsigned char*)mnemonic,
+                                                sizeof(mnemonic) - 1,
+                                                out_seed));
 
     assert_memory_equal(out_seed, expected_seed, sizeof(expected_seed));
 }
@@ -92,10 +93,10 @@ static void test_bip39_seed_length_boundary(void** state) {
     uint8_t seed_128[64];
     uint8_t seed_129[64];
 
-    bolos_ux_bip39_mnemonic_to_seed(buf, 128, seed_128);
+    assert_true(bolos_ux_bip39_mnemonic_to_seed(buf, 128, seed_128));
     assert_memory_equal(seed_128, expected_seed_128, sizeof(expected_seed_128));
 
-    bolos_ux_bip39_mnemonic_to_seed(buf, 129, seed_129);
+    assert_true(bolos_ux_bip39_mnemonic_to_seed(buf, 129, seed_129));
     assert_memory_equal(seed_129, expected_seed_129, sizeof(expected_seed_129));
 }
 

--- a/tests/unit/tests/bip39_entry_bounds.c
+++ b/tests/unit/tests/bip39_entry_bounds.c
@@ -51,7 +51,7 @@
  * It is not on the entry path under test; this exists only so the object links,
  * and aborts if it is ever reached.
  */
-bool compare_recovery_phrase(bool* reconstructed) {
+unsigned int compare_recovery_phrase(bool* reconstructed) {
     (void)reconstructed;
     fail_msg("not on the entry path");
 }

--- a/tests/unit/tests/bip39_seed_derivation_failure.c
+++ b/tests/unit/tests/bip39_seed_derivation_failure.c
@@ -1,0 +1,136 @@
+/*
+ * What bolos_ux_bip39_mnemonic_to_seed() does when the key derivation
+ * underneath it fails.
+ *
+ * The call it makes reads as a void one and is not: cx_pbkdf2_sha512 is a
+ * macro (lcx_pbkdf2.h) over cx_pbkdf2_no_throw(CX_SHA512, ...), which returns
+ * a cx_err_t. The SDK header says in as many words, above that prototype, that
+ * it does not mark the return WARN_UNUSED_RESULT because the "return value is
+ * never checked" -- so nothing in a build points at a caller that drops it.
+ * The value was dropped here, in this application's seed derivation.
+ *
+ * The failure is not reachable from the entry screens. cx_pbkdf2_hmac()
+ * returns CX_INVALID_PARAMETER only for a NULL password, salt or output, and
+ * all three are stack arrays at the one call site; everything else it can
+ * return comes from the 2048 rounds of HMAC-SHA512 underneath, i.e. from the
+ * hardware. That is precisely the condition a fault-injection attempt sets out
+ * to create, and it is why this is worth a test rather than an argument: the
+ * only way to reach it on host is to stand in for that hardware.
+ *
+ * cx_pbkdf2_no_throw() is therefore defined here, overriding the SDK build of
+ * it that libtestutils carries for every other target -- the same technique
+ * tests/unit/tests/compare_recovery_phrase_finish.c uses for
+ * os_secure_memcmp(). Two behaviours, chosen per test:
+ *
+ *   - an error, with the output left exactly as the caller passed it in. That
+ *     is not quite what the real function does on a mid-loop failure (it fills
+ *     the output block by block, so some of it would be derived), but it is
+ *     the stronger case for what is asserted: if the caller returns the
+ *     buffer untouched, whatever was there before travels on as a seed.
+ *   - success, writing a recognisable pattern. Without this the test would
+ *     pass against a function that zeroed the seed and returned false on every
+ *     call.
+ *
+ * What this file does not cover: it does not exercise the real PBKDF2 at all.
+ * tests/unit/tests/bip39.c holds that against published vectors, and now also
+ * asserts the true return on each of them.
+ */
+
+#include <cmocka.h>
+#include <cx.h>
+#include <setjmp.h>
+#include <stdarg.h>
+#include <stdbool.h>
+#include <stddef.h>
+#include <stdint.h>
+#include <string.h>
+
+/* testutils.h has to come first: it defines WIDE, which
+ * bip39/seed_rom_variables.h uses without defining. Not sorted, hence the
+ * clang-format exclusion. */
+// clang-format off
+#include "testutils.h"
+#include "bip39/common_bip39.h"
+// clang-format on
+
+/* An arbitrary mnemonic-shaped input. Nothing here decodes or validates it --
+ * the function under test hashes whatever bytes it is given. */
+static const unsigned char k_mnemonic[] =
+    "fly mule excess resource treat plunge nose soda reflect adult ramp planet";
+
+/* The byte the seed buffer is prefilled with, so that "was it erased" and
+ * "was it never written" are different observations. */
+#define PREFILL (0x5A)
+
+/* The byte the succeeding stub writes, so the control test can tell a real
+ * write from an untouched buffer. */
+#define STUB_DERIVED (0xC7)
+
+static bool s_pbkdf2_fails = false;
+
+cx_err_t cx_pbkdf2_no_throw(cx_md_t md_type, const uint8_t *password,
+                            size_t password_len, uint8_t *salt, size_t salt_len,
+                            uint32_t iterations, uint8_t *out,
+                            size_t out_len) {
+    (void)md_type;
+    (void)password;
+    (void)password_len;
+    (void)salt;
+    (void)salt_len;
+    (void)iterations;
+
+    if (s_pbkdf2_fails) {
+        /* left untouched on purpose: see the file header */
+        return CX_INTERNAL_ERROR;
+    }
+
+    memset(out, STUB_DERIVED, out_len);
+    return CX_OK;
+}
+
+static void test_a_failed_derivation_is_reported_and_wipes_the_seed(
+    void **state) {
+    (void)state;
+
+    uint8_t seed[64];
+    memset(seed, PREFILL, sizeof(seed));
+
+    s_pbkdf2_fails = true;
+    const bool ok = bolos_ux_bip39_mnemonic_to_seed(
+        k_mnemonic, sizeof(k_mnemonic) - 1, seed);
+    s_pbkdf2_fails = false;
+
+    assert_false(ok);
+
+    /* Not one byte of what was there is left. Before this, the caller had no
+     * way to know the difference and would HMAC it as a seed. */
+    for (size_t i = 0; i < sizeof(seed); i++) {
+        assert_int_equal(seed[i], 0x00);
+    }
+}
+
+/* The control. A function that answered false and zeroed the seed whatever
+ * happened would satisfy the test above and be useless. */
+static void test_a_successful_derivation_is_reported_and_kept(void **state) {
+    (void)state;
+
+    uint8_t seed[64];
+    memset(seed, PREFILL, sizeof(seed));
+
+    const bool ok = bolos_ux_bip39_mnemonic_to_seed(
+        k_mnemonic, sizeof(k_mnemonic) - 1, seed);
+
+    assert_true(ok);
+
+    for (size_t i = 0; i < sizeof(seed); i++) {
+        assert_int_equal(seed[i], STUB_DERIVED);
+    }
+}
+
+int main(void) {
+    const struct CMUnitTest tests[] = {
+        cmocka_unit_test(test_a_failed_derivation_is_reported_and_wipes_the_seed),
+        cmocka_unit_test(test_a_successful_derivation_is_reported_and_kept),
+    };
+    return cmocka_run_group_tests(tests, NULL, NULL);
+}

--- a/tests/unit/tests/compare_recovery_phrase_finish.c
+++ b/tests/unit/tests/compare_recovery_phrase_finish.c
@@ -7,10 +7,34 @@
  * the derivation-failure path -- never exercised anywhere in this suite
  * until now, since nothing could force that syscall to fail in a
  * controlled way.
+ *
+ * It is also where the application decides whether the phrase in front of the
+ * user is the one their device holds, which makes it the one decision here
+ * worth injecting a fault into, and the reason the function is written the way
+ * it is. What this file can hold of that, and what it cannot:
+ *
+ *   - the verdict is one of two constants that differ in all 32 bits, and the
+ *     function returns one of those two and nothing else. Held, by asserting
+ *     equality with the constants rather than truthiness, and by asserting the
+ *     distance between them.
+ *   - two independent comparisons have to agree. Held, by overriding
+ *     os_secure_memcmp() for this target and making it report agreement on two
+ *     root keys that differ in every byte -- which is what a glitch landing on
+ *     that call looks like from here.
+ *   - the third reading inside the "match" branch, and the checkpoint counter
+ *     checked before the return. Not held, and not holdable here: both fire
+ *     only on a fault, and a host process cannot be made to skip an
+ *     instruction. They are written to be read, and the erasure of both
+ *     buffers is asserted on every path so that neither can quietly stop
+ *     happening.
  */
 
 #include <cmocka.h>
 #include <cx.h>
+/* for the os_secure_memcmp() prototype: this file defines it, and a
+ * definition with no declaration in sight is exactly what
+ * -Wmissing-prototypes is here to report. */
+#include <os_utils.h>
 #include <setjmp.h>
 #include <stdarg.h>
 #include <stddef.h>
@@ -25,6 +49,34 @@ static void assert_all_zero(const uint8_t* data, size_t len) {
     }
 }
 
+/*
+ * os_secure_memcmp() again, overriding the one testutils.c exports for every
+ * other target, so that one test can make it lie. This is the whole point of
+ * the second comparison: a fault landing on that call, or on the register its
+ * result comes back in, is the cheapest single-glitch way to turn "this is not
+ * your seed" into "this is". Nothing else in this file changes behaviour --
+ * s_memcmp_lies is false everywhere but inside the one test that sets it, and
+ * that test puts it back.
+ *
+ * The body when it is not lying is the SDK's own (src/os.c), byte for byte:
+ * two counters run down together, every byte XOR-accumulated, no early exit.
+ */
+static bool s_memcmp_lies = false;
+
+char os_secure_memcmp(const void* src1, const void* src2, size_t length) {
+    const unsigned char* a = (const unsigned char*)src1;
+    const unsigned char* b = (const unsigned char*)src2;
+    unsigned char xoracc = 0;
+
+    if (s_memcmp_lies) {
+        return 0;
+    }
+    for (size_t i = 0; i < length; i++) {
+        xoracc |= a[i] ^ b[i];
+    }
+    return (char)xoracc;
+}
+
 static void test_finish_matching_keys_succeeds_and_erases(void** state) {
     (void)state;
 
@@ -33,9 +85,10 @@ static void test_finish_matching_keys_succeeds_and_erases(void** state) {
     memset(buffer, 0x42, sizeof(buffer));
     memset(buffer_device, 0x42, sizeof(buffer_device));
 
-    bool result = compare_recovery_phrase_finish(CX_OK, buffer, buffer_device);
+    const unsigned int result =
+        compare_recovery_phrase_finish(CX_OK, buffer, buffer_device);
 
-    assert_true(result);
+    assert_int_equal(result, VERDICT_MATCH);
     assert_all_zero(buffer, sizeof(buffer));
     assert_all_zero(buffer_device, sizeof(buffer_device));
 }
@@ -48,9 +101,10 @@ static void test_finish_mismatched_keys_fails_and_erases(void** state) {
     memset(buffer, 0x42, sizeof(buffer));
     memset(buffer_device, 0x24, sizeof(buffer_device));
 
-    bool result = compare_recovery_phrase_finish(CX_OK, buffer, buffer_device);
+    const unsigned int result =
+        compare_recovery_phrase_finish(CX_OK, buffer, buffer_device);
 
-    assert_false(result);
+    assert_int_equal(result, VERDICT_NO_MATCH);
     assert_all_zero(buffer, sizeof(buffer));
     assert_all_zero(buffer_device, sizeof(buffer_device));
 }
@@ -71,19 +125,81 @@ static void test_finish_derivation_failure_fails_and_erases(void** state) {
     memset(buffer, 0x11, sizeof(buffer));
     memset(buffer_device, 0x99, sizeof(buffer_device));
 
-    bool result = compare_recovery_phrase_finish(CX_INTERNAL_ERROR, buffer,
-                                                 buffer_device);
+    const unsigned int result = compare_recovery_phrase_finish(
+        CX_INTERNAL_ERROR, buffer, buffer_device);
 
-    assert_false(result);
+    assert_int_equal(result, VERDICT_NO_MATCH);
     assert_all_zero(buffer, sizeof(buffer));
     assert_all_zero(buffer_device, sizeof(buffer_device));
 }
 
+/*
+ * The mutation the second comparison exists for: os_secure_memcmp() reports
+ * agreement on two root keys that differ in all 64 bytes. That is what a
+ * successful glitch on that call looks like from here, and it is the error
+ * direction that costs the user their funds -- a false "no match" sends them
+ * back to the entry screen, a false "match" sends them away with a backup that
+ * does not open their device.
+ *
+ * A second call to os_secure_memcmp() would not catch this: the stub lies to
+ * every caller, exactly as a fault on the function's own body would. What
+ * catches it has to read the bytes itself.
+ */
+static void test_finish_a_defeated_comparison_is_still_a_mismatch(
+    void** state) {
+    (void)state;
+
+    uint8_t buffer[64];
+    uint8_t buffer_device[64];
+    memset(buffer, 0x42, sizeof(buffer));
+    memset(buffer_device, 0x24, sizeof(buffer_device));
+
+    s_memcmp_lies = true;
+    const unsigned int result =
+        compare_recovery_phrase_finish(CX_OK, buffer, buffer_device);
+    s_memcmp_lies = false;
+
+    assert_int_equal(result, VERDICT_NO_MATCH);
+    assert_all_zero(buffer, sizeof(buffer));
+    assert_all_zero(buffer_device, sizeof(buffer_device));
+}
+
+/*
+ * What makes the two verdicts worth carrying around as 32-bit values rather
+ * than as a bool: no single bit flip anywhere between this function and the
+ * screen turns one into the other, and neither is a value a register arrives
+ * at by accident. Asserted rather than left to whoever next edits common.h --
+ * two constants that merely look unusual are not the same as two constants a
+ * fault cannot bridge.
+ */
+static void test_the_two_verdicts_cannot_be_bridged_by_one_bit(void** state) {
+    (void)state;
+
+    const unsigned int difference = VERDICT_MATCH ^ VERDICT_NO_MATCH;
+    unsigned int differing_bits = 0;
+
+    for (unsigned int bit = 0; bit < 32; bit++) {
+        differing_bits += (difference >> bit) & 1u;
+    }
+
+    assert_int_equal(differing_bits, 32);
+
+    /* and neither is a value a cleared, incremented or short-counting
+     * register lands on */
+    assert_int_not_equal(VERDICT_MATCH, 0u);
+    assert_int_not_equal(VERDICT_MATCH, 1u);
+    assert_int_not_equal(VERDICT_NO_MATCH, 0u);
+    assert_int_not_equal(VERDICT_NO_MATCH, 1u);
+}
+
 int main(void) {
     const struct CMUnitTest tests[] = {
+        cmocka_unit_test(test_the_two_verdicts_cannot_be_bridged_by_one_bit),
         cmocka_unit_test(test_finish_matching_keys_succeeds_and_erases),
         cmocka_unit_test(test_finish_mismatched_keys_fails_and_erases),
         cmocka_unit_test(test_finish_derivation_failure_fails_and_erases),
+        cmocka_unit_test(
+            test_finish_a_defeated_comparison_is_still_a_mismatch),
     };
     return cmocka_run_group_tests(tests, NULL, NULL);
 }

--- a/tests/unit/tests/sskr_byteword_sentinel.c
+++ b/tests/unit/tests/sskr_byteword_sentinel.c
@@ -42,7 +42,7 @@ extern unsigned char const SSKR_WORDLIST[];
 char *bip39_mnemonic_get(void) { fail_msg("not on the entry path"); }
 size_t bip39_mnemonic_length_get(void) { fail_msg("not on the entry path"); }
 uint8_t bip39_mnemonic_final_size_get(void) { fail_msg("not on the entry path"); }
-bool compare_recovery_phrase(void) { fail_msg("not on the entry path"); }
+unsigned int compare_recovery_phrase(void) { fail_msg("not on the entry path"); }
 
 /* ByteWord whose decoded value is `b`; the table holds 256 four-letter words. */
 static const char *word_for(uint8_t b)

--- a/tests/unit/tests/sskr_cbor_additional_info.c
+++ b/tests/unit/tests/sskr_cbor_additional_info.c
@@ -62,7 +62,7 @@ extern unsigned char const SSKR_WORDLIST[];
 char *bip39_mnemonic_get(void) { fail_msg("not on the entry path"); }
 size_t bip39_mnemonic_length_get(void) { fail_msg("not on the entry path"); }
 uint8_t bip39_mnemonic_final_size_get(void) { fail_msg("not on the entry path"); }
-bool compare_recovery_phrase(void) { fail_msg("not on the entry path"); }
+unsigned int compare_recovery_phrase(void) { fail_msg("not on the entry path"); }
 
 /* Largest a serialized share can be on the wire: CBOR long-form header
  * (tag + 0x58 + length byte), the shard itself, and the CRC32. Also the

--- a/tests/unit/tests/sskr_entry_bounds.c
+++ b/tests/unit/tests/sskr_entry_bounds.c
@@ -63,7 +63,7 @@ extern unsigned char const SSKR_WORDLIST[];
 char *bip39_mnemonic_get(void) { fail_msg("not on the entry path"); }
 size_t bip39_mnemonic_length_get(void) { fail_msg("not on the entry path"); }
 uint8_t bip39_mnemonic_final_size_get(void) { fail_msg("not on the entry path"); }
-bool compare_recovery_phrase(void) { fail_msg("not on the entry path"); }
+unsigned int compare_recovery_phrase(void) { fail_msg("not on the entry path"); }
 
 /* Largest a serialized share can be on the wire: CBOR long-form header
  * (tag + 0x58 + length byte), the shard itself, and the CRC32. */

--- a/tests/unit/tests/sskr_entry_lifecycle.c
+++ b/tests/unit/tests/sskr_entry_lifecycle.c
@@ -70,7 +70,7 @@ size_t bip39_mnemonic_length_get(void) { fail_msg("not on the removal path"); }
 size_t bip39_mnemonic_final_size_get(void) {
     fail_msg("not on the removal path");
 }
-bool compare_recovery_phrase(bool* reconstructed) {
+unsigned int compare_recovery_phrase(bool* reconstructed) {
     (void)reconstructed;
     fail_msg("not on the removal path");
 }

--- a/tests/unit/tests/sskr_multi_share_entry.c
+++ b/tests/unit/tests/sskr_multi_share_entry.c
@@ -72,7 +72,7 @@ size_t bip39_mnemonic_length_get(void) { fail_msg("not on the entry path"); }
 size_t bip39_mnemonic_final_size_get(void) {
     fail_msg("not on the entry path");
 }
-bool compare_recovery_phrase(bool* reconstructed) {
+unsigned int compare_recovery_phrase(bool* reconstructed) {
     (void)reconstructed;
     fail_msg("not on the entry path");
 }

--- a/tests/unit/tests/sskr_to_seed_convert.c
+++ b/tests/unit/tests/sskr_to_seed_convert.c
@@ -72,8 +72,9 @@ static void test_shards_convert_to_mnemonic_and_seed(void** state) {
     memset(words_buffer, 0x00, sizeof(words_buffer));
     memset(seed, 0x5A, sizeof(seed));
 
-    bolos_ux_sskr_to_seed_convert(shares, sizeof(shares), 2, words_buffer,
-                                  &words_buffer_length, seed);
+    assert_true(bolos_ux_sskr_to_seed_convert(shares, sizeof(shares), 2,
+                                              words_buffer,
+                                              &words_buffer_length, seed));
 
     /* The mnemonic length the encode step reported, propagated to the caller
      * and used as the length fed to the seed derivation. */


### PR DESCRIPTION
> **Stacked on #135.** The two touch the same function, so this branch is
> built on top of that one rather than beside it. Until #135 merges, the
> diff below also shows its commits. Review and merge that one first.

`bolos_ux_bip39_mnemonic_to_seed()` derives the 64 bytes the whole comparison
rests on, and threw away the only thing that says whether the derivation
happened.

The call does not look like it returns anything. `cx_pbkdf2_sha512` is a macro
(`lcx_pbkdf2.h`) over `cx_pbkdf2_no_throw(CX_SHA512, ...)`, which returns a
`cx_err_t` — and the SDK header states, right above that prototype, that it
deliberately does not mark the return `WARN_UNUSED_RESULT` because the "return
value is never checked". So nothing in a build points at a caller that drops it.

Of the two ways it can fail, only one is real here. `CX_INVALID_PARAMETER` wants
a NULL password, salt or output, and all three are stack arrays at this call
site. Everything else comes out of the 2048 rounds of HMAC-SHA512 underneath,
i.e. the hardware — the condition a fault-injection attempt sets out to create,
on the same code path as the verdict it wants to flip.

`cx_pbkdf2_hmac()` fills its output block by block, so a failure part way through
leaves the buffer partly derived and the rest untouched. Nothing downstream could
tell that from a seed: it was HMAC'd, compared against the device's root key, and
reported as "does not match".

The derivation now returns a `bool`, zeroing the 64 bytes before it reports
false, and the failure is propagated to `compare_recovery_phrase()`, where it is
treated exactly as a failed device derivation already is — no match, the entered
phrase left alone, both buffers erased.

## This changes no behaviour

Three reasons, in order of strength:

1. **On the path that succeeds — every path, in practice — the only difference is
   a comparison against `CX_OK`.** Nothing else is added before the HMAC.
2. **On the path that fails, the screen is the same.** Before: wrong seed → HMAC →
   root keys differ → "does not match". After: `goto cleanup` → no match. What
   changes is that it is a decision instead of a coincidence, and that nothing
   partly-derived reaches the HMAC.
3. **The two distinct diagnoses stay distinct.** "Shards unusable" and "does not
   match" are different screens. The `words_buffer_length == 0` check stays
   *ahead* of the derivation check on both UI stacks, so shards that never became
   a mnemonic are still reported as such. That is also why
   `bip39_mnemonic_from_sskr_shares()` takes an out-parameter rather than folding
   both answers into its return: folding them would report a failed derivation as
   unusable shares, which is the wrong thing to tell someone holding a set of
   shares that are perfectly good.

Checked by execution, not only by reading: the 71 pre-existing tests pass with
their assertions unchanged (four lines gain an `assert_true` around a call that
used to return nothing), and the Speculos buffer-erasure check was replayed end
to end on a flex build — full 12-word entry, genuine match path, both buffers
holding the independently recomputed root key right before erasure and reading
all-zero after.

## Measured

An out-of-tree reproducer, compiled twice — against `seed_bip39.c` as it is on
`bip85`, then against the fixed one — with a stub standing in for the hardware:

```
######## BEFORE ########
seed[] prefilled with 0x5A, standing in for whatever the caller had there
    [stub] cx_pbkdf2_no_throw() reports CX_INTERNAL_ERROR, writes nothing
    bolos_ux_bip39_mnemonic_to_seed() returns void -- the caller is told nothing
    seed[64] after the call: 64 bytes still 0x5A, 0 bytes zero
    -> the prefill travels on and gets HMAC'd as a seed

######## AFTER ########
    [stub] cx_pbkdf2_no_throw() reports CX_INTERNAL_ERROR, writes nothing
    bolos_ux_bip39_mnemonic_to_seed() returned false
    seed[64] after the call: 0 bytes still 0x5A, 64 bytes zero
    -> wiped; nothing to mistake for a seed
```

## Tests

`tests/unit/tests/bip39_seed_derivation_failure.c` is a new target that defines
`cx_pbkdf2_no_throw()` itself, overriding the SDK build of it that libtestutils
carries, and drives both directions: an error leaves the seed zeroed and reports
false, a success writes and reports true. A target of its own rather than more
cases in `tests/bip39.c`, because that override applies to the whole executable
and `tests/bip39.c` has to keep the real implementation for its published
vectors — where the true return is now asserted on each one.

```
ASan             warnings=18   72/72
UBSan            warnings=18   72/72
-O2              warnings= 0   72/72
-Os              warnings= 0   72/72
-fsigned-char    warnings=18   72/72
-funsigned-char  warnings=18   72/72
```

Six ARM targets, 0 warnings each. Two deliberate departures from the previous
counts:

* **72, not 71** — the new target.
* **18, not 19** — the `-Wunused-label` on `compare_recovery_phrase()`'s
  `cleanup:`, which only ever appeared in the one target that defines neither UI
  stack, is gone: the new check jumps to that label from outside the guarded
  block. The `CMakeLists.txt` comment that recorded that warning now says so, and
  says why its absence matters — if it comes back, the check has been moved back
  inside the guards, where a failed derivation on the other UI stack would stop
  being handled.

None of the 18 is in `src/`.

## Not covered

* The three other discarded returns (`cx_hash_sha512`, `cx_hash_sha256` twice,
  `cx_hmac_sha256`) are untouched: they return a `size_t`, not a `cx_err_t`.
* The new test does not exercise the real PBKDF2 — it cannot, it replaces it. The
  published vectors stay in `tests/unit/tests/bip39.c`.
* Nothing forces the failure on hardware. The stub stands in for a coprocessor
  failure; it does not prove one can be provoked.
