### PR TITLE
fix: wipe the HMAC context and hold the BIP85 DRNG to its specified seed length

### DIFF
--- a/src/common/bip85/seed_bip85.c
+++ b/src/common/bip85/seed_bip85.c
@@ -219,16 +219,24 @@ bool bip85_entropy_from_key(const uint8_t key[32], uint8_t* out,
                             size_t out_len) {
     cx_hmac_sha512_t ctx;
     const char hmac_key[] = "bip-entropy-from-k";
+    bool result = false;
 
     if (cx_hmac_sha512_init_no_throw(&ctx, (const uint8_t*)hmac_key,
                                      strlen(hmac_key)) != CX_OK) {
-        return false;
+        goto cleanup;
     }
     if (cx_hmac_no_throw((cx_hmac_t*)&ctx, CX_LAST, key, 32, out, out_len) !=
         CX_OK) {
-        return false;
+        goto cleanup;
     }
-    return true;
+    result = true;
+
+cleanup:
+    // `ctx` carries the HMAC padding blocks and the running SHA-512 state over
+    // the root key it was just fed. Wiped on every exit, the way this module
+    // already wipes every entropy buffer it puts on the stack.
+    explicit_bzero(&ctx, sizeof(ctx));
+    return result;
 }
 #endif  // HAVE_HMAC
 

--- a/src/common/bip85/seed_bip85.c
+++ b/src/common/bip85/seed_bip85.c
@@ -169,15 +169,35 @@ int32_t bip85_dice_roll(uint32_t* out, size_t out_capacity, uint32_t sides,
  * @param[out] digest         Pointer to the buffer to store the generated
  * digest.
  * @param[in]  digest_length  Length of the digest in bytes.
- * @param[in]  seed           Pointer to the seed data.
+ * @param[in]  seed           Pointer to the seed data. Must be
+ * `BIP85_ENTROPY_LENGTH` bytes.
  * @param[in]  seed_length    Length of the seed data in bytes.
  *
- * @return 1 on success, 0 on failure.
+ * @return `true` on success, `false` if `seed_length` is not
+ * `BIP85_ENTROPY_LENGTH`, or if the SHAKE256 call failed.
  */
 bool bolos_ux_bip85_drng_with_seed(uint8_t* seed, size_t seed_length,
                                    uint8_t* digest, size_t digest_length) {
     LEDGER_ASSERT(digest_length <= BIP85_DRNG_MAX_DIGEST_SIZE,
                   "BIP85 DRNG digest length exceeds maximum");
+
+    // BIP-85 defines the DRNG as SHAKE256 over the BIP85 HMAC output and is
+    // explicit that its input must be exactly 64 bytes. Any other length
+    // still produces a well-formed SHAKE256 stream, just not the one the
+    // specification defines -- so the digest length was bounded here while
+    // the seed length was not.
+    //
+    // Reported rather than asserted, unlike `digest_length` one line above.
+    // That one bounds a write into the caller's buffer, where an out-of-range
+    // value is a memory error and stopping is the safe answer; a wrong
+    // `seed_length` only yields a wrong result. `false` is already this
+    // function's error channel for the SHAKE256 failure below, and it is a
+    // form a test can reach, which LEDGER_ASSERT is not on the host build.
+    if (seed_length != BIP85_ENTROPY_LENGTH) {
+        PRINTF("BIP85 DRNG seed is not %u bytes\n", BIP85_ENTROPY_LENGTH);
+        return false;
+    }
+
     if (cx_shake256_hash(seed, seed_length, digest, digest_length) != CX_OK) {
         PRINTF("SHAKE256 hash error\n");
         return 0;

--- a/src/common/common_seed.c
+++ b/src/common/common_seed.c
@@ -229,6 +229,14 @@ unsigned int compare_recovery_phrase(bool* reconstructed) {
     LEDGER_ASSERT(cx_hmac_no_throw((cx_hmac_t*)&ctx, CX_LAST, buffer, 64,
                                    buffer, 64) == CX_OK,
                   "HMAC failed");
+
+    // `ctx` carries the HMAC padding blocks and the running SHA-512 state over
+    // the 64 seed bytes it was just fed. It is dead from here on, and the
+    // function leaves by `return` a few lines below without passing the
+    // `cleanup:` label, so it is wiped here rather than there -- the same way
+    // `buffer` and `buffer_device` are wiped on every path out.
+    memzero(&ctx, sizeof(ctx));
+
     PRINTF("Root key from input: 64 bytes\n");
 
     // get rootkey from device's seed

--- a/src/nbgl/ui.c
+++ b/src/nbgl/ui.c
@@ -754,6 +754,24 @@ static void bip85_index_validate(const uint8_t* indexentry, uint8_t length) {
     }
     PRINTF("BIP85 index entered is '%d'\n", bip85_index_get());
 
+    // The bound below and the message on the else branch are two different
+    // numbers on purpose, so neither is a typo for the other.
+    //
+    // `UINT32_MAX >> 1` is what the derivation needs: the index goes into a
+    // hardened BIP32 path component as `0x80000000 | index`, so anything that
+    // does not fit in 31 bits would run into the hardening bit.
+    //
+    // The keypad above (`display_bip85_select_index_page()`) caps entry at
+    // `BIP85_INDEX_MAX_NUMBER_LENGTH` digits, so the largest value that can
+    // reach this function is 9,999,999 -- well inside 31 bits, and far too
+    // small for the `10 * index + digit` accumulation to overflow the
+    // `uint32_t` it runs in. The else branch is therefore unreachable from
+    // the screens, and the check is kept as a guard on the derivation
+    // precondition rather than on the entry.
+    //
+    // The message states the keypad's limit rather than the 31-bit one
+    // because it is addressed to whoever is typing, and 9,999,999 is what
+    // they can actually enter.
     if (bip85_index_get() <= (UINT32_MAX >> 1)) {
         switch (bip85_type_get()) {
             case BIP85_APP_BIP39:

--- a/tests/unit/tests/bip85_drng_with_seed.c
+++ b/tests/unit/tests/bip85_drng_with_seed.c
@@ -9,11 +9,19 @@
 #include "common/bip85/bip85_internal.h"
 
 #define BIP85_DRNG_MAX_DIGEST_SIZE 256
+#define BIP85_ENTROPY_LENGTH       64
 
-static uint8_t seed[] = {0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08,
-                         0x09, 0x0a, 0x0b, 0x0c, 0x0d, 0x0e, 0x0f, 0x10,
-                         0x11, 0x12, 0x13, 0x14, 0x15, 0x16, 0x17, 0x18,
-                         0x19, 0x1a, 0x1b, 0x1c, 0x1d, 0x1e, 0x1f, 0x20};
+// 64 bytes, the only seed length bolos_ux_bip85_drng_with_seed() accepts:
+// BIP-85 specifies the DRNG's input as exactly the 64 bytes of BIP85 HMAC
+// output. The contents are arbitrary -- the function hashes whatever it is
+// given -- but the length is not.
+static uint8_t seed[BIP85_ENTROPY_LENGTH] = {
+    0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09, 0x0a, 0x0b,
+    0x0c, 0x0d, 0x0e, 0x0f, 0x10, 0x11, 0x12, 0x13, 0x14, 0x15, 0x16,
+    0x17, 0x18, 0x19, 0x1a, 0x1b, 0x1c, 0x1d, 0x1e, 0x1f, 0x20, 0x21,
+    0x22, 0x23, 0x24, 0x25, 0x26, 0x27, 0x28, 0x29, 0x2a, 0x2b, 0x2c,
+    0x2d, 0x2e, 0x2f, 0x30, 0x31, 0x32, 0x33, 0x34, 0x35, 0x36, 0x37,
+    0x38, 0x39, 0x3a, 0x3b, 0x3c, 0x3d, 0x3e, 0x3f, 0x40};
 
 // bolos_ux_bip85_drng_with_seed() is a thin wrapper around cx_shake256_hash()
 // -- no derivation, no BOLOS syscall -- so its output for a given
@@ -119,6 +127,44 @@ static void test_drng_with_seed_accepts_max_digest_size(void** state) {
     assert_memory_equal(digest, expected, sizeof(digest));
 }
 
+// BIP-85 specifies the DRNG's input as exactly the 64 bytes of BIP85 HMAC
+// output. Anything else is refused rather than hashed: SHAKE256 would accept
+// it and return a perfectly well-formed stream, which is what makes the
+// wrong length worth catching -- there is nothing downstream that would
+// notice.
+//
+// One byte short and one byte long, rather than a single arbitrary wrong
+// length: the guard is an equality test, and the two values on either side
+// of it are the ones that would survive a `<` or `>` written in its place.
+//
+// The over-long case gets its own buffer that really is one byte longer,
+// rather than the 64-byte `seed` above with a larger length passed alongside
+// it: the point is what the function does with a 65-byte seed, not what the
+// sanitizers say about reading past a 64-byte array.
+static uint8_t seed_one_byte_too_long[BIP85_ENTROPY_LENGTH + 1];
+
+static void test_drng_with_seed_rejects_wrong_seed_length(void** state) {
+    (void)state;
+
+    uint8_t digest[64];
+
+    // Pre-filled with a value the function never writes, so that "the digest
+    // was left alone" is an assertion and not an assumption about whatever
+    // the stack happened to hold.
+    memset(digest, 0xa5, sizeof(digest));
+    memset(seed_one_byte_too_long, 0x5a, sizeof(seed_one_byte_too_long));
+
+    assert_false(bolos_ux_bip85_drng_with_seed(seed, BIP85_ENTROPY_LENGTH - 1,
+                                               digest, sizeof(digest)));
+    assert_false(bolos_ux_bip85_drng_with_seed(seed_one_byte_too_long,
+                                               sizeof(seed_one_byte_too_long),
+                                               digest, sizeof(digest)));
+
+    for (size_t i = 0; i < sizeof(digest); i++) {
+        assert_int_equal(digest[i], 0xa5);
+    }
+}
+
 // digest_length > BIP85_DRNG_MAX_DIGEST_SIZE is deliberately not exercised:
 // that path is a LEDGER_ASSERT, not a returned error, and LEDGER_ASSERT
 // terminates the process on this host build -- same as every other
@@ -132,6 +178,7 @@ int main(void) {
         cmocka_unit_test(test_drng_with_seed_matches_cx_shake256_hash),
         cmocka_unit_test(test_drng_with_seed_matches_bip85_vector),
         cmocka_unit_test(test_drng_with_seed_accepts_max_digest_size),
+        cmocka_unit_test(test_drng_with_seed_rejects_wrong_seed_length),
     };
     return cmocka_run_group_tests(tests, NULL, NULL);
 }


### PR DESCRIPTION
Three low-severity hygiene points. None of them is exploitable, none of them
fixes a defect a user can reach today, and the PR is written that way on
purpose: presenting them as security fixes would only make the real ones
harder to believe.

Base: `bip85` at `1687e15`. No file under `.github/workflows/` is touched.

## 1. The HMAC context was left on the stack

`bip85_entropy_from_key()` (`src/common/bip85/seed_bip85.c`) and
`compare_recovery_phrase()` (`src/common/common_seed.c`) each build a
`cx_hmac_sha512_t` on the stack and leave it there. The context holds the HMAC
padding blocks and the running SHA-512 state over what was hashed -- the BIP32
root key in the first case, the 64-byte input seed in the second -- so the
frame keeps a derivative of that material after the function returns, until
something else happens to overwrite it.

Both files already wipe every entropy buffer they put on the stack. The
context was the one thing they did not. `bip85_entropy_from_key()` gains a
single exit so the wipe covers its two error paths as well as the success one;
`compare_recovery_phrase()` wipes as soon as the HMAC is finalised, since it
leaves by a `return` that does not pass its `cleanup:` label.

**Scope: small.** The residue is a stack frame, not the key, and it is
generally overwritten in short order. This closes a gap in a discipline the
rest of the code keeps.

**What the sweep found.** Looking for stack-allocated crypto contexts across
the whole tree -- `cx_hmac_sha512_t`, `cx_hmac_sha256_t`, `cx_sha256_t`,
`cx_sha512_t`, `cx_sha3_t`, `cx_hash_t`, `cx_aes_key_t`,
`cx_ecfp_private_key_t` -- turns up exactly these two in `src/` and nothing
else. The only other hit is a prototype in `tests/unit/lib/bolos/cxlib.h`,
which is a declaration, not an object.

**Not held by a test.** Reading a stack frame after the function that owned it
has returned is undefined behaviour, and a test that managed to do it would
prove nothing portable. It is a review rule, not a checked property. The one
piece of evidence available is the size measurement below: both functions grow
in the optimised ARM image, so the wipe is not being elided.

## 2. The DRNG did not hold its seed to the length the specification requires

BIP-85 defines its DRNG as SHAKE256 over the 64 bytes of BIP85 HMAC output and
is explicit that the input must be exactly that long.
`bolos_ux_bip85_drng_with_seed()` bounded the digest length it writes and not
the seed length it reads: any other seed length produced a well-formed
SHAKE256 stream that is simply not the stream BIP-85 defines, with nothing
downstream in a position to notice.

**No caller violates the contract today.** `bolos_ux_bip85_drng_test()` is the
only one, and it passes `BIP85_ENTROPY_LENGTH`.

**Why `false` rather than `LEDGER_ASSERT`,** unlike the digest-length check one
line above: the two parameters are not the same kind of thing. `digest_length`
bounds a write into the caller's buffer, where an out-of-range value is a
memory error and stopping is the safe answer. A wrong `seed_length` only
yields a wrong result, and `false` is already this function's error channel for
the SHAKE256 failure below it. It is also the only form a test can reach --
`assert_exit()` in `tests/unit/lib/testutils.c` is `exit(1)`, so a
`LEDGER_ASSERT` terminates the test binary. That is why the digest-length bound
still has no test of its own, as the test file already notes in a comment.

**Held by a test, with discriminance.** Two of the existing cases were passing
a 32-byte seed, which the guard now refuses; they use the length the
specification prescribes. The new case checks one byte short and one byte long
-- the two values that would survive a `<` or a `>` written in place of the
equality -- and checks the digest buffer is left untouched. Neutralising the
guard turns that case red (`bip85_drng_with_seed.c:157`, 3/4 passing, exit 1);
restoring it returns 4/4.

## 3. The BIP85 index bound and its message are different numbers

The check in `bip85_index_validate()` (`src/nbgl/ui.c`) is
`bip85_index_get() <= (UINT32_MAX >> 1)`; the message on its failing branch
says "between 0 and 9,999,999". Both are correct and neither is a typo for the
other, but nothing in the file said so.

The 31-bit bound is what the derivation needs: the index goes into a hardened
BIP32 path component as `0x80000000 | index`, the same reason
`bip85_dice_sides_valid()` stops at the same value. The keypad caps entry at
`BIP85_INDEX_MAX_NUMBER_LENGTH` digits, so the largest value that can reach the
check is 9,999,999 -- far inside 31 bits, and far too small for the
`10 * index + digit` accumulation to overflow the `uint32_t` it runs in. The
failing branch is therefore unreachable from the screens, and the message
states the keypad's limit because it is addressed to whoever is typing.

Comment only, no change in behaviour. **Nothing here is held by a test:**
`src/nbgl/ui.c` is compiled into no test target.

## Verification

`clang-format --dry-run -Werror` on the three touched `src/` files: clean.

Unit test suite across the six configurations of `unit-tests-matrix.yml`,
each a full clean configure, build and `ctest`:

| Configuration | Result |
|---|---|
| ASan | 75/75 |
| UBSan | 75/75 |
| `-O2` | 75/75 |
| `-Os` | 75/75 |
| `-fsigned-char` | 75/75 |
| `-funsigned-char` | 75/75 |

All six `ledger_app.toml` targets built, `nanos` by hand since the CI matrix
builds five. `text`/`data`/`bss` are identical before and after on every one:

| Device | text | data | bss |
|---|---|---|---|
| nanos | 40904 | 0 | 3708 |
| nanox | 47928 | 0 | 28672 |
| nanos+ | 48200 | 0 | 40960 |
| stax | 75889 | 0 | 36864 |
| flex | 76429 | 0 | 36864 |
| apex_p | 72817 | 0 | 40960 |

Unchanged section sizes are not the same thing as an unchanged image, so here
is the number rather than the word "neutral". On stax, `bin/app.elf` changes
(`8a1ff1b1…` to `953fe36a…`); `seed_bip85.o` goes 1997 to 2021 bytes and
`common_seed.o` 657 to 669. In the linked image, `bip85_entropy_from_key`
grows from 0x6c to 0x74 (+8 bytes) and `compare_recovery_phrase` from 0xe0 to
0xec (+12), so **+20 bytes of live code**, absorbed by existing section
alignment padding. `bolos_ux_bip85_drng_with_seed` appears in neither image --
it is garbage-collected -- so the new guard costs nothing in the shipped app.
