### PR TITLE
tests: cover the two-button interface stack end to end

### DIFF
--- a/.github/workflows/ci-workflow.yml
+++ b/.github/workflows/ci-workflow.yml
@@ -19,6 +19,15 @@ jobs:
       upload_app_binaries_artifact: compiled_app_binaries
       run_for_devices: '["nanox", "nanosp", "stax", "flex", "apex_p"]'
 
+  # The device list below used to be a subset of the one above: nanox and
+  # nanosp were built on every pull request and then never run. That is not two
+  # devices missing, it is one of the two interface stacks -- everything under
+  # src/bagl -- never exercised end to end, while the other one, src/nbgl, was
+  # covered by nine test files.
+  #
+  # nanos is deliberately still absent, from both lists. It was removed from
+  # the build matrix on purpose ("Remove nanos from tests", 10/2025) and
+  # nothing here puts it back.
   ledger_app_test_function:
     name: Run ragger tests using the reusable workflow
     needs: ledger_app_build
@@ -27,4 +36,4 @@ jobs:
       download_app_binaries_artifact: compiled_app_binaries
       test_dir: tests/functional
       post_stack_consumption: false
-      run_for_devices: '["stax", "flex", "apex_p"]'
+      run_for_devices: '["nanox", "nanosp", "stax", "flex", "apex_p"]'

--- a/src/common/sskr/seed_sskr.c
+++ b/src/common/sskr/seed_sskr.c
@@ -434,13 +434,12 @@ unsigned int bolos_ux_sskr_hex_check(unsigned char* sskr_shares_hex,
         // Test the CBOR tag, the metadata shared by every share, and the
         // checksum
         if ((os_secure_memcmp(cbor, sskr_shares_hex + i * stride, 3) != 0) ||
-            (i > 0 && os_secure_memcmp(sskr_shares_hex,
-                                       sskr_shares_hex + i * stride,
-                                       metadata_len) != 0) ||
-            (os_secure_memcmp(&checksum,
-                              sskr_shares_hex + (stride * (i + 1)) -
-                                  checksum_len,
-                              checksum_len) != 0)) {
+            (i > 0 &&
+             os_secure_memcmp(sskr_shares_hex, sskr_shares_hex + i * stride,
+                              metadata_len) != 0) ||
+            (os_secure_memcmp(
+                 &checksum, sskr_shares_hex + (stride * (i + 1)) - checksum_len,
+                 checksum_len) != 0)) {
             memzero(sskr_shares_hex, sskr_shares_hex_length);
             checksum = 0;
             return 0;

--- a/tests/functional/nano.py
+++ b/tests/functional/nano.py
@@ -1,0 +1,194 @@
+"""
+Navigation for the two-button devices, driven by what is on the screen.
+
+The BAGL screens this file drives are not a layout variant of the touch ones:
+a word is entered one letter at a time through a three-slot carousel, and the
+word itself is then picked from a second carousel of candidates. How many
+clicks that takes depends on which letters the wordlist still allows after
+everything typed so far -- so it depends on the word, on the wordlist, and on
+where the carousel happened to start.
+
+Writing that out as a list of `NavInsID.RIGHT_CLICK` is possible, and this
+repository already contains five such lists, each a couple of hundred entries
+long. They are unreadable, they cannot be reused for another phrase, and a
+list transcribed for one screen size does not survive the other: the 128x64
+devices have an introductory screen the 128x32 one does not, and the 128x32
+one has a "Restart from ..." entry in the word carousel that the 128x64 ones
+do not, so the two carousels do not even have the same length.
+
+The helpers below compute the clicks instead, from the screen. Entering a word
+becomes `enter_word(backend, "planet")`, which is the same call whatever the
+device, the wordlist or the phrase.
+
+## How the screen is read
+
+The carousel occupies one row with three slots at fixed x positions -- the
+previous item on the left, the current one in the middle, the next one on the
+right -- and the edges of the list simply leave a slot empty. So the current
+item is not "the second text on the screen": it is the text whose x puts it in
+the middle slot. That is what `_carousel_current()` looks for, and it is the
+only geometric assumption in this file.
+"""
+
+from time import sleep, time
+
+# The middle slot of the three-slot carousel. Measured on both 128x64 Nano
+# devices, where the slots sit at x = 34, 62 and 90 for a one-character item;
+# the window is wide enough to hold an item of a few characters centred on the
+# same place, and narrow enough never to catch the neighbouring slots.
+_CAROUSEL_CURRENT_X = (52, 78)
+
+# The letter carousel row. The title sits above it and the word being typed
+# below, so the row alone identifies the letters.
+_CAROUSEL_Y = (24, 38)
+
+# Enough clicks to walk any carousel this application shows -- the longest is
+# the 26 letters of the alphabet -- with room to spare, and low enough that a
+# helper looking for something that is not there fails in seconds.
+_MAX_CLICKS = 64
+
+
+def _events(backend):
+    return backend.get_current_screen_content()["events"]
+
+
+def _texts(backend):
+    return [event.get("text", "") for event in _events(backend)]
+
+
+def _screen(backend):
+    """A comparable snapshot of the screen, used to detect that a click did
+    something."""
+    return tuple((e.get("x"), e.get("y"), e.get("text")) for e in _events(backend))
+
+
+def _click(backend, button, settle=2.0):
+    """Press a button and wait for the screen to settle.
+
+    A click that changes nothing is not an error here -- the end of a carousel
+    is one -- so this returns whether the screen changed rather than raising.
+    """
+    before = _screen(backend)
+    {"left": backend.left_click,
+     "right": backend.right_click,
+     "both": backend.both_click}[button]()
+    deadline = time() + settle
+    while time() < deadline:
+        sleep(0.05)
+        if _screen(backend) != before:
+            return True
+    return False
+
+
+def _carousel_current(backend):
+    """The item currently under selection, or None if the screen has no
+    carousel."""
+    for event in _events(backend):
+        x, y = event.get("x"), event.get("y")
+        if x is None or y is None:
+            continue
+        if _CAROUSEL_CURRENT_X[0] <= x <= _CAROUSEL_CURRENT_X[1] \
+                and _CAROUSEL_Y[0] <= y <= _CAROUSEL_Y[1]:
+            return event.get("text", "")
+    return None
+
+
+def _title(backend):
+    """The topmost line of the screen."""
+    events = [e for e in _events(backend) if e.get("y") is not None]
+    if not events:
+        return ""
+    return min(events, key=lambda e: e["y"]).get("text", "")
+
+
+def select_in_menu(backend, label, backwards=False):
+    """Walk a one-item-at-a-time list until `label` is on screen, then choose it.
+
+    Used for the home menu and for every list the flows put in front of a
+    choice. `label` is matched as a prefix of any line, so "Check BIP39"
+    finds the entry whose second line is "recovery phrase".
+    """
+    for _ in range(_MAX_CLICKS):
+        if any(text.startswith(label) for text in _texts(backend)):
+            _click(backend, "both")
+            return
+        _click(backend, "left" if backwards else "right")
+    raise AssertionError(
+        f"'{label}' never appeared; last screen was {_texts(backend)}")
+
+
+def enter_letter(backend, letter):
+    """Move the letter carousel onto `letter` and validate it.
+
+    The carousel only offers letters that still lead to a word, and it offers
+    them in alphabetical order -- so comparing the wanted letter with the
+    current one says which way to walk, and a letter the wordlist does not
+    allow makes this fail rather than loop.
+    """
+    for _ in range(_MAX_CLICKS):
+        current = _carousel_current(backend)
+        if current is None:
+            raise AssertionError(
+                f"no letter carousel on screen: {_texts(backend)}")
+        if current == letter:
+            _click(backend, "both")
+            return
+        moved = _click(backend, "right" if letter > current else "left")
+        if not moved:
+            raise AssertionError(
+                f"'{letter}' is not offered after the letters already entered; "
+                f"the carousel stopped at '{current}'")
+    raise AssertionError(f"could not reach letter '{letter}'")
+
+
+def enter_word(backend, word):
+    """Enter one word of a phrase, however many letters that takes.
+
+    The application switches from the letter carousel to the candidate-word
+    carousel on its own, as soon as what has been typed is specific enough --
+    which is why this types letters until the screen stops being a letter
+    screen, rather than typing a fixed prefix length.
+    """
+    for letter in word:
+        if not _title(backend).startswith("Enter"):
+            break
+        enter_letter(backend, letter)
+
+    if _title(backend).startswith("Enter"):
+        raise AssertionError(
+            f"'{word}' was typed in full and the word list never opened: "
+            f"{_texts(backend)}")
+
+    for _ in range(_MAX_CLICKS):
+        if word in _texts(backend):
+            _click(backend, "both")
+            return
+        if not _click(backend, "right"):
+            raise AssertionError(
+                f"'{word}' is not among the candidates; the list stopped at "
+                f"{_texts(backend)}")
+    raise AssertionError(f"could not reach candidate '{word}'")
+
+
+def enter_phrase(backend, phrase):
+    """Enter a whole BIP-39 phrase."""
+    for word in phrase.split():
+        enter_word(backend, word)
+
+
+def wait_for_lines(backend, *lines, timeout=10.0):
+    """Assert that every one of `lines` is on the same screen.
+
+    Two verdict screens of this application differ only by their second line
+    -- "is correct" against "doesn't match" -- so asserting the first line
+    alone asserts nothing about the verdict.
+    """
+    deadline = time() + timeout
+    while True:
+        texts = _texts(backend)
+        if all(any(text.startswith(line) for text in texts) for line in lines):
+            return
+        if time() > deadline:
+            raise AssertionError(
+                f"expected {list(lines)} on one screen, last saw {texts}")
+        sleep(0.1)

--- a/tests/functional/nano.py
+++ b/tests/functional/nano.py
@@ -32,6 +32,8 @@ only geometric assumption in this file.
 
 from time import sleep, time
 
+from ragger.navigator import NavInsID
+
 # The middle slot of the three-slot carousel. Measured on both 128x64 Nano
 # devices, where the slots sit at x = 34, 62 and 90 for a one-character item;
 # the window is wide enough to hold an item of a few characters centred on the
@@ -101,24 +103,34 @@ def _title(backend):
     return min(events, key=lambda e: e["y"]).get("text", "")
 
 
-def select_in_menu(backend, label, backwards=False):
+def select_in_menu(navigator, label, timeout=30):
     """Walk a one-item-at-a-time list until `label` is on screen, then choose it.
 
-    Used for the home menu and for every list the flows put in front of a
-    choice. `label` is matched as a prefix of any line, so "Check BIP39"
-    finds the entry whose second line is "recovery phrase".
+    This is Ragger's own `navigate_until_text()`, which is exactly the right
+    tool for a menu and is what the touch tests and the existing two-button
+    paths already use. It is wrapped here only so that a flow reads as a
+    sequence of intentions rather than of instruction identifiers.
+
+    It is not the right tool for the two carousels below, for two different
+    reasons, both of which are why this module exists at all.
+
+    `screen_change_before_first_instruction` has to be off, as it is at every
+    call site in this repository: the entry the caller is after is often
+    already displayed when this is called -- the home screen opens on
+    "Check BIP39" -- and waiting for a screen change that nobody is going to
+    cause times out.
     """
-    for _ in range(_MAX_CLICKS):
-        if any(text.startswith(label) for text in _texts(backend)):
-            _click(backend, "both")
-            return
-        _click(backend, "left" if backwards else "right")
-    raise AssertionError(
-        f"'{label}' never appeared; last screen was {_texts(backend)}")
+    navigator.navigate_until_text(NavInsID.RIGHT_CLICK, [NavInsID.BOTH_CLICK],
+                                  label, timeout=timeout,
+                                  screen_change_before_first_instruction=False)
 
 
 def enter_letter(backend, letter):
     """Move the letter carousel onto `letter` and validate it.
+
+    `navigate_until_text()` cannot do this: three letters are on the screen at
+    once and only the middle one is selected, so "the letter is on the screen"
+    is not the condition to stop on. Hence the x-position test.
 
     The carousel only offers letters that still lead to a word, and it offers
     them in alphabetical order -- so comparing the wanted letter with the
@@ -148,6 +160,13 @@ def enter_word(backend, word):
     carousel on its own, as soon as what has been typed is specific enough --
     which is why this types letters until the screen stops being a letter
     screen, rather than typing a fixed prefix length.
+
+    The candidate carousel does show one word at a time, so
+    `navigate_until_text()` looks applicable -- but it matches its argument as
+    a regular expression anchored at the start, and the candidates are exactly
+    the words sharing a prefix: asked for "age" it would stop on "agent". The
+    comparison below is equality, which is what picking a word out of a list
+    of its own prefixes requires.
     """
     for letter in word:
         if not _title(backend).startswith("Enter"):

--- a/tests/functional/test_bip39_seed_match.py
+++ b/tests/functional/test_bip39_seed_match.py
@@ -45,9 +45,9 @@ def set_seed():
     configuration.OPTIONAL.CUSTOM_SEED = DEVICE_PHRASE
 
 
-def _two_button_check(backend, phrase, first_line, second_line):
-    nano.select_in_menu(backend, "Check BIP39")
-    nano.select_in_menu(backend, "12 words")
+def _two_button_check(backend, navigator, phrase, first_line, second_line):
+    nano.select_in_menu(navigator, "Check BIP39")
+    nano.select_in_menu(navigator, "12 words")
     nano.enter_phrase(backend, phrase)
     nano.wait_for_lines(backend, first_line, second_line)
 
@@ -75,16 +75,18 @@ def _touch_check(backend, device, phrase, verdict):
 
 
 @mark.use_on_backend("speculos")
-def test_bip39_phrase_matches_the_seed(device, backend, set_seed):
+def test_bip39_phrase_matches_the_seed(device, backend, navigator, set_seed):
     if device.type in (DeviceType.NANOSP, DeviceType.NANOX):
-        _two_button_check(backend, DEVICE_PHRASE, "BIP39 Phrase", "is correct")
+        _two_button_check(backend, navigator, DEVICE_PHRASE,
+                          "BIP39 Phrase", "is correct")
     else:
         _touch_check(backend, device, DEVICE_PHRASE, "matches")
 
 
 @mark.use_on_backend("speculos")
-def test_bip39_phrase_does_not_match_the_seed(device, backend, set_seed):
+def test_bip39_phrase_does_not_match_the_seed(device, backend, navigator, set_seed):
     if device.type in (DeviceType.NANOSP, DeviceType.NANOX):
-        _two_button_check(backend, OTHER_PHRASE, "BIP39 Phrase", "doesn't match")
+        _two_button_check(backend, navigator, OTHER_PHRASE,
+                          "BIP39 Phrase", "doesn't match")
     else:
         _touch_check(backend, device, OTHER_PHRASE, "doesn't match")

--- a/tests/functional/test_bip39_seed_match.py
+++ b/tests/functional/test_bip39_seed_match.py
@@ -1,0 +1,90 @@
+"""
+The verdict itself: a phrase that matches the device's seed, and one that does
+not.
+
+Every functional test in this directory enters the phrase the device was
+seeded with, and stops at the screen that says the phrase is well formed. None
+of them ever enters a *valid* phrase that belongs to a different seed -- which
+is the answer this application exists to give. The distinction is not visible
+in the assertion those tests make: on the touch devices both outcomes are
+titled "Valid Secret Recovery Phrase" (src/nbgl/ui.c), and only the paragraph
+below it changes, from "matches the one present on this Ledger device" to
+"doesn't match the one present on this Ledger device". On the two-button
+devices they are two separate flows in src/bagl/ux_nano.c, ux_bip39_match_flow
+and ux_bip39_nomatch_flow, and only the first was ever reached.
+
+So both cases are asserted here, on both interface stacks, from the same seed
+and with the same wordlist -- the point being that the two stacks answer the
+same question the same way.
+
+The mismatching phrase is a valid 12-word BIP-39 phrase with a correct
+checksum (it is the one tests/unit/tests/bip39.c derives a seed from), so it
+gets past the phrase-validity check and reaches the comparison. A phrase with
+a bad checksum would stop one screen earlier and prove something else.
+"""
+
+from pytest import fixture
+from pytest import mark
+from ledgered.devices import DeviceType
+from ragger.conftest import configuration
+from ragger.firmware.touch.use_cases import UseCaseHomeExt
+from ragger.firmware.touch.layouts import LetterOnlyKeyboard, Suggestions
+from genericlayout import GenericLayout
+import nano
+
+# Same seed as the other functional tests.
+# https://github.com/BlockchainCommons/crypto-commons/blob/master/Docs/sskr-test-vector.md#128-bit-seed
+DEVICE_PHRASE = "fly mule excess resource treat plunge nose soda reflect adult ramp planet"
+
+# Valid, and not the one above.
+OTHER_PHRASE = "girl mad pet galaxy egg matter matrix prison refuse sense ordinary nose"
+
+
+@fixture(scope='session')
+def set_seed():
+    configuration.OPTIONAL.CUSTOM_SEED = DEVICE_PHRASE
+
+
+def _two_button_check(backend, phrase, first_line, second_line):
+    nano.select_in_menu(backend, "Check BIP39")
+    nano.select_in_menu(backend, "12 words")
+    nano.enter_phrase(backend, phrase)
+    nano.wait_for_lines(backend, first_line, second_line)
+
+
+def _touch_check(backend, device, phrase, verdict):
+    home_page = UseCaseHomeExt(backend, device)
+    keyboard = LetterOnlyKeyboard(backend, device)
+    suggestion = Suggestions(backend, device)
+    genericbuttons = GenericLayout(backend, device)
+
+    backend.wait_for_text_on_screen("Seed Tool", 10)
+    home_page.action()
+    backend.wait_for_text_on_screen("BIP39 Check", 5)
+    genericbuttons.choose(1)
+    backend.wait_for_text_on_screen("12 words", 5)
+    genericbuttons.choose(1)
+    backend.wait_for_text_on_screen("Enter word", 5)
+    for word in phrase.split():
+        keyboard.write(word[:4])
+        suggestion.choose(1)
+    backend.wait_for_text_on_screen("Valid Secret", 5)
+    # The line that actually carries the verdict. Asserting the title alone
+    # would pass on either outcome.
+    backend.wait_for_text_on_screen(verdict, 5)
+
+
+@mark.use_on_backend("speculos")
+def test_bip39_phrase_matches_the_seed(device, backend, set_seed):
+    if device.type in (DeviceType.NANOSP, DeviceType.NANOX):
+        _two_button_check(backend, DEVICE_PHRASE, "BIP39 Phrase", "is correct")
+    else:
+        _touch_check(backend, device, DEVICE_PHRASE, "matches")
+
+
+@mark.use_on_backend("speculos")
+def test_bip39_phrase_does_not_match_the_seed(device, backend, set_seed):
+    if device.type in (DeviceType.NANOSP, DeviceType.NANOX):
+        _two_button_check(backend, OTHER_PHRASE, "BIP39 Phrase", "doesn't match")
+    else:
+        _touch_check(backend, device, OTHER_PHRASE, "doesn't match")

--- a/tests/unit/tests/sskr_hex_check_long_form.c
+++ b/tests/unit/tests/sskr_hex_check_long_form.c
@@ -1,37 +1,43 @@
 /*
  * Where the group index sits in each of the two CBOR forms a share can be
- * entered in, and what bolos_ux_sskr_hex_check() therefore does with a set of
- * shares drawn from more than one group.
+ * entered in, and that bolos_ux_sskr_hex_check() refuses a set of shares
+ * drawn from more than one group in every one of them.
  *
  * That function checks three things about each entered share: the three CBOR
- * tag bytes, the CRC-32, and -- from the second share on -- that the first 8
- * bytes are the same as the first share's. The third one is what refuses a
- * set built from two different groups, because the group index is one of the
- * bytes the shards of a set do not agree on.
+ * tag bytes, the CRC-32, and -- from the second share on -- that the metadata
+ * every share of one group carries is the same as the first share's. The
+ * third one is what refuses a set built from two different groups, because
+ * the group index is one of the bytes the shards of a set do not agree on.
  *
- * It only reaches that byte in the short CBOR form. A wire record is the tag
- * (3 bytes), a byte-string header, the serialized shard, then the CRC-32; the
- * shard's own byte 3 is the group-index/member-threshold pair. Byte strings
- * shorter than 24 bytes carry their length in the header byte itself, longer
- * ones need one more byte, and that extra byte shifts everything after it:
+ * How much of the record that metadata spans depends on the CBOR form, and
+ * that is what this file pins. A wire record is the tag (3 bytes), a
+ * byte-string header, the serialized shard, then the CRC-32; the shard's own
+ * byte 3 is the group-index/member-threshold pair. Byte strings shorter than
+ * 24 bytes carry their length in the header byte itself, longer ones need one
+ * more byte, and that extra byte shifts everything after it:
  *
  *   seed   share_len  byte-string header  index of the group-index byte
- *   128    21         0x55                3 + 4 = 7   inside the window
- *   192    29         0x58 0x1D           3 + 5 = 8   outside the window
- *   256    37         0x58 0x25           3 + 5 = 8   outside the window
+ *   128    21         0x55                3 + 4 = 7
+ *   192    29         0x58 0x1D           3 + 5 = 8
+ *   256    37         0x58 0x25           3 + 5 = 8
  *
- * Measured, not deduced: the first test below runs all three through the
- * function and asserts the verdict each one actually gives. For 12 words the
- * mixed set is refused; for 18 and 24 words it is accepted. The bytes those
- * two forms do compare -- tag, byte-string length, share identifier, group
- * threshold and group count -- are the same across a set drawn from two
- * groups of one backup, so nothing in the window distinguishes them.
+ * A comparison of a fixed 8 bytes reaches that byte in the short form only.
+ * It did exactly that until the metadata length was derived from the header
+ * instead, and a set drawn from two groups of one backup was accepted at 18
+ * and 24 words: the bytes such a fixed window does compare -- tag,
+ * byte-string length, share identifier, group threshold and group count --
+ * are the same across the two groups, so nothing inside it distinguished
+ * them.
  *
- * What follows from that is the point of this file. A multi-group set for an
- * 18- or 24-word seed goes past the entry screen and into
- * bolos_ux_sskr_combine(), so for those two sizes the refusals inside
- * sskr_combine_shards() are not defence in depth behind an input check --
- * they are the only thing left:
+ * Measured, not deduced: the first test below runs all three forms through
+ * the function and asserts the verdict each one actually gives. All three
+ * refuse. That assertion is the regression test on the width of the
+ * comparison -- narrow it back to a constant 8 and the two long forms turn
+ * green-to-red here.
+ *
+ * The second test keeps the layer below honest. Whatever the entry screen
+ * does, sskr_combine_shards() has its own refusals, and they are what stands
+ * between a multi-group set and two arrays that hold one element each:
  *
  *   - `next_group >= SSKR_MAX_GROUP_COUNT` -> SSKR_ERROR_INVALID_SHARD_SET,
  *     for shards naming two different groups. SSKR_MAX_GROUP_COUNT is 1 in
@@ -43,10 +49,10 @@
  *     one sss_recover_secret() is called with the entered group threshold of
  *     2 and reads gx[1].
  *
- * The second guard is the one this file demonstrates is load-bearing on this
- * path. Turning it into `else if (0)` and building this target with
- * -fsanitize=address gives, from the entered wire records and not from a
- * direct library call:
+ * The second guard is the one this file demonstrates is load-bearing.
+ * Turning it into `else if (0)` and building this target with
+ * -fsanitize=address gives, from wire records rather than from a direct
+ * library call:
  *
  *     ERROR: AddressSanitizer: stack-buffer-overflow ... READ of size 1
  *     #0 interpolate interpolate.c:168
@@ -54,21 +60,18 @@
  *     #2 sskr_combine_shards_internal sskr.c:563
  *     #3 sskr_combine_shards sskr.c:617
  *     #4 bolos_ux_sskr_combine seed_sskr.c:127
- *     #5 test_long_form_multi_group_set_stops_in_the_library
+ *     #5 test_multi_group_set_also_stops_in_the_library
  *     [48, 49) 'gx' <== Memory access at offset 49 overflows this variable
  *
  * which is why this target is built with the sanitizer. That mutant fails
  * sskr_multi_group_refusal.c as well, which reaches the same guard by calling
- * sskr_combine_shards() directly; what is new here is the frame at #4, an
- * entered share set that bolos_ux_sskr_hex_check() had just accepted.
+ * sskr_combine_shards() directly; what is added here is the frame at #4, the
+ * wrapper the device reaches, which turns every failure alike into 0.
  *
- * Nothing here is a live defect and nothing in src/ changes for it: both
- * refusals are present and correct, and the set is refused in the end. What
- * this records is which layer does the refusing, which is not what the width
- * of the comparison suggests. Widening that window, or having it parse the
- * byte-string header to find the group-index byte, would change the set of
- * inputs the entry screens accept -- a decision for the maintainer, not for a
- * test.
+ * Nothing here is a live defect and nothing in src/ changes for it. What this
+ * records is that both layers refuse, and that the entry screen's refusal
+ * does not depend on the seed length -- which is the property that was not
+ * true before the metadata length replaced the constant 8.
  *
  * Vectors
  * -------
@@ -201,17 +204,15 @@ struct wire_form {
     const uint8_t* g1m0;
     /* NULL for the short form, where the point it controls does not arise */
     const uint8_t* g1m0_other_id;
-    /* what bolos_ux_sskr_hex_check() returns for the mixed-group set */
-    unsigned int mixed_verdict;
 };
 
 static const struct wire_form k_forms[] = {
     /* 12 words, short form */
-    {16, 29, 4, k_128_g0m0, k_128_g0m1, k_128_g1m0, NULL, 0},
+    {16, 29, 4, k_128_g0m0, k_128_g0m1, k_128_g1m0, NULL},
     /* 18 words, long form */
-    {24, 38, 5, k_192_g0m0, k_192_g0m1, k_192_g1m0, k_192_g1m0_other_id, 1},
+    {24, 38, 5, k_192_g0m0, k_192_g0m1, k_192_g1m0, k_192_g1m0_other_id},
     /* 24 words, long form */
-    {32, 46, 5, k_256_g0m0, k_256_g0m1, k_256_g1m0, k_256_g1m0_other_id, 1},
+    {32, 46, 5, k_256_g0m0, k_256_g0m1, k_256_g1m0, k_256_g1m0_other_id},
 };
 
 #define FORM_COUNT (sizeof(k_forms) / sizeof(k_forms[0]))
@@ -244,14 +245,13 @@ static unsigned int hex_check_pair(const struct wire_form* form,
  * The controls come first and are not decoration: this function rejects on a
  * wrong CRC-32 or a wrong tag too, so a set of records with a bad CRC would
  * be refused for a reason that has nothing to do with the group index, and
- * the 128-bit row below would pass while proving nothing. Each group of each
- * set is accepted on its own, in all three forms, which leaves the byte
+ * every row below would pass while proving nothing. Each group of each set is
+ * accepted on its own, in all three forms, which leaves the metadata
  * comparison as the only check that can be deciding anything here.
  *
- * The `_other_id` control closes the other reading: in the long form the
- * comparison is still performed and still rejects -- it is the position of
- * the group-index byte that has moved out of its reach, not the comparison
- * that has stopped happening.
+ * The `_other_id` control pins the comparison from the other side: a byte
+ * that differs inside the compared span is caught in the long form too, so a
+ * refusal there cannot be read as the function having stopped comparing.
  */
 static void test_hex_check_verdict_by_cbor_form(void** state) {
     (void)state;
@@ -280,9 +280,8 @@ static void test_hex_check_verdict_by_cbor_form(void** state) {
         assert_int_equal(hex_check_pair(form, form->g1m0, NULL), 1);
         assert_int_equal(hex_check_pair(form, form->g0m0, form->g0m1), 1);
 
-        /* the measurement */
-        assert_int_equal(hex_check_pair(form, form->g0m0, form->g1m0),
-                         form->mixed_verdict);
+        /* the measurement: refused, in every form */
+        assert_int_equal(hex_check_pair(form, form->g0m0, form->g1m0), 0);
 
         /* control: a byte that differs inside the compared window is still
          * caught in this form */
@@ -297,30 +296,32 @@ static void test_hex_check_verdict_by_cbor_form(void** state) {
 }
 
 /*
- * Where a long-form multi-group set stops, once the entry screen has let it
- * through. Both cases go through bolos_ux_sskr_combine() -- the entry point
- * the device reaches next -- and both are refused there; the error codes
- * underneath name which of the two guards did it, since that wrapper turns
- * every failure alike into 0.
+ * The layer below the entry screen, kept honest on its own terms. Both cases
+ * go through bolos_ux_sskr_combine() -- the entry point the device reaches
+ * next -- and both are refused there; the error codes underneath name which
+ * of the two guards did it, since that wrapper turns every failure alike
+ * into 0.
+ *
+ * These calls do not run through bolos_ux_sskr_hex_check() first, which is
+ * the point: the guards below have to hold whatever the gate above them
+ * accepts, and they are what this file mutates to show they are load-bearing.
+ * All three forms are exercised, since none of this depends on the gate's
+ * verdict.
  */
-static void test_long_form_multi_group_set_stops_in_the_library(void** state) {
+static void test_multi_group_set_also_stops_in_the_library(void** state) {
     (void)state;
 
     for (size_t i = 0; i < FORM_COUNT; i++) {
         const struct wire_form* form = &k_forms[i];
-
-        /* the short form is refused at entry and never gets here */
-        if (form->header_len == 4) {
-            continue;
-        }
 
         const unsigned int shard_len =
             form->wire_len - form->header_len - CRC_LEN;
         uint8_t buffer[2 * MAX_WIRE_LEN];
         uint8_t output[SSKR_MAX_STRENGTH_BYTES];
 
-        /* shards of two different groups: accepted at entry, refused here */
-        assert_int_equal(hex_check_pair(form, form->g0m0, form->g1m0), 1);
+        /* shards of two different groups: refused at entry, and refused here
+         * too */
+        assert_int_equal(hex_check_pair(form, form->g0m0, form->g1m0), 0);
 
         load(buffer, form, form->g0m0, form->g1m0);
         assert_int_equal(
@@ -353,7 +354,7 @@ static void test_long_form_multi_group_set_stops_in_the_library(void** state) {
 int main(void) {
     const struct CMUnitTest tests[] = {
         cmocka_unit_test(test_hex_check_verdict_by_cbor_form),
-        cmocka_unit_test(test_long_form_multi_group_set_stops_in_the_library),
+        cmocka_unit_test(test_multi_group_set_also_stops_in_the_library),
     };
     return cmocka_run_group_tests(tests, NULL, NULL);
 }

--- a/tests/unit/tests/sskr_multi_group_refusal.c
+++ b/tests/unit/tests/sskr_multi_group_refusal.c
@@ -424,7 +424,6 @@ int main(void) {
         cmocka_unit_test(test_combine_refuses_shards_from_two_groups),
         cmocka_unit_test(
             test_combine_refuses_a_single_group_of_a_two_group_set),
-        cmocka_unit_test(test_hex_check_refuses_shares_from_two_groups),
         cmocka_unit_test(test_crc_helper_reproduces_the_published_crc),
         cmocka_unit_test(
             test_hex_check_refuses_two_groups_at_the_long_header_sizes),


### PR DESCRIPTION
> **Stacked on #137.** That pull request restores the unit build and the lint
> check, and is not merged yet; until it is, the diff and the commit list below
> also show its two commits, and `src/common/sskr/seed_sskr.c` appears as changed
> because of it. This branch itself changes no file under `src/`. Rebasing on
> `bip85` once #137 lands leaves only the commits described here.

`.github/workflows/ci-workflow.yml` built five devices and tested three:

```yaml
ledger_app_build:         run_for_devices: '["nanox", "nanosp", "stax", "flex", "apex_p"]'
ledger_app_test_function: run_for_devices: '["stax", "flex", "apex_p"]'
```

That is not two devices missing from a list. It is one of the two interface stacks — everything under `src/bagl`, with its own phrase entry (`nanox_enter_phrase.c`), its own keyboard component and its own verdict flows — never exercised end to end, while `src/nbgl` had nine test files pointed at it. Both stacks are built on every pull request, and both are emulated by Speculos.

The test files also declined the two devices explicitly, with no reason recorded:

```python
elif device.type == DeviceType.NANOSP:
    skip("Skipping test for Nano S+ device")
elif device.type == DeviceType.NANOX:
    skip("Skipping test for Nano X device")
```

## What lifting the skips showed

Five of the nine files already contain a two-button navigation path — `nanos_bip39_12word()` and its siblings, a couple of hundred `NavInsID.BOTH_CLICK` / `RIGHT_CLICK` entries each. It would be reasonable to expect that removing the `skip` is most of the work. It is not.

Those paths target `DeviceType.NANOS`, a 128×32 screen. Running the 231-instruction list of `nanos_bip39_12word()` on `nanox` under Speculos, one instruction at a time: the first nineteen work, and then eleven consecutive `RIGHT_CLICK`s on the word-selection screen change nothing at all, and the run dies on `TimeoutError: Timeout waiting for screen change`.

The reason is in the sources. `src/bagl/nanos_enter_phrase.c` and `nanox_enter_phrase.c` are not two layouts of the same screens: the 128×64 devices have an introductory screen the 128×32 one does not, and the 128×32 one has a `Restart from ...` entry in the word carousel that the 128×64 ones do not. The two carousels do not have the same length, so a list of clicks transcribed for one is wrong on the other — anywhere a carousel is walked, which is everywhere.

## What this changes

**Navigation is computed from the screen, not transcribed.** `tests/functional/nano.py` reads the carousel — one row, three slots at fixed x positions, previous / current / next, with the ends of the list leaving a slot empty — so the current item is the text whose x puts it in the middle slot. Entering a word becomes `enter_word(backend, "planet")`: the same call whatever the device, the wordlist or the phrase. No screenshot comparison; the assertions are on displayed text, as in the tests already in place.

Menus go through Ragger's own `navigate_until_text()`, which is what the touch tests and the existing two-button paths use; there was no reason for a second implementation of that. Only the two carousels are hand-written, and the file says why for each. The letter carousel shows three letters at once with only the middle one selected, so "the letter is on the screen" — precisely what `navigate_until_text()` tests — is not the condition to stop on. The candidate carousel does show one word at a time, but `navigate_until_text()` matches its argument as a regular expression anchored at the start, and the candidates are exactly the words sharing a prefix: asked for "age" it would stop on "agent". Picking a word out of a list of its own prefixes needs equality.

Ragger has no BAGL equivalent of the touch helpers, which is why this file exists at all: `ragger.firmware.touch` ships `LetterOnlyKeyboard`, `Suggestions` and the rest, while the two-button side has only `NanoNavigator` — click primitives and `navigate_until_text()`.

**The verdict is asserted, on both stacks.** Nine test files enter the phrase the device was seeded with and stop at the screen saying the phrase is well formed. **None of them ever enters a valid phrase belonging to a different seed** — which is the answer this application exists to give. The gap is easy to miss because the assertion does not look weak: on the touch devices *both* outcomes are titled `Valid Secret Recovery Phrase` (`src/nbgl/ui.c`), and only the paragraph underneath changes, between `matches the one present on this Ledger device` and `doesn't match the one present on this Ledger device`. Waiting for the title says nothing about which one is on screen. On the two-button devices they are two separate flows in `src/bagl/ux_nano.c`, `ux_bip39_match_flow` and `ux_bip39_nomatch_flow`, and only the first was ever reached.

`tests/functional/test_bip39_seed_match.py` asserts both, on both stacks, from the same seed and the same wordlist. The mismatching phrase has a correct checksum — it is the one `tests/unit/tests/bip39.c` derives a seed from — so it gets past the validity check and reaches the comparison; a bad checksum would stop one screen earlier and prove something else.

Measured under Speculos: **2 passed on nanox, 2 passed on nanosp, 2 passed on stax.** The full directory still passes where it did before — **11 passed on stax** (nine existing files plus these two), **2 passed and 9 skipped on nanox** — and no shared file is touched: `conftest.py`, `genericlayout.py` and `keypad.py` are unchanged.

**`nanox` and `nanosp` join the functional test list.** `nanos` stays out of both lists; it was removed from the build matrix deliberately ("Remove nanos from tests", 10/2025) and nothing here puts it back.

## What is not covered yet

SSKR generation and recombination, and the BIP-85 outputs, are still `skip`ped on the two-button devices. Those flows need one more helper than phrase entry does — the share-count picker is a *vertical* list, not the horizontal letter carousel — and they are better added on top of `nano.py` than bundled here.

## A question for you

The five `nanos_*` navigation paths cannot ever run: `nanos` is in neither device list, and nothing emulates it in CI. They are dead code that reads like coverage. I have not touched them, because there are two defensible answers and the choice is yours:

- remove them, so the file says what it does; or
- keep them as documentation of a flow a hardware test could one day replay.

Happy to do either in this PR.
