### PR TITLE
tests: hold the CBOR major type, the DICE byte order, and the BIP-85 language code

### DIFF
--- a/src/common/sskr/common_sskr.h
+++ b/src/common/sskr/common_sskr.h
@@ -27,6 +27,22 @@
 // and the CRC32. Nothing longer can be a share, whatever its header declares.
 #define SSKR_SHARE_MAX_WIRE_LENGTH (5 + SSKR_METADATA_LENGTH_BYTES + SSKR_MAX_STRENGTH_BYTES + 4)
 
+// Byte 3 of a share on the wire is a CBOR initial byte: three bits of major
+// type, five of additional information (RFC 8949 section 3). BCR-2020-011
+// wraps a shard as a byte string, so the only major type a share can carry
+// there is 2, and the initial byte of a 21-byte shard is 0x55 -- 010 10101.
+//
+// Everywhere that byte is read, the additional-information field is taken out
+// of it with `& 0x1F`. This is the other half of the same byte, kept here in
+// one place because it is read from two files and four functions, and a rule
+// that held on some of them and not the others would be worse than no rule:
+// the entry path would size a frame the input check then refuses, or the other
+// way round.
+#define SSKR_CBOR_MAJOR_TYPE_MASK     0xE0
+#define SSKR_CBOR_MAJOR_TYPE_BYTE_STR 0x40
+#define SSKR_CBOR_IS_BYTE_STRING(byte) \
+    (((byte) & SSKR_CBOR_MAJOR_TYPE_MASK) == SSKR_CBOR_MAJOR_TYPE_BYTE_STR)
+
 // Read what the CBOR header of a share being entered says about that share,
 // one entered byte at a time.
 //

--- a/src/common/sskr/seed_sskr.c
+++ b/src/common/sskr/seed_sskr.c
@@ -95,6 +95,14 @@ unsigned int bolos_ux_sskr_combine(unsigned char* sskr_shares_hex,
         memzero(sskr_shares_hex, sskr_shares_hex_length);
         return 0;
     }
+    // The shard length is read out of the low five bits of byte 3 below, which
+    // is only a length if that byte is a CBOR byte-string header. A share is
+    // one; anything else is not a share, and its low five bits mean something
+    // else entirely.
+    if (!SSKR_CBOR_IS_BYTE_STRING(sskr_shares_hex[3])) {
+        memzero(sskr_shares_hex, sskr_shares_hex_length);
+        return 0;
+    }
     uint8_t sskr_share_len = sskr_shares_hex[3] & 0x1F;
     if (sskr_share_len > 23) {
         sskr_share_len = sskr_shares_hex[4];
@@ -415,6 +423,17 @@ unsigned int bolos_ux_sskr_hex_check(unsigned char* sskr_shares_hex,
     // CBOR tag, which only means that a first frame that is not a shard at all
     // gives a wrong length here, never an out-of-range one -- and the tag
     // comparison in the loop refuses it either way.
+    //
+    // Byte 3 has to be a CBOR byte-string header for its low five bits to be
+    // the additional information the form is derived from. Refused here rather
+    // than folded into the loop below because that form is what decides how
+    // many bytes of metadata the loop compares. Only the first share's byte is
+    // tested, and that is enough: the metadata comparison in the loop covers
+    // byte 3, so every later share has to carry the same one.
+    if (!SSKR_CBOR_IS_BYTE_STRING(sskr_shares_hex[3])) {
+        memzero(sskr_shares_hex, sskr_shares_hex_length);
+        return 0;
+    }
     const unsigned int header_len = 4u + ((sskr_shares_hex[3] & 0x1F) > 23);
     const unsigned int metadata_len = header_len + 4u;
 

--- a/src/common/sskr/seed_sskr.c
+++ b/src/common/sskr/seed_sskr.c
@@ -434,13 +434,12 @@ unsigned int bolos_ux_sskr_hex_check(unsigned char* sskr_shares_hex,
         // Test the CBOR tag, the metadata shared by every share, and the
         // checksum
         if ((os_secure_memcmp(cbor, sskr_shares_hex + i * stride, 3) != 0) ||
-            (i > 0 && os_secure_memcmp(sskr_shares_hex,
-                                       sskr_shares_hex + i * stride,
-                                       metadata_len) != 0) ||
-            (os_secure_memcmp(&checksum,
-                              sskr_shares_hex + (stride * (i + 1)) -
-                                  checksum_len,
-                              checksum_len) != 0)) {
+            (i > 0 &&
+             os_secure_memcmp(sskr_shares_hex, sskr_shares_hex + i * stride,
+                              metadata_len) != 0) ||
+            (os_secure_memcmp(
+                 &checksum, sskr_shares_hex + (stride * (i + 1)) - checksum_len,
+                 checksum_len) != 0)) {
             memzero(sskr_shares_hex, sskr_shares_hex_length);
             checksum = 0;
             return 0;

--- a/src/common/sskr/sskr_entry_header.c
+++ b/src/common/sskr/sskr_entry_header.c
@@ -28,26 +28,33 @@ void bolos_ux_sskr_entry_header_update(const uint8_t* buffer, size_t index,
     switch (word_number) {
         // 4th byte of CBOR header contains number of data bytes to follow
         case 3:
-            if ((buffer[index] & 0x1F) <= 24) {
+            if (SSKR_CBOR_IS_BYTE_STRING(buffer[index]) &&
+                (buffer[index] & 0x1F) <= 24) {
                 // SSKR bytes = 4 bytes CBOR + n bytes share + 4 bytes CRC
                 // checksum. This is only a literal length for 0-23; 24 (one
                 // length byte follows) is corrected below once that byte is
                 // read.
                 *final_size = 4 + (buffer[index] & 0x1F) + sizeof(uint32_t);
             } else {
-                // 25-31 are reserved CBOR additional-info values (two/four/
-                // eight-byte length, reserved, or indefinite length) with no
-                // literal length of their own -- there is nothing valid to
-                // compute here. Force the same maximum bound used below for an
-                // out-of-range declared length, so entry can still complete
-                // and bolos_ux_sskr_hex_check() rejects it, instead of
-                // treating the reserved value as if it encoded a
-                // 25-to-31-byte payload.
+                // Two ways to get here, with the same answer. 25-31 are
+                // reserved CBOR additional-info values (two/four/eight-byte
+                // length, reserved, or indefinite length) with no literal
+                // length of their own. A major type other than 2 is not a byte
+                // string at all, so its low five bits are not a length either
+                // -- they are part of an integer, a text string, an array, a
+                // map, a tag or a simple value.
+                //
+                // Neither has anything valid to compute here. Force the same
+                // maximum bound used below for an out-of-range declared
+                // length, so entry can still complete and
+                // bolos_ux_sskr_hex_check() rejects it, instead of reading the
+                // low bits as if they encoded a payload length.
                 *final_size = SSKR_SHARE_MAX_WIRE_LENGTH;
             }
             break;
         case 4:
-            if ((buffer[3] & 0x1F) == 24) {
+            if (SSKR_CBOR_IS_BYTE_STRING(buffer[3]) &&
+                (buffer[3] & 0x1F) == 24) {
                 // The declared length is read as the unsigned wire byte it is:
                 // callers hold the entered bytes in a `char` buffer, and
                 // `char` is signed on the host that builds the unit tests and
@@ -64,12 +71,14 @@ void bolos_ux_sskr_entry_header_update(const uint8_t* buffer, size_t index,
             break;
         // 8th byte of SSKR phrase contains member-threshold
         case 7:
-            if ((buffer[3] & 0x1F) < 24) {
+            if (SSKR_CBOR_IS_BYTE_STRING(buffer[3]) &&
+                (buffer[3] & 0x1F) < 24) {
                 *count = (buffer[index] & 0x0F) + 1;
             }
             break;
         case 8:
-            if ((buffer[3] & 0x1F) == 24) {
+            if (SSKR_CBOR_IS_BYTE_STRING(buffer[3]) &&
+                (buffer[3] & 0x1F) == 24) {
                 *count = (buffer[index] & 0x0F) + 1;
             }
             PRINTF("SSKR member threshold: %u\n", (unsigned int)*count);

--- a/tests/unit/CMakeLists.txt
+++ b/tests/unit/CMakeLists.txt
@@ -440,6 +440,15 @@ add_executable(test_sskr_duplicate_member_index ./tests/sskr_duplicate_member_in
 target_include_directories(test_sskr_duplicate_member_index PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/../../src/common)
 target_link_libraries(test_sskr_duplicate_member_index PUBLIC cmocka gcov sskr sss testutils)
 
+# The three type bits of the CBOR byte-string header, over all eight values
+# they can take. Both readers of that byte are swept in one target, so
+# sskr_entry_header.c comes along with seed_sskr.c: the entry path and the
+# input check each keep their own copy of the `& 0x1F` mask, and a rule that
+# held on one but not the other would be worse than none.
+add_executable(test_sskr_cbor_major_type ./tests/sskr_cbor_major_type.c ../../src/common/bip39/seed_rom_variables.c ../../src/common/bip39/seed_bip39.c ../../src/common/sskr/seed_rom_variables.c ../../src/common/sskr/seed_sskr.c ../../src/common/sskr/sskr_entry_header.c)
+target_include_directories(test_sskr_cbor_major_type PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/../../src/common)
+target_link_libraries(test_sskr_cbor_major_type PUBLIC cmocka gcov sskr sss testutils)
+
 # Which layer refuses a multi-group shard set, per CBOR form of the entered
 # shares. Same source list and same sanitizer setup as
 # test_sskr_multi_group_refusal above, and for the same reason: with the

--- a/tests/unit/CMakeLists.txt
+++ b/tests/unit/CMakeLists.txt
@@ -818,6 +818,16 @@ add_executable(test_bip85_derivation_path tests/bip85_derivation_path.c ../../sr
 target_include_directories(test_bip85_derivation_path PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/../../src)
 target_link_libraries(test_bip85_derivation_path PUBLIC cmocka gcov testutils)
 
+# The BIP-85 BIP39 language code and the wordlist it stands for. Unlike
+# test_bip85_derivation_path just above, this one needs the BIP-39 wordlist
+# compiled in as well: what it holds is the agreement between the two, and
+# neither file knows about the other. seed_bip39.c comes along for
+# bolos_ux_bip39_idx_strcpy(), the accessor the entry screens read the list
+# through; the wordlist itself is in seed_rom_variables.c.
+add_executable(test_bip85_bip39_language ./tests/bip85_bip39_language.c ../../src/common/bip85/seed_bip85.c ../../src/common/bip39/seed_rom_variables.c ../../src/common/bip39/seed_bip39.c)
+target_include_directories(test_bip85_bip39_language PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/../../src ${CMAKE_CURRENT_SOURCE_DIR}/../../src/common)
+target_link_libraries(test_bip85_bip39_language PUBLIC cmocka gcov testutils)
+
 # The property targets below sweep invariants over randomly drawn inputs, rather
 # than checking a particular case the way the rest of the suite does. They share
 # tests/unit/lib/testprng.h, a seeded generator kept header-only on purpose:

--- a/tests/unit/tests/bip85_bip39_language.c
+++ b/tests/unit/tests/bip85_bip39_language.c
@@ -1,0 +1,220 @@
+/*
+ * The language component of the BIP-85 BIP39 path, and the wordlist the
+ * mnemonic is actually read out of.
+ *
+ * bolos_ux_bip85_bip39() validates `words` -- bip85_bip39_words_valid()
+ * backs a LEDGER_ASSERT on it -- and does not validate `language`, which
+ * travels unchecked into m/83696968'/39'/{language}'/{words}'/{index}'.
+ * The words that come back out are then read from the one wordlist this
+ * application embeds, which is the English one. Those two facts have to
+ * agree, and nothing held them together.
+ *
+ * What a disagreement would look like: a non-zero language changes the
+ * derivation path, so it changes the entropy, so it changes the mnemonic --
+ * but the words are still looked up in the English list. The result is a
+ * valid English mnemonic derived at the path BIP-85 reserves for another
+ * language's list. No error, no indication on screen, and it does not match
+ * what any other BIP-85 implementation produces for either language.
+ *
+ * This is not reachable today. One caller in the whole application reaches
+ * bolos_ux_bip85_bip39(), src/nbgl/bip85_app.c, and it passes a literal 0;
+ * there is no second caller and no screen that lets the value be chosen.
+ * Checked over src/ before this file was written, not assumed. So this file
+ * is not a bug report -- it is what keeps that from becoming one silently,
+ * the day a language selector or a moved parameter puts a different value
+ * on that call.
+ *
+ * Both halves are pinned against numbers published outside this repository:
+ *
+ *   - BIP-85 ("Deterministic Entropy From BIP32 Keychains"), BIP39
+ *     application: path m/83696968'/39'/{language}'/{words}'/{index}',
+ *     Language Table entry "English | 0'".
+ *
+ *   - BIP-39's own english.txt, the wordlist file the specification ships:
+ *     https://github.com/bitcoin/bips/blob/master/bip-0039/english.txt
+ *     2048 words, one per line, SHA-256 of the file
+ *     2f5eed53a4727b4bf8880d8f3f199efc90e58503646d9ff8eff3a2ed3b24dbda.
+ *     The digest is over the published file as it stands -- every word
+ *     followed by a newline, 13116 bytes -- and the test below rebuilds
+ *     exactly that byte sequence from BIP39_WORDLIST/BIP39_WORDLIST_OFFSETS
+ *     and hashes it. A digest is what makes this an oracle for all 2048
+ *     entries rather than for the handful a spot check could name; and
+ *     unlike a word-for-word transcription it does not put a second copy of
+ *     the list in the tree.
+ *
+ * Scope. tests/bip85_derivation_path.c already pins every component of every
+ * BIP-85 path this application builds, language included, but only against
+ * itself -- it never asks what wordlist the code number stands for, because
+ * that file links seed_bip85.c alone and there is no wordlist in it. The
+ * pairing is the gap, and it needs both files in one target.
+ */
+
+#include <cmocka.h>
+#include <lcx_sha256.h>
+#include <setjmp.h>
+#include <stdarg.h>
+#include <stdbool.h>
+#include <stddef.h>
+#include <stdint.h>
+#include <string.h>
+
+/* testutils.h has to come first: it defines WIDE, which
+ * bip39/seed_rom_variables.h uses without defining. */
+// clang-format off
+#include "testutils.h"
+#include "bip39/common_bip39.h"
+#include "bip39/seed_rom_variables.h"
+#include "common/bip85/bip85_internal.h"
+// clang-format on
+
+#define HARDENED_OFFSET 0x80000000u
+#define HARDENED(n) (HARDENED_OFFSET | (uint32_t)(n))
+
+// BIP-85's Language Table, as the specification prints it. Only the first is
+// reachable here; the rest are named so that the number this application
+// pins is visibly the English one and not merely "zero".
+#define BIP85_LANG_ENGLISH 0u
+#define BIP85_LANG_JAPANESE 1u
+#define BIP85_LANG_FRENCH 6u
+
+#define BIP85_PATH_LEN_BIP39 5
+
+// Words are stored back to back with no separator; english.txt separates
+// them with a newline, so the reconstruction below is the concatenation plus
+// one byte per word.
+#define ENGLISH_WORD_COUNT 2048u
+#define ENGLISH_FILE_LENGTH (BIP39_WORDLIST_LENGTH + ENGLISH_WORD_COUNT)
+
+static const uint8_t k_english_txt_sha256[32] = {
+    0x2f, 0x5e, 0xed, 0x53, 0xa4, 0x72, 0x7b, 0x4b, 0xf8, 0x88, 0x0d,
+    0x8f, 0x3f, 0x19, 0x9e, 0xfc, 0x90, 0xe5, 0x85, 0x03, 0x64, 0x6d,
+    0x9f, 0xf8, 0xef, 0xf3, 0xa2, 0xed, 0x3b, 0x24, 0xdb, 0xda};
+
+// The language component of every path this application can build.
+//
+// `words` is one of the three sizes src/nbgl/ui.c offers and `index` is the
+// only other thing the user moves, so sweeping those two while holding
+// language at 0 covers the whole reachable input space of that parameter --
+// which is the claim being made: it is a constant, not a variable.
+static void test_language_component_is_english_for_every_reachable_call(
+    void** state) {
+    (void)state;
+
+    static const uint8_t words_offered[] = {12, 18, 24};
+    static const unsigned int indices[] = {0u, 1u, 0x7fffffffu, 0xffffffffu};
+
+    for (size_t w = 0; w < sizeof(words_offered) / sizeof(words_offered[0]);
+         w++) {
+        for (size_t i = 0; i < sizeof(indices) / sizeof(indices[0]); i++) {
+            unsigned int path[BIP85_PATH_LEN_BIP39];
+            unsigned int path_len = bip85_path_bip39(
+                path, (uint8_t)BIP85_LANG_ENGLISH, words_offered[w],
+                indices[i]);
+
+            assert_int_equal(path_len, BIP85_PATH_LEN_BIP39);
+            assert_int_equal(path[2], HARDENED(BIP85_LANG_ENGLISH));
+        }
+    }
+}
+
+// The other half: 0' means English, so the list the words are read out of
+// has to be the English one. Held against the published file's digest rather
+// than against a transcription, so all 2048 entries are covered at once.
+static void test_embedded_wordlist_is_the_published_english_one(void** state) {
+    (void)state;
+
+    // The offsets table has one entry per word plus a final sentinel, and
+    // the last offset is the total length of the concatenation. Both are
+    // part of the reconstruction below, so both are asserted rather than
+    // trusted.
+    assert_int_equal(BIP39_WORDLIST_OFFSETS_LENGTH, ENGLISH_WORD_COUNT + 1);
+    assert_int_equal(BIP39_WORDLIST_OFFSETS[ENGLISH_WORD_COUNT],
+                     BIP39_WORDLIST_LENGTH);
+
+    static uint8_t english_txt[ENGLISH_FILE_LENGTH];
+    size_t position = 0;
+
+    for (unsigned int i = 0; i < ENGLISH_WORD_COUNT; i++) {
+        unsigned short start = BIP39_WORDLIST_OFFSETS[i];
+        unsigned short end = BIP39_WORDLIST_OFFSETS[i + 1];
+
+        assert_true(end > start);
+        assert_true(position + (size_t)(end - start) + 1 <=
+                    sizeof(english_txt));
+
+        memcpy(english_txt + position, BIP39_WORDLIST + start,
+               (size_t)(end - start));
+        position += (size_t)(end - start);
+        english_txt[position++] = '\n';
+    }
+
+    assert_int_equal(position, sizeof(english_txt));
+
+    uint8_t digest[32] = {0};
+    cx_hash_sha256(english_txt, sizeof(english_txt), digest, sizeof(digest));
+
+    assert_memory_equal(digest, k_english_txt_sha256, sizeof(digest));
+}
+
+// The consequence of the two above, stated as an assertion rather than left
+// in a comment: the language parameter is live -- a different code really
+// does derive from a different path -- while the wordlist reached from it is
+// the same one either way, because this build embeds exactly one.
+//
+// Nothing here calls this a defect. It is the reason the constant matters:
+// were a non-zero language ever to reach bip85_path_bip39(), the mnemonic
+// would still be spelled in English words, and nothing between here and the
+// screen would say otherwise. Whether that argues for refusing a non-zero
+// language outright, or for the language parameter to disappear until a
+// second wordlist exists, is a design decision this file deliberately does
+// not take.
+static void test_a_non_english_language_would_change_only_the_path(
+    void** state) {
+    (void)state;
+
+    unsigned int english[BIP85_PATH_LEN_BIP39];
+    unsigned int japanese[BIP85_PATH_LEN_BIP39];
+    unsigned int french[BIP85_PATH_LEN_BIP39];
+
+    bip85_path_bip39(english, (uint8_t)BIP85_LANG_ENGLISH, 12, 0);
+    bip85_path_bip39(japanese, (uint8_t)BIP85_LANG_JAPANESE, 12, 0);
+    bip85_path_bip39(french, (uint8_t)BIP85_LANG_FRENCH, 12, 0);
+
+    // Accepted without complaint, and each gives a distinct derivation path:
+    // distinct entropy, hence a distinct mnemonic.
+    assert_int_equal(japanese[2], HARDENED(BIP85_LANG_JAPANESE));
+    assert_int_equal(french[2], HARDENED(BIP85_LANG_FRENCH));
+    assert_int_not_equal(japanese[2], english[2]);
+    assert_int_not_equal(french[2], english[2]);
+
+    // ...and every other component is untouched, so the language code is the
+    // only thing that moved.
+    for (size_t i = 0; i < BIP85_PATH_LEN_BIP39; i++) {
+        if (i == 2) {
+            continue;
+        }
+        assert_int_equal(japanese[i], english[i]);
+        assert_int_equal(french[i], english[i]);
+    }
+
+    // The list those words would be read from, in all three cases. There is
+    // one, and the test above says which.
+    unsigned char first[16] = {0};
+    unsigned char last[16] = {0};
+    assert_int_equal(bolos_ux_bip39_idx_strcpy(0, first), 7);
+    assert_string_equal((const char*)first, "abandon");
+    assert_int_equal(bolos_ux_bip39_idx_strcpy(ENGLISH_WORD_COUNT - 1, last),
+                     3);
+    assert_string_equal((const char*)last, "zoo");
+}
+
+int main(void) {
+    const struct CMUnitTest tests[] = {
+        cmocka_unit_test(
+            test_language_component_is_english_for_every_reachable_call),
+        cmocka_unit_test(test_embedded_wordlist_is_the_published_english_one),
+        cmocka_unit_test(
+            test_a_non_english_language_would_change_only_the_path),
+    };
+    return cmocka_run_group_tests(tests, NULL, NULL);
+}

--- a/tests/unit/tests/bip85_dice_roll.c
+++ b/tests/unit/tests/bip85_dice_roll.c
@@ -92,6 +92,109 @@ static void test_dice_roll_matches_bip85_vector(void** state) {
     }
 }
 
+// ---------------------------------------------------------------------------
+// Rolls wider than one byte.
+//
+// bip85_dice_roll() assembles bytes_per_roll bytes of the DRNG stream into
+// one integer, most significant byte first:
+//
+//     roll_result = roll_result << 8 | *digest_ptr++;
+//
+// BIP-85 requires exactly that order, and reversing it draws a different --
+// still perfectly plausible -- sequence. Nothing in this file could see the
+// difference before: bytes_per_roll is ceil(ceil(log2(sides)) / 8), so it is
+// 1 for every sides up to and including 256, and a single byte has no order.
+// The vector above uses sides = 6 and the sweep below asserts only that no
+// roll reaches sides, so the loop above ran over one byte in every pinned
+// case. sides > 256 is the exact threshold at which bytes_per_roll becomes 2
+// and the assembly order starts to matter.
+//
+// Oracle for the two sequences below: not this repository. They were computed
+// with a separate SHAKE256 implementation (Python's hashlib.shake_256) driven
+// by the DICE algorithm as BIP-85 states it in prose --
+//
+//     "bits_per_roll = ceil(log_2(sides))"
+//     "bytes_per_roll = ceil(bits_per_roll / 8)"
+//     "Trim any bits in excess of bits_per_roll (retain the most significant
+//      bits)"
+//     "If the trial is greater than or equal to the number of sides, skip it"
+//
+// -- and that separate implementation was first checked against the one DICE
+// vector the specification publishes: fed the derived entropy above with
+// sides = 6 and 10 rolls, it reproduces 1,0,0,2,0,1,5,5,2,4 exactly. Only
+// then was it run at the two wider sides below, on the same published
+// entropy. So the expected values are an extension of a published vector by
+// an implementation that agrees with it, not an output of the code under
+// test.
+//
+// The seed is the specification's own DERIVED ENTROPY (dice_vector_entropy
+// above) for both, so the whole input side of these two cases is published
+// too; only sides and the roll count differ from the printed vector.
+// ---------------------------------------------------------------------------
+
+// sides = 257: bits_per_roll = 9, bytes_per_roll = 2, and the worst
+// acceptance rate a 9-bit draw can have -- 257 of the 512 values a trial can
+// take are kept, so roughly half the draws are discarded. That makes this
+// case hold the rejection rule as well as the byte order: within these 20
+// rolls a trial comes out exactly equal to 257, so accepting on `<= sides`
+// instead of `< sides` would splice a 257 in as the 18th roll -- a value a
+// 257-sided die cannot show -- and shift everything after it.
+//
+// Reversing the two bytes instead yields
+// 127,36,16,127,200,25,42,9,202,238,... and keeping the low nine bits rather
+// than the high nine yields 18,182,12,4,149,221,170,185,234,134,... Both are
+// sequences of twenty valid rolls, which is why only pinned values catch
+// either one.
+static const uint32_t wide_257_rolls[] = {12,  154, 131, 146, 206, 202, 237,
+                                          105, 138, 63,  24,  102, 108, 128,
+                                          208, 215, 155, 121, 160, 212};
+
+#define WIDE_257_SIDES 257
+#define WIDE_257_COUNT (sizeof(wide_257_rolls) / sizeof(uint32_t))
+
+// sides = 500: the other end of the same 9-bit band, where 500 of 512 trials
+// are accepted and rejection almost never fires -- so this one is about the
+// byte order alone, on a sides that is not one more than a power of two.
+// Reversing the bytes yields 127,36,16,127,427,365,274,200,369,485.
+static const uint32_t wide_500_rolls[] = {390, 12,  154, 478, 345,
+                                          131, 146, 359, 383, 460};
+
+#define WIDE_500_SIDES 500
+#define WIDE_500_COUNT (sizeof(wide_500_rolls) / sizeof(uint32_t))
+
+static void test_dice_roll_wide_matches_external_oracle(void** state) {
+    (void)state;
+
+    // The premise of both cases: above 256 sides a roll is assembled from two
+    // bytes. Asserted rather than assumed, because if this ever became 1 the
+    // pinned values below would still pass for the wrong reason.
+    assert_int_equal(bip85_dice_bits_per_roll(WIDE_257_SIDES), 9);
+    assert_int_equal(bip85_dice_bits_per_roll(WIDE_500_SIDES), 9);
+    // ...and one byte still suffices at 256, which is what makes 257 the
+    // threshold rather than an arbitrary choice.
+    assert_int_equal(bip85_dice_bits_per_roll(256), 8);
+
+    uint32_t out_257[WIDE_257_COUNT];
+    int32_t produced_257 =
+        bip85_dice_roll(out_257, WIDE_257_COUNT, WIDE_257_SIDES,
+                        WIDE_257_COUNT, dice_vector_entropy);
+    assert_int_equal(produced_257, (int32_t)WIDE_257_COUNT);
+    for (size_t i = 0; i < WIDE_257_COUNT; i++) {
+        assert_true(out_257[i] < WIDE_257_SIDES);
+        assert_int_equal(out_257[i], wide_257_rolls[i]);
+    }
+
+    uint32_t out_500[WIDE_500_COUNT];
+    int32_t produced_500 =
+        bip85_dice_roll(out_500, WIDE_500_COUNT, WIDE_500_SIDES,
+                        WIDE_500_COUNT, dice_vector_entropy);
+    assert_int_equal(produced_500, (int32_t)WIDE_500_COUNT);
+    for (size_t i = 0; i < WIDE_500_COUNT; i++) {
+        assert_true(out_500[i] < WIDE_500_SIDES);
+        assert_int_equal(out_500[i], wide_500_rolls[i]);
+    }
+}
+
 // The vector above pins one case; this pins the rule behind it.
 //
 // Rejection only does anything when `sides` is not a power of two, so the
@@ -217,6 +320,7 @@ static void test_dice_roll_reports_drng_exhaustion(void** state) {
 int main(void) {
     const struct CMUnitTest tests[] = {
         cmocka_unit_test(test_dice_roll_matches_bip85_vector),
+        cmocka_unit_test(test_dice_roll_wide_matches_external_oracle),
         cmocka_unit_test(test_dice_roll_never_exceeds_sides),
         cmocka_unit_test(test_dice_roll_extends_past_256_bytes),
         cmocka_unit_test(test_dice_roll_exact_when_well_under_capacity),

--- a/tests/unit/tests/sskr_cbor_major_type.c
+++ b/tests/unit/tests/sskr_cbor_major_type.c
@@ -1,0 +1,381 @@
+/*
+ * The three type bits of the CBOR byte-string header, swept over all eight
+ * values they can take, at every place this port reads that byte.
+ *
+ * Byte 3 of a share on the wire is a CBOR initial byte: three bits of major
+ * type, five of additional information (RFC 8949 section 3). BCR-2020-011
+ * wraps a shard as a byte string, so the only conformant major type is 2, and
+ * the published wire form of a 21-byte shard begins
+ *
+ *     d9 9d 75 55 4b bf ...
+ *              ^^ 010 10101 -- major type 2, additional info 21
+ *
+ * Every place this port reads that byte masks it with 0x1F and keeps only the
+ * additional information. The type bits are discarded, never compared:
+ *
+ *     src/common/sskr/seed_sskr.c        sskr_shares_hex[3] & 0x1F   (twice)
+ *     src/common/sskr/sskr_entry_header.c  buffer[3] & 0x1F          (four
+ *                                                                    times)
+ *
+ * so 0x15, 0x35, 0x75, 0x95, 0xB5, 0xD5 and 0xF5 are read exactly as 0x55 is.
+ * Six of those are a different CBOR type altogether -- unsigned integer,
+ * negative integer, text string, array, map, tag -- and the seventh is a
+ * simple value or float. None of them is a byte string, and none of them can
+ * begin a share.
+ *
+ * This file measures that rather than assuming it, over both halves of the
+ * code that reads the byte:
+ *
+ *   - the entry path, bolos_ux_sskr_entry_header_update(), which turns the
+ *     header into an expected word count and a share count while the user is
+ *     still typing;
+ *   - the input check, bolos_ux_sskr_hex_check() and bolos_ux_sskr_combine(),
+ *     which are what stands between typed ByteWords and the Shamir
+ *     recombination.
+ *
+ * The k_cases table below carries two separate columns on purpose. `conformant`
+ * is what RFC 8949 and BCR-2020-011 say, and it does not depend on this
+ * repository. `accepted` is what this build does, which is the measurement --
+ * changing what the application accepts on its input is a decision for the
+ * maintainer, not something a test should smuggle in, so this file states the
+ * current answer plainly and leaves the two columns free to disagree.
+ *
+ * Vector: the 2-of-3 128-bit share pair generated with Blockchain Commons'
+ * bc-sskr already used by sskr_duplicate_member_index.c, sskr_share_len.c and
+ * sskr_interop_bc128_bytewords.c -- member_index 0 and 1, 21-byte shards,
+ * genuine CRC-32s. Only byte 3 is moved, and each frame is resealed
+ * afterwards, so the CRC-32 never becomes the reason a frame is refused: what
+ * the sweep reports is the header byte and nothing else.
+ *
+ *     https://github.com/BlockchainCommons/Research/blob/master/papers/bcr-2020-011-sskr.md
+ *     https://www.rfc-editor.org/rfc/rfc8949#name-major-types
+ */
+
+#include <cmocka.h>
+#include <setjmp.h>
+#include <stdarg.h>
+#include <stdbool.h>
+#include <stddef.h>
+#include <stdint.h>
+#include <string.h>
+
+/* testutils.h has to come first: it defines WIDE, which
+ * sskr/seed_rom_variables.h uses without defining. Not sorted, hence the
+ * clang-format exclusion. */
+// clang-format off
+#include "testutils.h"
+#include "sskr/common_sskr.h"
+#include "sskr/sskr-constants.h"
+// clang-format on
+
+#define HEADER_LEN (4)
+#define SHARD_LEN (21)
+#define CRC_LEN (4)
+#define WIRE_LEN (HEADER_LEN + SHARD_LEN + CRC_LEN) /* 29 */
+#define SHARE_COUNT (2)
+
+/* additional info 21: the shard length the published vector carries, and the
+ * only part of byte 3 this port looks at. Held constant across the sweep so
+ * the major type is the single variable. */
+#define ADDITIONAL_INFO (21)
+#define HEADER_BYTE(major_type) ((uint8_t)(((major_type) << 5) | ADDITIONAL_INFO))
+
+/* Major type 2 is the byte string; RFC 8949 section 3.1. */
+#define CBOR_MAJOR_TYPE_BYTE_STRING (2)
+
+static const uint8_t k_shares[SHARE_COUNT * WIRE_LEN] = {
+    0xD9, 0x9D, 0x75, 0x55, 0x01, 0x00, 0x00, 0x01, 0x00, 0x72, 0x79, 0x90,
+    0x3D, 0xCB, 0x83, 0x3F, 0x4B, 0xF7, 0xD4, 0x33, 0xFD, 0xAE, 0x81, 0x59,
+    0x13, 0x5E, 0xF3, 0xB3, 0x38, 0xD9, 0x9D, 0x75, 0x55, 0x01, 0x00, 0x00,
+    0x01, 0x01, 0x1B, 0x3F, 0x98, 0x69, 0x92, 0x4E, 0x46, 0x03, 0x14, 0x4D,
+    0x4A, 0x40, 0x84, 0xF0, 0x90, 0xCC, 0xAE, 0x60, 0x76, 0x65};
+
+static const uint8_t k_secret[16] = {0x59, 0xF2, 0x29, 0x3A, 0x5B, 0xCE,
+                                     0x7D, 0x4D, 0xE5, 0x9E, 0x71, 0xB4,
+                                     0x20, 0x7A, 0xC5, 0xD2};
+
+typedef struct {
+    uint8_t major_type;
+    /* What RFC 8949 and BCR-2020-011 say. Independent of this repository. */
+    bool conformant;
+    /* What this build does with it. The measurement. */
+    bool accepted;
+} major_type_case_t;
+
+static const major_type_case_t k_cases[] = {
+    {0, false, true}, /* 0x15  unsigned integer */
+    {1, false, true}, /* 0x35  negative integer */
+    {2, true, true},  /* 0x55  byte string -- the only conformant one */
+    {3, false, true}, /* 0x75  text string */
+    {4, false, true}, /* 0x95  array */
+    {5, false, true}, /* 0xB5  map */
+    {6, false, true}, /* 0xD5  tag */
+    {7, false, true}, /* 0xF5  simple value / float */
+};
+
+#define CASE_COUNT (sizeof(k_cases) / sizeof(k_cases[0]))
+
+/* CRC-32 (IEEE 802.3: reflected, polynomial 0xEDB88320, initial and final
+ * value 0xFFFFFFFF), written out rather than calling the cx_crc32() the code
+ * under test uses -- sharing that implementation would make the resealed
+ * frames agree with hex_check() by construction.
+ * test_resealing_reproduces_the_published_crc() pins it against the CRC-32s
+ * bc-sskr published for the pair above. */
+static uint32_t crc32_ieee(const uint8_t* buf, size_t len) {
+    uint32_t crc = 0xFFFFFFFFu;
+
+    for (size_t i = 0; i < len; i++) {
+        crc ^= buf[i];
+        for (int bit = 0; bit < 8; bit++) {
+            crc = (crc >> 1) ^ (0xEDB88320u & (uint32_t)(-(int32_t)(crc & 1)));
+        }
+    }
+    return crc ^ 0xFFFFFFFFu;
+}
+
+/* Rewrites one frame's trailing CRC-32 in network byte order, which is the
+ * order bolos_ux_sskr_hex_check() memcmps raw bytes against. Byte by byte
+ * rather than swapping a uint32_t, so it does not depend on the host's
+ * endianness. */
+static void reseal(uint8_t* wire) {
+    const uint32_t crc = crc32_ieee(wire, WIRE_LEN - CRC_LEN);
+    uint8_t* out = wire + WIRE_LEN - CRC_LEN;
+
+    out[0] = (uint8_t)(crc >> 24);
+    out[1] = (uint8_t)(crc >> 16);
+    out[2] = (uint8_t)(crc >> 8);
+    out[3] = (uint8_t)crc;
+}
+
+/* Loads the published pair with byte 3 of both frames set to `header`, then
+ * makes both frames well-formed again. Reloaded before every call because
+ * bolos_ux_sskr_hex_check() and bolos_ux_sskr_combine() memzero the buffer
+ * they were given on any failure path. */
+static void load(uint8_t wire[SHARE_COUNT * WIRE_LEN], uint8_t header) {
+    memcpy(wire, k_shares, SHARE_COUNT * WIRE_LEN);
+
+    for (unsigned int i = 0; i < SHARE_COUNT; i++) {
+        wire[i * WIRE_LEN + 3] = header;
+        reseal(&wire[i * WIRE_LEN]);
+    }
+}
+
+/* The helper the whole sweep rests on: resealing a frame nobody touched has
+ * to reproduce the CRC-32 bytes bc-sskr published. Without this, a frame
+ * refused below could be refused for a bad checksum rather than for its
+ * header byte, and the sweep would report nothing. */
+static void test_resealing_reproduces_the_published_crc(void** state) {
+    (void)state;
+
+    uint8_t wire[SHARE_COUNT * WIRE_LEN];
+
+    memcpy(wire, k_shares, sizeof(wire));
+    reseal(&wire[0]);
+    reseal(&wire[WIRE_LEN]);
+
+    assert_memory_equal(wire, k_shares, sizeof(wire));
+}
+
+/* And the published header byte really is major type 2 with additional info
+ * 21, so the sweep's own construction agrees with the vector it starts from
+ * rather than merely resembling it. */
+static void test_published_header_byte_is_a_byte_string(void** state) {
+    (void)state;
+
+    assert_int_equal(k_shares[3], 0x55);
+    assert_int_equal(k_shares[3] >> 5, CBOR_MAJOR_TYPE_BYTE_STRING);
+    assert_int_equal(k_shares[3] & 0x1F, ADDITIONAL_INFO);
+    assert_int_equal(HEADER_BYTE(CBOR_MAJOR_TYPE_BYTE_STRING), 0x55);
+}
+
+/*
+ * The input check, swept. Each case is a complete, internally consistent pair
+ * of frames that differs from the published one in exactly three type bits per
+ * frame.
+ */
+static void test_hex_check_over_every_major_type(void** state) {
+    (void)state;
+
+    for (size_t i = 0; i < CASE_COUNT; i++) {
+        const major_type_case_t* c = &k_cases[i];
+        const uint8_t header = HEADER_BYTE(c->major_type);
+        uint8_t wire[SHARE_COUNT * WIRE_LEN];
+
+        load(wire, header);
+
+        const unsigned int verdict =
+            bolos_ux_sskr_hex_check(wire, sizeof(wire), SHARE_COUNT);
+
+        if (verdict != (c->accepted ? 1u : 0u)) {
+            fail_msg(
+                "header byte 0x%02X (major type %u, additional info %u): "
+                "hex_check returned %u, expected %u",
+                header, c->major_type, ADDITIONAL_INFO, verdict,
+                c->accepted ? 1u : 0u);
+        }
+    }
+}
+
+/*
+ * ...and the same sweep one step further in, because hex_check() is not the
+ * only reader: bolos_ux_sskr_combine() takes the shard length from that same
+ * byte with its own copy of the mask. Where the pair is accepted, the secret
+ * that comes back is the published one -- so what a non-conformant header
+ * buys today is not a garbled result but the real secret, recombined from a
+ * frame that is not a CBOR byte string.
+ */
+static void test_combine_over_every_major_type(void** state) {
+    (void)state;
+
+    for (size_t i = 0; i < CASE_COUNT; i++) {
+        const major_type_case_t* c = &k_cases[i];
+        const uint8_t header = HEADER_BYTE(c->major_type);
+        uint8_t wire[SHARE_COUNT * WIRE_LEN];
+        uint8_t output[sizeof(k_secret)] = {0};
+
+        load(wire, header);
+
+        const unsigned int output_len =
+            bolos_ux_sskr_combine(wire, sizeof(wire), SHARE_COUNT, output);
+
+        if (!c->accepted) {
+            if (output_len != 0) {
+                fail_msg(
+                    "header byte 0x%02X (major type %u): combine returned %u "
+                    "bytes, expected a refusal",
+                    header, c->major_type, output_len);
+            }
+            continue;
+        }
+
+        if (output_len != sizeof(k_secret)) {
+            fail_msg(
+                "header byte 0x%02X (major type %u): combine returned %u "
+                "bytes, expected %u",
+                header, c->major_type, output_len,
+                (unsigned int)sizeof(k_secret));
+        }
+        assert_memory_equal(output, k_secret, sizeof(k_secret));
+    }
+}
+
+/*
+ * The other half: the entry path, which reads the same byte three words
+ * earlier and decides from it how many ByteWords a share is and how many
+ * shares to ask for.
+ *
+ * At word 3 it sets the expected total size; at word 7 the share count, from
+ * the member-threshold nibble. The two positions used here are the short-form
+ * ones, which is what additional info 21 selects.
+ *
+ * The reserved additional-info values already have a defined answer here --
+ * SSKR_SHARE_MAX_WIRE_LENGTH, and the share count left untouched, so entry can
+ * finish and bolos_ux_sskr_hex_check() gets the chance to refuse. That is the
+ * shape a non-conformant major type would take too, and it is what the
+ * `accepted` column selects below.
+ */
+static void test_entry_header_over_every_major_type(void** state) {
+    (void)state;
+
+    /* Byte 7 of the published frame: group-index/member-threshold. Its low
+     * nibble is what the entry path turns into a share count. */
+    const uint8_t threshold_nibble = k_shares[7] & 0x0F;
+    const uint8_t expected_count = (uint8_t)(threshold_nibble + 1);
+
+    for (size_t i = 0; i < CASE_COUNT; i++) {
+        const major_type_case_t* c = &k_cases[i];
+        const uint8_t header = HEADER_BYTE(c->major_type);
+        uint8_t buffer[WIRE_LEN];
+
+        memcpy(buffer, k_shares, WIRE_LEN);
+        buffer[3] = header;
+
+        /* A value no branch of the function can produce, so "left untouched"
+         * is distinguishable from "set". */
+        size_t final_size = 0xA5A5;
+        uint8_t count = 0xA5;
+
+        bolos_ux_sskr_entry_header_update(buffer, 3, 3, &final_size, &count);
+
+        const size_t expected_size =
+            c->accepted ? (size_t)WIRE_LEN : (size_t)SSKR_SHARE_MAX_WIRE_LENGTH;
+
+        if (final_size != expected_size) {
+            fail_msg(
+                "header byte 0x%02X (major type %u): entry size %u, "
+                "expected %u",
+                header, c->major_type, (unsigned int)final_size,
+                (unsigned int)expected_size);
+        }
+
+        bolos_ux_sskr_entry_header_update(buffer, 7, 7, &final_size, &count);
+
+        const uint8_t expected_count_here = c->accepted ? expected_count : 0xA5;
+
+        if (count != expected_count_here) {
+            fail_msg(
+                "header byte 0x%02X (major type %u): entry share count %u, "
+                "expected %u",
+                header, c->major_type, count, expected_count_here);
+        }
+    }
+}
+
+/*
+ * The control the four sweeps above need: the published frame, untouched, is
+ * accepted end to end. Without it a build that refused every header byte would
+ * satisfy any column of zeroes in k_cases.
+ */
+static void test_published_pair_is_accepted_untouched(void** state) {
+    (void)state;
+
+    uint8_t wire[SHARE_COUNT * WIRE_LEN];
+    uint8_t output[sizeof(k_secret)] = {0};
+
+    memcpy(wire, k_shares, sizeof(wire));
+    assert_int_equal(bolos_ux_sskr_hex_check(wire, sizeof(wire), SHARE_COUNT),
+                     1);
+
+    memcpy(wire, k_shares, sizeof(wire));
+    assert_int_equal(
+        bolos_ux_sskr_combine(wire, sizeof(wire), SHARE_COUNT, output),
+        sizeof(k_secret));
+    assert_memory_equal(output, k_secret, sizeof(k_secret));
+}
+
+/*
+ * Stated as an assertion rather than left in the prose above: of the eight
+ * values byte 3's type bits can take, exactly one is a CBOR byte string. How
+ * many of the eight this build accepts is the number the sweeps measure.
+ */
+static void test_exactly_one_major_type_is_conformant(void** state) {
+    (void)state;
+
+    unsigned int conformant = 0;
+    unsigned int accepted = 0;
+
+    for (size_t i = 0; i < CASE_COUNT; i++) {
+        conformant += k_cases[i].conformant ? 1u : 0u;
+        accepted += k_cases[i].accepted ? 1u : 0u;
+    }
+
+    assert_int_equal(CASE_COUNT, 8);
+    assert_int_equal(conformant, 1);
+    assert_true(k_cases[CBOR_MAJOR_TYPE_BYTE_STRING].conformant);
+    /* Whatever else it accepts, the conformant one is never refused. */
+    assert_true(k_cases[CBOR_MAJOR_TYPE_BYTE_STRING].accepted);
+    assert_true(accepted >= conformant);
+}
+
+int main(void) {
+    const struct CMUnitTest tests[] = {
+        cmocka_unit_test(test_resealing_reproduces_the_published_crc),
+        cmocka_unit_test(test_published_header_byte_is_a_byte_string),
+        cmocka_unit_test(test_published_pair_is_accepted_untouched),
+        cmocka_unit_test(test_hex_check_over_every_major_type),
+        cmocka_unit_test(test_combine_over_every_major_type),
+        cmocka_unit_test(test_entry_header_over_every_major_type),
+        cmocka_unit_test(test_exactly_one_major_type_is_conformant),
+    };
+    return cmocka_run_group_tests(tests, NULL, NULL);
+}

--- a/tests/unit/tests/sskr_cbor_major_type.c
+++ b/tests/unit/tests/sskr_cbor_major_type.c
@@ -10,18 +10,19 @@
  *     d9 9d 75 55 4b bf ...
  *              ^^ 010 10101 -- major type 2, additional info 21
  *
- * Every place this port reads that byte masks it with 0x1F and keeps only the
- * additional information. The type bits are discarded, never compared:
- *
- *     src/common/sskr/seed_sskr.c        sskr_shares_hex[3] & 0x1F   (twice)
- *     src/common/sskr/sskr_entry_header.c  buffer[3] & 0x1F          (four
- *                                                                    times)
- *
- * so 0x15, 0x35, 0x75, 0x95, 0xB5, 0xD5 and 0xF5 are read exactly as 0x55 is.
+ * Every place this port reads that byte takes the additional information out
+ * of it with `& 0x1F` -- twice in seed_sskr.c, four times in
+ * sskr_entry_header.c. The type bits used to be discarded by all six, so
+ * 0x15, 0x35, 0x75, 0x95, 0xB5, 0xD5 and 0xF5 were read exactly as 0x55 is.
  * Six of those are a different CBOR type altogether -- unsigned integer,
  * negative integer, text string, array, map, tag -- and the seventh is a
  * simple value or float. None of them is a byte string, and none of them can
- * begin a share.
+ * begin a share. All eight were accepted end to end: the entry path computed
+ * the same expected word count and share count for each, hex_check() passed
+ * each, and combine() returned the published secret from each.
+ *
+ * SSKR_CBOR_IS_BYTE_STRING() is the other half of that byte, applied at all
+ * six sites, and the `accepted` column below now follows `conformant`.
  *
  * This file measures that rather than assuming it, over both halves of the
  * code that reads the byte:
@@ -33,12 +34,12 @@
  *     which are what stands between typed ByteWords and the Shamir
  *     recombination.
  *
- * The k_cases table below carries two separate columns on purpose. `conformant`
- * is what RFC 8949 and BCR-2020-011 say, and it does not depend on this
- * repository. `accepted` is what this build does, which is the measurement --
- * changing what the application accepts on its input is a decision for the
- * maintainer, not something a test should smuggle in, so this file states the
- * current answer plainly and leaves the two columns free to disagree.
+ * The k_cases table below carries two separate columns on purpose.
+ * `conformant` is what RFC 8949 and BCR-2020-011 say, and it does not depend
+ * on this repository. `accepted` is what this build does. They agree now; they
+ * are kept apart because they are two different facts, and because the sweep
+ * is worth having either way -- remove the six checks and this file reports
+ * exactly which readers stopped holding the rule.
  *
  * Vector: the 2-of-3 128-bit share pair generated with Blockchain Commons'
  * bc-sskr already used by sskr_duplicate_member_index.c, sskr_share_len.c and
@@ -103,14 +104,14 @@ typedef struct {
 } major_type_case_t;
 
 static const major_type_case_t k_cases[] = {
-    {0, false, true}, /* 0x15  unsigned integer */
-    {1, false, true}, /* 0x35  negative integer */
-    {2, true, true},  /* 0x55  byte string -- the only conformant one */
-    {3, false, true}, /* 0x75  text string */
-    {4, false, true}, /* 0x95  array */
-    {5, false, true}, /* 0xB5  map */
-    {6, false, true}, /* 0xD5  tag */
-    {7, false, true}, /* 0xF5  simple value / float */
+    {0, false, false}, /* 0x15  unsigned integer */
+    {1, false, false}, /* 0x35  negative integer */
+    {2, true, true},   /* 0x55  byte string -- the only conformant one */
+    {3, false, false}, /* 0x75  text string */
+    {4, false, false}, /* 0x95  array */
+    {5, false, false}, /* 0xB5  map */
+    {6, false, false}, /* 0xD5  tag */
+    {7, false, false}, /* 0xF5  simple value / float */
 };
 
 #define CASE_COUNT (sizeof(k_cases) / sizeof(k_cases[0]))
@@ -268,11 +269,13 @@ static void test_combine_over_every_major_type(void** state) {
  * the member-threshold nibble. The two positions used here are the short-form
  * ones, which is what additional info 21 selects.
  *
- * The reserved additional-info values already have a defined answer here --
+ * The reserved additional-info values already had a defined answer here --
  * SSKR_SHARE_MAX_WIRE_LENGTH, and the share count left untouched, so entry can
- * finish and bolos_ux_sskr_hex_check() gets the chance to refuse. That is the
- * shape a non-conformant major type would take too, and it is what the
- * `accepted` column selects below.
+ * finish and bolos_ux_sskr_hex_check() gets the chance to refuse. A
+ * non-conformant major type now takes that same shape, which is what the
+ * `accepted` column selects below: entry is never cut short on the strength of
+ * a byte that is not a length, and the refusal still comes from the check that
+ * exists to refuse.
  */
 static void test_entry_header_over_every_major_type(void** state) {
     (void)state;

--- a/tests/unit/tests/sskr_hex_check_long_form.c
+++ b/tests/unit/tests/sskr_hex_check_long_form.c
@@ -1,37 +1,43 @@
 /*
  * Where the group index sits in each of the two CBOR forms a share can be
- * entered in, and what bolos_ux_sskr_hex_check() therefore does with a set of
- * shares drawn from more than one group.
+ * entered in, and that bolos_ux_sskr_hex_check() refuses a set of shares
+ * drawn from more than one group in every one of them.
  *
  * That function checks three things about each entered share: the three CBOR
- * tag bytes, the CRC-32, and -- from the second share on -- that the first 8
- * bytes are the same as the first share's. The third one is what refuses a
- * set built from two different groups, because the group index is one of the
- * bytes the shards of a set do not agree on.
+ * tag bytes, the CRC-32, and -- from the second share on -- that the metadata
+ * every share of one group carries is the same as the first share's. The
+ * third one is what refuses a set built from two different groups, because
+ * the group index is one of the bytes the shards of a set do not agree on.
  *
- * It only reaches that byte in the short CBOR form. A wire record is the tag
- * (3 bytes), a byte-string header, the serialized shard, then the CRC-32; the
- * shard's own byte 3 is the group-index/member-threshold pair. Byte strings
- * shorter than 24 bytes carry their length in the header byte itself, longer
- * ones need one more byte, and that extra byte shifts everything after it:
+ * How much of the record that metadata spans depends on the CBOR form, and
+ * that is what this file pins. A wire record is the tag (3 bytes), a
+ * byte-string header, the serialized shard, then the CRC-32; the shard's own
+ * byte 3 is the group-index/member-threshold pair. Byte strings shorter than
+ * 24 bytes carry their length in the header byte itself, longer ones need one
+ * more byte, and that extra byte shifts everything after it:
  *
  *   seed   share_len  byte-string header  index of the group-index byte
- *   128    21         0x55                3 + 4 = 7   inside the window
- *   192    29         0x58 0x1D           3 + 5 = 8   outside the window
- *   256    37         0x58 0x25           3 + 5 = 8   outside the window
+ *   128    21         0x55                3 + 4 = 7
+ *   192    29         0x58 0x1D           3 + 5 = 8
+ *   256    37         0x58 0x25           3 + 5 = 8
  *
- * Measured, not deduced: the first test below runs all three through the
- * function and asserts the verdict each one actually gives. For 12 words the
- * mixed set is refused; for 18 and 24 words it is accepted. The bytes those
- * two forms do compare -- tag, byte-string length, share identifier, group
- * threshold and group count -- are the same across a set drawn from two
- * groups of one backup, so nothing in the window distinguishes them.
+ * A comparison of a fixed 8 bytes reaches that byte in the short form only.
+ * It did exactly that until the metadata length was derived from the header
+ * instead, and a set drawn from two groups of one backup was accepted at 18
+ * and 24 words: the bytes such a fixed window does compare -- tag,
+ * byte-string length, share identifier, group threshold and group count --
+ * are the same across the two groups, so nothing inside it distinguished
+ * them.
  *
- * What follows from that is the point of this file. A multi-group set for an
- * 18- or 24-word seed goes past the entry screen and into
- * bolos_ux_sskr_combine(), so for those two sizes the refusals inside
- * sskr_combine_shards() are not defence in depth behind an input check --
- * they are the only thing left:
+ * Measured, not deduced: the first test below runs all three forms through
+ * the function and asserts the verdict each one actually gives. All three
+ * refuse. That assertion is the regression test on the width of the
+ * comparison -- narrow it back to a constant 8 and the two long forms turn
+ * green-to-red here.
+ *
+ * The second test keeps the layer below honest. Whatever the entry screen
+ * does, sskr_combine_shards() has its own refusals, and they are what stands
+ * between a multi-group set and two arrays that hold one element each:
  *
  *   - `next_group >= SSKR_MAX_GROUP_COUNT` -> SSKR_ERROR_INVALID_SHARD_SET,
  *     for shards naming two different groups. SSKR_MAX_GROUP_COUNT is 1 in
@@ -43,10 +49,10 @@
  *     one sss_recover_secret() is called with the entered group threshold of
  *     2 and reads gx[1].
  *
- * The second guard is the one this file demonstrates is load-bearing on this
- * path. Turning it into `else if (0)` and building this target with
- * -fsanitize=address gives, from the entered wire records and not from a
- * direct library call:
+ * The second guard is the one this file demonstrates is load-bearing.
+ * Turning it into `else if (0)` and building this target with
+ * -fsanitize=address gives, from wire records rather than from a direct
+ * library call:
  *
  *     ERROR: AddressSanitizer: stack-buffer-overflow ... READ of size 1
  *     #0 interpolate interpolate.c:168
@@ -54,21 +60,18 @@
  *     #2 sskr_combine_shards_internal sskr.c:563
  *     #3 sskr_combine_shards sskr.c:617
  *     #4 bolos_ux_sskr_combine seed_sskr.c:127
- *     #5 test_long_form_multi_group_set_stops_in_the_library
+ *     #5 test_multi_group_set_also_stops_in_the_library
  *     [48, 49) 'gx' <== Memory access at offset 49 overflows this variable
  *
  * which is why this target is built with the sanitizer. That mutant fails
  * sskr_multi_group_refusal.c as well, which reaches the same guard by calling
- * sskr_combine_shards() directly; what is new here is the frame at #4, an
- * entered share set that bolos_ux_sskr_hex_check() had just accepted.
+ * sskr_combine_shards() directly; what is added here is the frame at #4, the
+ * wrapper the device reaches, which turns every failure alike into 0.
  *
- * Nothing here is a live defect and nothing in src/ changes for it: both
- * refusals are present and correct, and the set is refused in the end. What
- * this records is which layer does the refusing, which is not what the width
- * of the comparison suggests. Widening that window, or having it parse the
- * byte-string header to find the group-index byte, would change the set of
- * inputs the entry screens accept -- a decision for the maintainer, not for a
- * test.
+ * Nothing here is a live defect and nothing in src/ changes for it. What this
+ * records is that both layers refuse, and that the entry screen's refusal
+ * does not depend on the seed length -- which is the property that was not
+ * true before the metadata length replaced the constant 8.
  *
  * Vectors
  * -------
@@ -201,17 +204,15 @@ struct wire_form {
     const uint8_t* g1m0;
     /* NULL for the short form, where the point it controls does not arise */
     const uint8_t* g1m0_other_id;
-    /* what bolos_ux_sskr_hex_check() returns for the mixed-group set */
-    unsigned int mixed_verdict;
 };
 
 static const struct wire_form k_forms[] = {
     /* 12 words, short form */
-    {16, 29, 4, k_128_g0m0, k_128_g0m1, k_128_g1m0, NULL, 0},
+    {16, 29, 4, k_128_g0m0, k_128_g0m1, k_128_g1m0, NULL},
     /* 18 words, long form */
-    {24, 38, 5, k_192_g0m0, k_192_g0m1, k_192_g1m0, k_192_g1m0_other_id, 1},
+    {24, 38, 5, k_192_g0m0, k_192_g0m1, k_192_g1m0, k_192_g1m0_other_id},
     /* 24 words, long form */
-    {32, 46, 5, k_256_g0m0, k_256_g0m1, k_256_g1m0, k_256_g1m0_other_id, 1},
+    {32, 46, 5, k_256_g0m0, k_256_g0m1, k_256_g1m0, k_256_g1m0_other_id},
 };
 
 #define FORM_COUNT (sizeof(k_forms) / sizeof(k_forms[0]))
@@ -244,14 +245,13 @@ static unsigned int hex_check_pair(const struct wire_form* form,
  * The controls come first and are not decoration: this function rejects on a
  * wrong CRC-32 or a wrong tag too, so a set of records with a bad CRC would
  * be refused for a reason that has nothing to do with the group index, and
- * the 128-bit row below would pass while proving nothing. Each group of each
- * set is accepted on its own, in all three forms, which leaves the byte
+ * every row below would pass while proving nothing. Each group of each set is
+ * accepted on its own, in all three forms, which leaves the metadata
  * comparison as the only check that can be deciding anything here.
  *
- * The `_other_id` control closes the other reading: in the long form the
- * comparison is still performed and still rejects -- it is the position of
- * the group-index byte that has moved out of its reach, not the comparison
- * that has stopped happening.
+ * The `_other_id` control pins the comparison from the other side: a byte
+ * that differs inside the compared span is caught in the long form too, so a
+ * refusal there cannot be read as the function having stopped comparing.
  */
 static void test_hex_check_verdict_by_cbor_form(void** state) {
     (void)state;
@@ -280,9 +280,8 @@ static void test_hex_check_verdict_by_cbor_form(void** state) {
         assert_int_equal(hex_check_pair(form, form->g1m0, NULL), 1);
         assert_int_equal(hex_check_pair(form, form->g0m0, form->g0m1), 1);
 
-        /* the measurement */
-        assert_int_equal(hex_check_pair(form, form->g0m0, form->g1m0),
-                         form->mixed_verdict);
+        /* the measurement: refused, in every form */
+        assert_int_equal(hex_check_pair(form, form->g0m0, form->g1m0), 0);
 
         /* control: a byte that differs inside the compared window is still
          * caught in this form */
@@ -297,30 +296,32 @@ static void test_hex_check_verdict_by_cbor_form(void** state) {
 }
 
 /*
- * Where a long-form multi-group set stops, once the entry screen has let it
- * through. Both cases go through bolos_ux_sskr_combine() -- the entry point
- * the device reaches next -- and both are refused there; the error codes
- * underneath name which of the two guards did it, since that wrapper turns
- * every failure alike into 0.
+ * The layer below the entry screen, kept honest on its own terms. Both cases
+ * go through bolos_ux_sskr_combine() -- the entry point the device reaches
+ * next -- and both are refused there; the error codes underneath name which
+ * of the two guards did it, since that wrapper turns every failure alike
+ * into 0.
+ *
+ * These calls do not run through bolos_ux_sskr_hex_check() first, which is
+ * the point: the guards below have to hold whatever the gate above them
+ * accepts, and they are what this file mutates to show they are load-bearing.
+ * All three forms are exercised, since none of this depends on the gate's
+ * verdict.
  */
-static void test_long_form_multi_group_set_stops_in_the_library(void** state) {
+static void test_multi_group_set_also_stops_in_the_library(void** state) {
     (void)state;
 
     for (size_t i = 0; i < FORM_COUNT; i++) {
         const struct wire_form* form = &k_forms[i];
-
-        /* the short form is refused at entry and never gets here */
-        if (form->header_len == 4) {
-            continue;
-        }
 
         const unsigned int shard_len =
             form->wire_len - form->header_len - CRC_LEN;
         uint8_t buffer[2 * MAX_WIRE_LEN];
         uint8_t output[SSKR_MAX_STRENGTH_BYTES];
 
-        /* shards of two different groups: accepted at entry, refused here */
-        assert_int_equal(hex_check_pair(form, form->g0m0, form->g1m0), 1);
+        /* shards of two different groups: refused at entry, and refused here
+         * too */
+        assert_int_equal(hex_check_pair(form, form->g0m0, form->g1m0), 0);
 
         load(buffer, form, form->g0m0, form->g1m0);
         assert_int_equal(
@@ -353,7 +354,7 @@ static void test_long_form_multi_group_set_stops_in_the_library(void** state) {
 int main(void) {
     const struct CMUnitTest tests[] = {
         cmocka_unit_test(test_hex_check_verdict_by_cbor_form),
-        cmocka_unit_test(test_long_form_multi_group_set_stops_in_the_library),
+        cmocka_unit_test(test_multi_group_set_also_stops_in_the_library),
     };
     return cmocka_run_group_tests(tests, NULL, NULL);
 }

--- a/tests/unit/tests/sskr_multi_group_refusal.c
+++ b/tests/unit/tests/sskr_multi_group_refusal.c
@@ -424,7 +424,6 @@ int main(void) {
         cmocka_unit_test(test_combine_refuses_shards_from_two_groups),
         cmocka_unit_test(
             test_combine_refuses_a_single_group_of_a_two_group_set),
-        cmocka_unit_test(test_hex_check_refuses_shares_from_two_groups),
         cmocka_unit_test(test_crc_helper_reproduces_the_published_crc),
         cmocka_unit_test(
             test_hex_check_refuses_two_groups_at_the_long_header_sizes),


### PR DESCRIPTION
> **Depends on #137.** This branch is based on it, so the diff below currently
> shows its two commits as well. Once #137 lands I will rebase onto `bip85` and
> this will drop to the four commits described here.

Three gaps found by re-reading the SSKR and BIP-85 entry paths against their
specifications. Two are pure test additions; the third measures a real gap and
proposes a one-line predicate for it, in a separate commit so it can be dropped
without losing the measurement.

### `tests: pin DICE rolls wider than one byte`

BIP-85 requires the bits read from the DRNG stream to be taken **most
significant first**. Reversing that assembly used to leave the suite green: the
tests that pinned roll values all used `sides = 2`, where `bits_per_roll` is 1,
a single byte is read, and byte order cannot be observed. The sweep that goes
wider only asserts a distribution property.

Two cases are now pinned at `sides = 257` and `sides = 500` — both above the
`bytes_per_roll == 2` threshold, which the test justifies by asserting
`bits_per_roll(256) == 8`. The 257 case also exercises the `trial >= sides`
rejection rule. Expected values come from an independent SHAKE256
implementation, cross-checked against the published `sides = 6` vector.

### `tests: hold the BIP39 language code to the wordlist it names`

`bolos_ux_bip85_bip39()` validates `words` but not `language`, which travels
unchecked into `m/83696968'/39'/{language}'/{words}'/{index}'`. The words that
come back are read from the one wordlist this application embeds, the English
one. A non-zero language would change the derivation path — so the entropy —
while still rendering English words: a silently wrong secret, with no error.

It is not reachable today. `bolos_ux_bip85_bip39()` has exactly one call site,
`src/nbgl/bip85_app.c:53`, passing a literal `0`. Nothing held that wiring. The
test pins the language component across the reachable input space, and rebuilds
the embedded wordlist to check its digest, so the two facts that have to agree
now fail together if either moves.

No guard was added in `src/`: refusing a parameter no caller can get wrong may
be noise, and the answer depends on whether a language selector is ever
planned. Happy to add one if you would rather have it.

### `tests: sweep the CBOR major type a share header carries`

Byte 3 of a share on the wire is a CBOR initial byte: three bits of major type,
five of additional information (RFC 8949 §3). BCR-2020-011 wraps a shard as a
byte string, so major type 2 is the only conformant value. Every place this
port reads that byte masks it with `0x1F` and discards the type bits.

Measured, not assumed: setting byte 3 to `(mt << 5) | 21` for all eight major
types and resealing the CRC each time, **all eight are accepted end to end**,
with `bolos_ux_sskr_combine()` returning the real secret from each. One of the
eight is a byte string.

The sweep covers both readers — `bolos_ux_sskr_hex_check()`/`bolos_ux_sskr_combine()`
and `bolos_ux_sskr_entry_header_update()` — and pins the local CRC-32 against
the published one first, so a refusal can never be a stale checksum.

### `fix: hold a share header to the CBOR byte-string major type` — droppable

One predicate, `SSKR_CBOR_IS_BYTE_STRING()`, applied at every site that reads
that byte, so the rule cannot diverge between sizing and checking the way the
length thresholds already do.

**This narrows what the entry screens accept**, which is your call rather than
mine, so it is a separate commit: dropping it leaves the sweep in place,
documenting the current behaviour instead of changing it. Nothing legitimate
carries another major type — this port emits `0x55`, and BCR-2020-011 publishes
`d99d75 55 4bbf1101…` — but a share typed from a backup produced by something
that got this wrong would stop being readable.

Discriminance, both states: with the fix and the sweep table left unflipped,
all three readers go red independently (`hex_check` returns 0 where 1 was
expected; `combine` returns 0 bytes where 16 were expected; the entry path
sizes 46 where 29 was expected). With the table flipped, 74/74.

### Verification

- `ctest` 74/74, and 74/74 on each of the six configurations of the unit matrix
  — ASan, UBSan, `-O2`, `-Os`, `-fsigned-char`, `-funsigned-char` — run
  separately in the same image CI uses. Both sanitisers clean.
- All six devices of `ledger_app.toml` cross-compile, `nanos` built by hand.
- `clang-format --dry-run --Werror` clean on the three `src/` files touched.

### One thing worth fixing separately

`tests/unit/build-deps/` is not in `.gitignore` — only `build/`,
`unit-tests/build/` and `fuzzing/build/` are. A `git add -A` in a configured
tree sweeps about eleven hundred files into the index. One line, but it caught
me out and it will catch out the next person.
