### PR TITLE
fix: fail closed on a failed randomness draw, and bound the inputs that size buffers

### DIFF
--- a/fuzzing/extra/host_syscalls.c
+++ b/fuzzing/extra/host_syscalls.c
@@ -15,6 +15,8 @@
 #include <stdint.h>
 #include <stdlib.h>
 
+#include "cx_errors.h"
+
 /* Declared by the SDK's ledger_assert_internals.h; defined here so a
  * LEDGER_ASSERT() firing inside any fuzzed function stops the run with a
  * non-zero status the fuzzing engine reports, rather than exiting quietly. */
@@ -32,6 +34,17 @@ void cx_rng_no_throw(uint8_t *buffer, size_t len) {
     for (size_t i = 0; i < len; i++) {
         buffer[i] = (uint8_t) i;
     }
+}
+
+/* The same filler behind the syscall seed_sskr.c actually calls. Unlike
+ * cx_rng_no_throw() above this one has a status to return, which is why it is
+ * the one share generation goes through; a host stand-in has nothing to fail
+ * at, so it always succeeds. */
+cx_err_t cx_get_random_bytes(void *buffer, size_t len) {
+    for (size_t i = 0; i < len; i++) {
+        ((uint8_t *) buffer)[i] = (uint8_t) i;
+    }
+    return CX_OK;
 }
 
 /* Constant-time comparison. The wordlist searches and the CBOR/CRC checks all

--- a/src/bagl/nanox_enter_phrase.c
+++ b/src/bagl/nanox_enter_phrase.c
@@ -435,8 +435,7 @@ void screen_onboarding_restore_word_validate(void) {
                 bool reconstructed = true;
                 // Against VERDICT_MATCH, not "not zero": every other value,
                 // corrupted or not, is a mismatch. See common.h.
-                if (compare_recovery_phrase(&reconstructed) ==
-                    VERDICT_MATCH) {
+                if (compare_recovery_phrase(&reconstructed) == VERDICT_MATCH) {
                     ux_flow_init(0, &ux_bip39_match_flow, NULL);
                 } else {
                     memzero(G_bolos_ux_context.words_buffer,
@@ -482,9 +481,8 @@ void screen_onboarding_restore_word_validate(void) {
                     ux_flow_init(0, ux_load_flow, NULL);
                     bool reconstructed = true;
                     // Against VERDICT_MATCH, as above.
-                    const bool match =
-                        (compare_recovery_phrase(&reconstructed) ==
-                         VERDICT_MATCH);
+                    const bool match = (compare_recovery_phrase(
+                                            &reconstructed) == VERDICT_MATCH);
                     if (!reconstructed) {
                         // shards were well-formed but could not be combined
                         ux_flow_init(0, &ux_sskr_invalid_flow, NULL);

--- a/src/common/bip39/seed_bip39.c
+++ b/src/common/bip39/seed_bip39.c
@@ -39,6 +39,18 @@ bool bolos_ux_bip39_mnemonic_to_seed(const unsigned char* mnemonic,
     // Need to keep BIP39 mnemonic in case we want to generate SSKR from it
     // It will be zeroed later if not needed
     unsigned char mnemonic_hash[257];
+
+    // No caller can overrun this today, and none of them can say so on its own:
+    // WORDS_BUFFER_MAX_SIZE_B (bagl/ux_nano.h) is also 257 and
+    // BIP39_MNEMONIC_MAX_LENGTH (nbgl/bip39_mnemonic.h) is 216, so the copy
+    // below fits by an arithmetic coincidence spread over three files that
+    // nothing holds together. This is the one place that can.
+    if (mnemonic_length > sizeof(mnemonic_hash)) {
+        memzero(seed, 64);
+        PRINTF("BIP39 mnemonic longer than the derivation buffer\n");
+        return false;
+    }
+
     memcpy(mnemonic_hash, mnemonic, mnemonic_length);
     unsigned char passphrase[BIP39_MNEMONIC_LENGTH + 4];
     mnemonic_length = bolos_ux_bip39_mnemonic_to_seed_hash_length128(

--- a/src/common/sskr/seed_sskr.c
+++ b/src/common/sskr/seed_sskr.c
@@ -19,6 +19,10 @@
 #include <os.h>
 #include <string.h>
 
+// BIP39_MNEMONIC_SIZE_12/18/24, the three lengths bolos_ux_sskr_size_get()
+// accepts below.
+#include "constants.h"
+
 #include "../bip39/common_bip39.h"
 #include "../common.h"
 #include "./common_sskr.h"
@@ -78,9 +82,33 @@ bool bolos_ux_sskr_groups_from_descriptor(const unsigned int* group_descriptor,
     return true;
 }
 
+// The three mnemonic lengths this application offers, and the only values
+// `bip39_type` may take. It is the multiplicand of every length derived from it
+// -- the secret handed to sskr_generate_shards(), the serialized shard length,
+// and through it the size of the buffer a whole set is written into -- so it is
+// worth one place that says what it may be.
+//
+// Deliberately narrow, the same way bip85_bip39_words_valid() is: BIP-39 itself
+// also defines 15 and 21, and bolos_ux_bip39_mnemonic_encode() would encode
+// either of them happily, but no screen in this application asks for one.
+static bool bolos_ux_sskr_bip39_type_valid(unsigned int bip39_type) {
+    return (bip39_type == BIP39_MNEMONIC_SIZE_12) ||
+           (bip39_type == BIP39_MNEMONIC_SIZE_18) ||
+           (bip39_type == BIP39_MNEMONIC_SIZE_24);
+}
+
 int16_t bolos_ux_sskr_size_get(uint8_t bip39_type, uint8_t groups_threshold,
                                unsigned int* group_descriptor,
                                uint8_t groups_len, uint8_t* share_len) {
+    // Before anything is derived from it. *share_len is an output the caller
+    // sizes a buffer from, so a bip39_type this function does not recognise has
+    // to leave it at zero rather than at bip39_type * 4 / 3 + 5 of something
+    // arbitrary -- which for a bip39_type above 190 wraps the uint8_t as well.
+    *share_len = 0;
+    if (!bolos_ux_sskr_bip39_type_valid(bip39_type)) {
+        return SSKR_ERROR_INVALID_BIP39_TYPE;
+    }
+
     sskr_group_descriptor_t groups[SSKR_MAX_GROUP_COUNT];
     if (!bolos_ux_sskr_groups_from_descriptor(group_descriptor, groups_len,
                                               groups, SSKR_MAX_GROUP_COUNT)) {
@@ -455,7 +483,26 @@ unsigned int bolos_ux_sskr_hex_check(unsigned char* sskr_shares_hex,
         memzero(sskr_shares_hex, sskr_shares_hex_length);
         return 0;
     }
-    const unsigned int header_len = 4u + ((sskr_shares_hex[3] & 0x1F) > 23);
+
+    // The other half of that initial byte. RFC 8949 section 3 gives additional
+    // information 0..23 the meaning "this is the length", 24 "one length byte
+    // follows", and reserves 25..31 (two/four/eight-byte length, reserved,
+    // indefinite) -- none of which a share may use, and none of which carries a
+    // length this function could act on.
+    //
+    // Until now nothing here refused them. What kept them out was a side
+    // effect one layer up: bolos_ux_sskr_entry_header_update() only writes the
+    // share count for additional information below or equal to 24, so a
+    // reserved value left it at zero, and the count-of-zero bound above
+    // refused the frame. That works, and it is not what this function is
+    // documented to do -- a caller arriving here with a count of its own would
+    // have been given a frame nothing had checked the shape of.
+    const unsigned int additional_info = sskr_shares_hex[3] & 0x1F;
+    if (additional_info > 24) {
+        memzero(sskr_shares_hex, sskr_shares_hex_length);
+        return 0;
+    }
+    const unsigned int header_len = 4u + (additional_info == 24);
     const unsigned int metadata_len = header_len + 4u;
 
     // ...and that comparison has to stay inside the share it starts from. At
@@ -464,6 +511,21 @@ unsigned int bolos_ux_sskr_hex_check(unsigned char* sskr_shares_hex,
     // folded into the bound above: metadata_len is not known until byte 3 has
     // been read, and reading byte 3 is what that bound makes safe.
     if (stride < metadata_len) {
+        memzero(sskr_shares_hex, sskr_shares_hex_length);
+        return 0;
+    }
+
+    // The declared length has to be the one the frame actually arrived in. A
+    // share is a CBOR byte string of `declared` bytes wrapped in `header_len`
+    // bytes of tag and header, followed by four bytes of CRC32, so the three
+    // add up to the stride or the frame is not the share it says it is.
+    //
+    // Reading byte 4 for the long form is in bounds: the stride bound above is
+    // strictly greater than checksum_len, so at least five bytes of the first
+    // share are present.
+    const unsigned int declared =
+        (additional_info < 24) ? additional_info : sskr_shares_hex[4];
+    if (declared + header_len + checksum_len != stride) {
         memzero(sskr_shares_hex, sskr_shares_hex_length);
         return 0;
     }

--- a/src/common/sskr/seed_sskr.c
+++ b/src/common/sskr/seed_sskr.c
@@ -36,6 +36,19 @@
 #error "What kind of system is this?"
 #endif
 
+// The BOLOS randomness source, with its status preserved.
+//
+// The whole lcx_rng.h family -- cx_rng(), cx_rng_no_throw(), cx_rng_u8(),
+// cx_rng_u32() -- returns void or the buffer it was handed, so none of them can
+// report a failed draw. cx_get_random_bytes() (os_random.h) is the same TRNG
+// behind a syscall that returns cx_err_t, and it exists on every SDK this
+// application targets, nanos included. Everything randomness feeds here is
+// load-bearing -- the Shamir coefficients, the digest padding and the share-set
+// identifier -- so a failed draw has to stop generation, not pass through it.
+static bool sskr_rng_bolos(uint8_t* buffer, size_t len) {
+    return cx_get_random_bytes(buffer, len) == CX_OK;
+}
+
 // Largest a full set of serialized shards can be, in bytes, and hence the
 // capacity of every share buffer handed to bolos_ux_sskr_generate(): every
 // group at its maximum member count, each shard holding a maximum-strength
@@ -204,7 +217,7 @@ unsigned int bolos_ux_sskr_generate(uint8_t groups_threshold,
     // convert seed to SSKR shares
     int16_t share_count = sskr_generate_shards(
         groups_threshold, groups, groups_len, seed, seed_len, share_len,
-        share_buffer, share_buffer_len, cx_rng);
+        share_buffer, share_buffer_len, sskr_rng_bolos);
 
     PRINTF("SSKR share count expected: %d\n", share_count_expected);
     PRINTF("SSKR share count returned: %d\n", share_count);

--- a/src/common/sskr/seed_sskr.c
+++ b/src/common/sskr/seed_sskr.c
@@ -21,14 +21,13 @@
 
 // BIP39_MNEMONIC_SIZE_12/18/24, the three lengths bolos_ux_sskr_size_get()
 // accepts below.
-#include "constants.h"
-
 #include "../bip39/common_bip39.h"
 #include "../common.h"
 #include "./common_sskr.h"
 #include "./seed_rom_variables.h"
 #include "./seed_sskr_internal.h"
 #include "./sskr.h"
+#include "constants.h"
 
 // Return the CRC-32 checksum of the input buffer in network byte order (big
 // endian).

--- a/src/common/sskr/seed_sskr_internal.h
+++ b/src/common/sskr/seed_sskr_internal.h
@@ -38,6 +38,16 @@
 
 #include "./group.h"
 
+// Reported by bolos_ux_sskr_size_get() for a mnemonic length this application
+// does not offer, i.e. anything but 12, 18 or 24 words.
+//
+// Its own value rather than one of the SSKR_ERROR_* codes because this is not a
+// property of a shard set -- nothing in BCR-2020-011 has an opinion on how many
+// BIP-39 words the secret came from. It sits between the two ranges already in
+// use, SSKR_ERROR_* at -1..-19 and SSS_ERROR_* at -101..-107, so a caller
+// telling the three apart by range keeps working.
+#define SSKR_ERROR_INVALID_BIP39_TYPE (-50)
+
 // Expand the flat group descriptor the UI layers hold into the array of
 // sskr_group_descriptor_t that sskr_count_shards() and sskr_generate_shards()
 // take.

--- a/src/common/sskr/sskr-constants.h
+++ b/src/common/sskr/sskr-constants.h
@@ -45,5 +45,6 @@
 #define SSKR_ERROR_SECRET_TOO_LONG             (-16)
 #define SSKR_ERROR_INVALID_GROUP_LENGTH        (-17)
 #define SSKR_ERROR_INVALID_GROUP_COUNT         (-18)
+#define SSKR_ERROR_RNG_FAILURE                 (-19)
 
 #endif /* SSKR_CONSTANTS_H */

--- a/src/common/sskr/sskr.c
+++ b/src/common/sskr/sskr.c
@@ -261,7 +261,7 @@ static int16_t sskr_generate_shards_internal(
     uint8_t group_threshold, const sskr_group_descriptor_t* groups,
     uint8_t groups_len, const uint8_t* master_secret,
     uint16_t master_secret_len, sskr_shard_t* shards, uint16_t shards_size,
-    unsigned char* (*random_generator)(uint8_t*, size_t)) {
+    bool (*random_generator)(uint8_t*, size_t)) {
     int16_t error = sskr_check_secret_length(master_secret_len);
     if (error) {
         return error;
@@ -276,7 +276,9 @@ static int16_t sskr_generate_shards_internal(
 
     // assign a random identifier
     uint16_t identifier = 0;
-    random_generator((uint8_t*)(&identifier), 2);
+    if (!random_generator((uint8_t*)(&identifier), 2)) {
+        return SSKR_ERROR_RNG_FAILURE;
+    }
 
     if (shards_size < total_shards) {
         return SSKR_ERROR_INSUFFICIENT_SPACE;
@@ -346,8 +348,7 @@ int16_t sskr_generate_shards(uint8_t group_threshold,
                              uint8_t groups_len, const uint8_t* master_secret,
                              uint16_t master_secret_len, uint8_t* shard_len,
                              uint8_t* output, uint16_t buffer_size,
-                             unsigned char* (*random_generator)(uint8_t*,
-                                                                size_t)) {
+                             bool (*random_generator)(uint8_t*, size_t)) {
     // shard_len is an output parameter, and the function has several early
     // rejections that never reach the assignment at the bottom. Define it
     // once, here, so that no failure path can hand back the value the caller

--- a/src/common/sskr/sskr.h
+++ b/src/common/sskr/sskr.h
@@ -10,6 +10,7 @@
 
 #include <stdlib.h>
 #include <stdint.h>
+#include <stdbool.h>
 
 #include "sskr-constants.h"
 #include "group.h"
@@ -51,7 +52,7 @@ int16_t sskr_generate_shards(uint8_t group_threshold,
                              uint8_t *shard_len,
                              uint8_t *output,
                              uint16_t buffer_size,
-                             unsigned char *(*random_generator)(uint8_t *, size_t) );
+                             bool (*random_generator)(uint8_t *, size_t) );
 
 /**
  * @brief Combines shards to reconstruct a secret.

--- a/src/common/sskr/sskr.h
+++ b/src/common/sskr/sskr.h
@@ -52,7 +52,7 @@ int16_t sskr_generate_shards(uint8_t group_threshold,
                              uint8_t *shard_len,
                              uint8_t *output,
                              uint16_t buffer_size,
-                             bool (*random_generator)(uint8_t *, size_t) );
+                             bool (*random_generator)(uint8_t *, size_t));
 
 /**
  * @brief Combines shards to reconstruct a secret.

--- a/src/common/sskr/sss/sss-constants.h
+++ b/src/common/sskr/sss/sss-constants.h
@@ -29,5 +29,6 @@
 #define SSS_ERROR_SECRET_TOO_SHORT      (-105)
 #define SSS_ERROR_SECRET_NOT_EVEN_LEN   (-106)
 #define SSS_ERROR_INVALID_THRESHOLD     (-107)
+#define SSS_ERROR_RNG_FAILURE           (-108)
 
 #endif /* SSS_CONSTANTS_H */

--- a/src/common/sskr/sss/sss.c
+++ b/src/common/sskr/sss/sss.c
@@ -90,7 +90,7 @@ uint8_t* sss_create_digest(const uint8_t* random_data, uint32_t rdlen,
 int16_t sss_split_secret(uint8_t threshold, uint8_t share_count,
                          const uint8_t* secret, uint8_t secret_length,
                          uint8_t* result,
-                         unsigned char* (*random_generator)(uint8_t*, size_t)) {
+                         bool (*random_generator)(uint8_t*, size_t)) {
     int16_t error =
         sss_validate_parameters(threshold, share_count, secret_length);
     if (error) {
@@ -114,14 +114,29 @@ int16_t sss_split_secret(uint8_t threshold, uint8_t share_count,
         uint8_t* share = result;
 
         for (uint8_t i = 0; i < threshold - 2; ++i, share += secret_length) {
-            random_generator(share, secret_length);
+            // A failed draw here leaves `share` holding whatever the previous
+            // stack frame did, which would become a share of the secret. Same
+            // cleanup as the interpolation-failure path below.
+            if (!random_generator(share, secret_length)) {
+                memzero(result, (size_t)share_count * secret_length);
+                memzero(digest, sizeof(digest));
+                memzero(x, sizeof(x));
+                memzero(y, sizeof(y));
+                return SSS_ERROR_RNG_FAILURE;
+            }
             x[n] = i;
             y[n] = share;
             n += 1;
         }
 
         // generate secret_length - 4 bytes worth of random data
-        random_generator(digest + 4, secret_length - 4);
+        if (!random_generator(digest + 4, secret_length - 4)) {
+            memzero(result, (size_t)share_count * secret_length);
+            memzero(digest, sizeof(digest));
+            memzero(x, sizeof(x));
+            memzero(y, sizeof(y));
+            return SSS_ERROR_RNG_FAILURE;
+        }
         // put 4 bytes of digest at the top of the digest array
         sss_create_digest(digest + 4, secret_length - 4, secret, secret_length,
                           digest);

--- a/src/common/sskr/sss/sss.h
+++ b/src/common/sskr/sss/sss.h
@@ -9,6 +9,7 @@
 #define SSS_H
 
 #include <stdint.h>
+#include <stdbool.h>
 #include "sss-constants.h"
 
 #define SSS_SECRET_INDEX 255
@@ -58,7 +59,7 @@ int16_t sss_split_secret(uint8_t threshold,
                          const uint8_t *secret,
                          uint8_t secret_length,
                          uint8_t *result,
-                         unsigned char *(*random_generator)(uint8_t *, size_t) );
+                         bool (*random_generator)(uint8_t *, size_t) );
 
 /**
  * @brief Recovers a secret from Shamir's Secret Sharing (SSS) shares.

--- a/src/common/sskr/sss/sss.h
+++ b/src/common/sskr/sss/sss.h
@@ -59,7 +59,7 @@ int16_t sss_split_secret(uint8_t threshold,
                          const uint8_t *secret,
                          uint8_t secret_length,
                          uint8_t *result,
-                         bool (*random_generator)(uint8_t *, size_t) );
+                         bool (*random_generator)(uint8_t *, size_t));
 
 /**
  * @brief Recovers a secret from Shamir's Secret Sharing (SSS) shares.

--- a/src/nbgl/ui.c
+++ b/src/nbgl/ui.c
@@ -329,6 +329,15 @@ static void key_press_callback(const char touchedKey) {
         textToEnter[previousTextLen - 1] = '\0';
         textLen = previousTextLen - 1;
     } else {
+        // What keeps this inside textToEnter today is the keyboard mask, not
+        // the array: bolos_ux_bip39_get_keyboard_mask() disables every letter
+        // once no wordlist entry extends the prefix, and the longest BIP-39
+        // word is BIP39_MAX_WORD_LENGTH characters. That is a guard computed in
+        // another file, for another purpose, that this write happens to benefit
+        // from. The buffer's own size is the thing that has to hold here.
+        if (previousTextLen + 1 >= sizeof(textToEnter)) {
+            return;
+        }
         textToEnter[previousTextLen] = touchedKey;
         textToEnter[previousTextLen + 1] = '\0';
         textLen = previousTextLen + 1;
@@ -573,11 +582,22 @@ static void display_check_result_page(const bool result) {
     static const nbgl_icon_details_t* icons[3] = {
         &DENIED_CIRCLE_ICON, &IMPORTANT_CIRCLE_ICON, &CHECK_CIRCLE_ICON};
 
+    // The text index is 1 + tool_type * 2 + seed_match into a five-element row.
+    // TOOL_TYPE_BIP39 and TOOL_TYPE_SSKR give 1..4; TOOL_TYPE_BIP85, the third
+    // value of that enumeration (constants.h), would give 5 or 6 and read past
+    // the row. No path reaches this screen with the BIP85 tool selected -- that
+    // flow goes to display_generic_review() and never asks for a verdict -- so
+    // this is a bound on an index the screens cannot currently produce, not a
+    // fix for one they can.
+    const uint8_t text_index =
+        (tool_type == TOOL_TYPE_BIP39 || tool_type == TOOL_TYPE_SSKR)
+            ? (uint8_t)(1 + (tool_type * 2) + seed_match)
+            : 1;
+
     nbgl_pageInfoDescription_t info = {
         .centeredInfo.icon = icons[result + seed_match],
         .centeredInfo.text1 = possible_results[result][0],
-        .centeredInfo.text2 =
-            possible_results[result][1 + (tool_type * 2) + seed_match],
+        .centeredInfo.text2 = possible_results[result][text_index],
         .centeredInfo.text3 = NULL,
         .centeredInfo.style = LARGE_CASE_INFO,
         .centeredInfo.offsetY = -16,

--- a/tests/unit/CMakeLists.txt
+++ b/tests/unit/CMakeLists.txt
@@ -282,6 +282,17 @@ target_link_libraries(test_sskr_generate_combine_guards PUBLIC cmocka gcov testu
 add_executable(test_sskr_threshold_three_roundtrip tests/sskr_threshold_three_roundtrip.c)
 target_link_libraries(test_sskr_threshold_three_roundtrip PUBLIC cmocka gcov testutils sskr sss)
 
+# What generation does when a randomness draw fails. The generator is a
+# parameter of the public API, so this needs no hook into production code --
+# which is also why nothing held the behaviour before: every existing caller
+# passes a generator that always succeeds.
+add_executable(test_sskr_generate_rng_failure tests/sskr_generate_rng_failure.c)
+# testutils last, as test_sskr_memzero and test_sskr_share_len already do: this
+# file calls sss_split_secret() directly as well as through sskr_generate_shards(),
+# which makes libsss.so's own cx_bn_* references part of this executable's link,
+# and they are satisfied by testutils.
+target_link_libraries(test_sskr_generate_rng_failure PUBLIC cmocka gcov sskr sss testutils)
+
 # Built with AddressSanitizer, like test_sskr_combine_bounds and
 # test_sskr_generate_bound_groups below. The bound this covers is what keeps
 # sskr_deserialize_shard() from reading an entered length's worth of bytes out

--- a/tests/unit/CMakeLists.txt
+++ b/tests/unit/CMakeLists.txt
@@ -221,7 +221,9 @@ else()
   message(STATUS "LEDGER_SECURE_SDK already set: $ENV{LEDGER_SECURE_SDK}")
 endif()
 
-include_directories(${CMAKE_CURRENT_SOURCE_DIR}/lib $ENV{LEDGER_SECURE_SDK}/include $ENV{LEDGER_SECURE_SDK}/lib_cxng/src $ENV{LEDGER_SECURE_SDK}/lib_cxng/include $ENV{LEDGER_SECURE_SDK}/lib_ux/include $ENV{LEDGER_SECURE_SDK}/lib_bagl/include $ENV{LEDGER_SECURE_SDK}/io/include $ENV{LEDGER_SECURE_SDK}/io_legacy/include)
+# ../../src so that application sources can include "constants.h" the way they
+# do in the device build, where APP_SOURCE_PATH puts src/ on the include path.
+include_directories(${CMAKE_CURRENT_SOURCE_DIR}/../../src ${CMAKE_CURRENT_SOURCE_DIR}/lib $ENV{LEDGER_SECURE_SDK}/include $ENV{LEDGER_SECURE_SDK}/lib_cxng/src $ENV{LEDGER_SECURE_SDK}/lib_cxng/include $ENV{LEDGER_SECURE_SDK}/lib_ux/include $ENV{LEDGER_SECURE_SDK}/lib_bagl/include $ENV{LEDGER_SECURE_SDK}/io/include $ENV{LEDGER_SECURE_SDK}/io_legacy/include)
 
 # add src
 set(ExternalProject_Get_property(openssl INSTALL_DIR))
@@ -312,6 +314,16 @@ target_link_libraries(test_sskr_share_len PUBLIC cmocka gcov sskr sss testutils)
 # AddressSanitizer, like test_sskr_combine_bounds and
 # test_sskr_generate_bound_groups below, for the offsets this function derives
 # by dividing a caller-supplied buffer length by a caller-supplied share count.
+# The CBOR additional-information rule and the bip39_type bound, both called
+# directly rather than through the entry path: the entry path is where they
+# happened to hold before, via a side effect, and the point is that these
+# functions now hold them themselves.
+add_executable(test_sskr_input_validation_guards ./tests/sskr_input_validation_guards.c ../../src/common/bip39/seed_rom_variables.c ../../src/common/bip39/seed_bip39.c ../../src/common/sskr/seed_rom_variables.c ../../src/common/sskr/seed_sskr.c)
+target_include_directories(test_sskr_input_validation_guards PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/../../src ${CMAKE_CURRENT_SOURCE_DIR}/../../src/common)
+target_compile_options(test_sskr_input_validation_guards PRIVATE -fsanitize=address -fno-omit-frame-pointer)
+target_link_options(test_sskr_input_validation_guards PRIVATE -fsanitize=address)
+target_link_libraries(test_sskr_input_validation_guards PUBLIC cmocka gcov sskr sss testutils)
+
 add_executable(test_sskr_hex_check_guards ./tests/sskr_hex_check_guards.c ../../src/common/bip39/seed_rom_variables.c ../../src/common/bip39/seed_bip39.c ../../src/common/sskr/seed_rom_variables.c ../../src/common/sskr/seed_sskr.c)
 target_include_directories(test_sskr_hex_check_guards PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/../../src/common)
 target_compile_options(test_sskr_hex_check_guards PRIVATE -fsanitize=address -fno-omit-frame-pointer)

--- a/tests/unit/lib/testprng.h
+++ b/tests/unit/lib/testprng.h
@@ -40,6 +40,7 @@
 #ifndef TESTPRNG_H
 #define TESTPRNG_H
 
+#include <stdbool.h>
 #include <stddef.h>
 #include <stdint.h>
 
@@ -72,7 +73,7 @@ static inline uint32_t test_prng_below(uint32_t bound) {
 }
 
 /* Signature required by sss_split_secret() and sskr_generate_shards(). */
-static inline unsigned char *test_prng_fill(uint8_t *buffer, size_t len) {
+static inline bool test_prng_fill(uint8_t *buffer, size_t len) {
     size_t i = 0;
 
     while (i < len) {
@@ -82,7 +83,7 @@ static inline unsigned char *test_prng_fill(uint8_t *buffer, size_t len) {
             chunk >>= 8;
         }
     }
-    return (unsigned char *) buffer;
+    return true;
 }
 
 #endif /* TESTPRNG_H */

--- a/tests/unit/lib/testutils.c
+++ b/tests/unit/lib/testutils.c
@@ -47,3 +47,22 @@ uint32_t cx_crc32(const void *buf, size_t len)
 
   return crc;
 }
+
+// Host stub for the BOLOS randomness syscall, next to cx_rng_no_throw() above.
+// cx_get_random_bytes() is what seed_sskr.c uses now, because unlike the whole
+// lcx_rng.h family it returns a cx_err_t the caller can act on.
+cx_err_t cx_get_random_bytes(void *buffer, size_t len)
+{
+    for (size_t i = 0; i < len; i++) {
+        ((uint8_t *) buffer)[i] = (uint8_t) i;
+    }
+    return CX_OK;
+}
+
+bool test_rng(uint8_t *buffer, size_t len)
+{
+    for (size_t i = 0; i < len; i++) {
+        buffer[i] = (uint8_t) i;
+    }
+    return true;
+}

--- a/tests/unit/lib/testutils.h
+++ b/tests/unit/lib/testutils.h
@@ -3,4 +3,13 @@
 
 #define WIDE
 
+#include <stdbool.h>
+#include <stddef.h>
+#include <stdint.h>
+
+/* The suite's deterministic generator, in the shape sss_split_secret() and
+ * sskr_generate_shards() now require. Writes 0,1,2,... and always succeeds;
+ * tests that need a failing draw pass their own. */
+bool test_rng(uint8_t *buffer, size_t len);
+
 #endif /* TESTUTILS_H */

--- a/tests/unit/tests/sskr.c
+++ b/tests/unit/tests/sskr.c
@@ -100,7 +100,7 @@ static void test_sskr_generate(void **state) {
                                         &share_len,
                                         share_buffer,
                                         share_buffer_len,
-                                        cx_rng);
+                                        test_rng);
 
     assert_int_equal(share_count, groups[0].count);
     assert_int_equal(share_len, share_buffer_len / groups[0].count);

--- a/tests/unit/tests/sskr_bound_group_count.c
+++ b/tests/unit/tests/sskr_bound_group_count.c
@@ -87,7 +87,7 @@ static void test_generate_shards_rejects_more_groups_than_it_can_hold(
 
     int16_t result = sskr_generate_shards(
         SSKR_MAX_GROUP_COUNT + 1, groups, SSKR_MAX_GROUP_COUNT + 1,
-        master_secret, SECRET_LEN, &shard_len, output, sizeof(output), cx_rng);
+        master_secret, SECRET_LEN, &shard_len, output, sizeof(output), test_rng);
 
     assert_int_equal(result, SSKR_ERROR_INVALID_GROUP_LENGTH);
 }
@@ -107,7 +107,7 @@ static void test_generate_shards_still_accepts_the_supported_group_count(
 
     int16_t result = sskr_generate_shards(1, groups, SSKR_MAX_GROUP_COUNT,
                                           master_secret, SECRET_LEN, &shard_len,
-                                          output, sizeof(output), cx_rng);
+                                          output, sizeof(output), test_rng);
 
     assert_int_equal(result, 2);
     assert_int_equal(shard_len, SSKR_METADATA_LENGTH_BYTES + SECRET_LEN);

--- a/tests/unit/tests/sskr_generate_combine_guards.c
+++ b/tests/unit/tests/sskr_generate_combine_guards.c
@@ -63,7 +63,7 @@ static void generate_expecting(uint16_t master_secret_len, int16_t expected) {
 
     int16_t result =
         sskr_generate_shards(1, groups, 1, master_secret, master_secret_len,
-                             &shard_len, output, sizeof(output), cx_rng);
+                             &shard_len, output, sizeof(output), test_rng);
 
     assert_int_equal(result, expected);
 }
@@ -106,7 +106,7 @@ static void test_generate_rejects_undersized_output_buffer(void** state) {
     /* One byte short of what the three serialized shards need. */
     int16_t result =
         sskr_generate_shards(1, groups, 1, master_secret, sizeof(master_secret),
-                             &shard_len, output, sizeof(output) - 1, cx_rng);
+                             &shard_len, output, sizeof(output) - 1, test_rng);
 
     assert_int_equal(result, SSKR_ERROR_INSUFFICIENT_SPACE);
 }

--- a/tests/unit/tests/sskr_generate_erase_on_split_failure.c
+++ b/tests/unit/tests/sskr_generate_erase_on_split_failure.c
@@ -76,7 +76,7 @@ static void test_generate_erases_output_on_member_level_interpolation_failure(
 
     int16_t result = sskr_generate_shards(1, groups, 1, master_secret,
                                           SECRET_LEN, &share_len, share_buffer,
-                                          sizeof(share_buffer), cx_rng);
+                                          sizeof(share_buffer), test_rng);
 
     assert_int_equal(result, SSS_ERROR_INTERPOLATION_FAILURE);
     assert_int_equal(share_len, 0);
@@ -99,7 +99,7 @@ static void test_generate_erases_output_on_group_level_split_failure(
 
     int16_t result = sskr_generate_shards(0, groups, 1, master_secret,
                                           SECRET_LEN, &share_len, share_buffer,
-                                          sizeof(share_buffer), cx_rng);
+                                          sizeof(share_buffer), test_rng);
 
     assert_int_equal(result, SSS_ERROR_INVALID_THRESHOLD);
     assert_int_equal(share_len, 0);

--- a/tests/unit/tests/sskr_generate_error_contract.c
+++ b/tests/unit/tests/sskr_generate_error_contract.c
@@ -192,7 +192,7 @@ static int16_t run_error_case(const error_case_t* c, uint8_t* shard_len_out) {
 
     int16_t result = sskr_generate_shards(
         c->group_threshold, &c->group, c->groups_len, master_secret,
-        c->master_secret_len, &shard_len, output, c->buffer_size, cx_rng);
+        c->master_secret_len, &shard_len, output, c->buffer_size, test_rng);
 
     if (c->lock_bn) {
         cx_bn_unlock();
@@ -258,7 +258,7 @@ static void test_success_returns_the_shard_count_and_length(void** state) {
 
     int16_t result =
         sskr_generate_shards(1, groups, 1, master_secret, sizeof(master_secret),
-                             &shard_len, output, sizeof(output), cx_rng);
+                             &shard_len, output, sizeof(output), test_rng);
 
     assert_int_equal(result, 3);
     assert_int_equal(shard_len, SHARD_LEN);

--- a/tests/unit/tests/sskr_generate_rng_failure.c
+++ b/tests/unit/tests/sskr_generate_rng_failure.c
@@ -1,0 +1,194 @@
+/*
+ * What sskr_generate_shards() does when a randomness draw fails.
+ *
+ * Share generation consumes randomness at three points: the 16-bit share-set
+ * identifier (sskr_generate_shards_internal()), the threshold - 2 leading
+ * shares of each split, and the random half of the integrity digest
+ * (sss_split_secret()). None of the three used to be checked, and none of them
+ * could be: the generator was typed `unsigned char *(*)(uint8_t *, size_t)` and
+ * had no way to report a failure, while the BOLOS entry point it was given --
+ * cx_rng() -- calls cx_rng_no_throw(), which returns void. A failed draw was
+ * therefore invisible from top to bottom.
+ *
+ * What that produced was worse than a wrong answer. The identifier stayed at
+ * its zero initialiser, the coefficients and the digest padding kept whatever
+ * the previous stack frame had left in those buffers, and the shares built on
+ * them still recombined to the correct secret -- so generation reported
+ * success, the user wrote down a backup that works, and the secrecy Shamir is
+ * there to provide was gone. Nothing on the device, in the return value or in
+ * a trace said so.
+ *
+ * This file pins the opposite behaviour, one draw at a time. `fail_on_call`
+ * walks the whole sequence of draws a 3-of-5 split makes, so each consumer in
+ * turn is the one that fails, and every case has to come back:
+ *
+ *   - a negative error code, not a share count;
+ *   - *shard_len at 0, the same contract every other failure path holds
+ *     (tests/unit/tests/sskr_generate_error_contract.c);
+ *   - an output buffer erased in full, so that no partly-built share survives
+ *     a refusal.
+ *
+ * The generator is a parameter of the public API, so none of this needs a hook
+ * into production code -- which is also why the gap could have been closed
+ * before now.
+ */
+
+#include <cmocka.h>
+#include <cx.h>
+#include <setjmp.h>
+#include <stdarg.h>
+#include <stdbool.h>
+#include <stddef.h>
+#include <stdint.h>
+#include <string.h>
+
+#include "group.h"
+#include "sskr-constants.h"
+#include "sskr.h"
+#include "sss-constants.h"
+#include "sss.h"
+
+#define SECRET_LEN    16
+#define MEMBER_THRESHOLD 3
+#define MEMBER_COUNT     5
+
+// A 3-of-5 split over a 16-byte secret draws: 1 (identifier) + 1 (the single
+// leading share of the group split, threshold 1 -> none) ... rather than count
+// them by hand, sweep past the largest number any of these calls can make. A
+// draw index beyond the last one simply never fires, and the success case at
+// the end of the sweep is asserted separately below.
+#define DRAW_SWEEP 12
+
+static const uint8_t master_secret[SECRET_LEN] = {0x7d, 0xaa, 0x85, 0x12, 0x51, 0x00,
+                                                  0x28, 0x74, 0xe1, 0xa1, 0x99, 0x5f,
+                                                  0x08, 0x97, 0xe6, 0xb1};
+
+static unsigned fail_on_call;
+static unsigned call_count;
+
+// Succeeds with the suite's usual 0,1,2,... pattern except on the draw named by
+// `fail_on_call`, where it reports failure without writing anything -- which is
+// what a real failed draw leaves behind: the buffer's previous contents.
+static bool flaky_rng(uint8_t *buffer, size_t len) {
+    call_count++;
+    if (call_count == fail_on_call) {
+        return false;
+    }
+    for (size_t i = 0; i < len; i++) {
+        buffer[i] = (uint8_t) i;
+    }
+    return true;
+}
+
+static void test_rng_failure_is_fail_closed(void **state) {
+    (void) state;
+    sskr_group_descriptor_t groups[1] = {{MEMBER_THRESHOLD, MEMBER_COUNT}};
+    unsigned failures_seen = 0;
+
+    for (unsigned draw = 1; draw <= DRAW_SWEEP; draw++) {
+        uint8_t output[(SECRET_LEN + SSKR_METADATA_LENGTH_BYTES) * MEMBER_COUNT];
+        uint8_t shard_len = 0xFF;
+
+        // Poisoned, so that "erased" is distinguishable from "never written".
+        memset(output, 0xEE, sizeof(output));
+        fail_on_call = draw;
+        call_count = 0;
+
+        int16_t result =
+            sskr_generate_shards(1, groups, 1, master_secret, SECRET_LEN, &shard_len,
+                                 output, sizeof(output), flaky_rng);
+
+        if (call_count < draw) {
+            // That draw does not exist: this split made fewer. Nothing failed,
+            // so generation must have succeeded.
+            assert_int_equal(result, MEMBER_COUNT);
+            continue;
+        }
+
+        failures_seen++;
+        assert_true(result < 0);
+        assert_int_equal(shard_len, 0);
+        for (size_t i = 0; i < sizeof(output); i++) {
+            assert_int_equal(output[i], 0);
+        }
+    }
+
+    // The sweep has to have exercised the failure path, or the assertions above
+    // are vacuous and this test would stay green against the original defect.
+    assert_true(failures_seen > 0);
+}
+
+// The identifier is the first draw, and the one whose failure used to be
+// invisible in the most direct way: it left the field at 0x0000 in every shard
+// of the set, which is also what a second failed backup would produce -- so two
+// unrelated sets would have looked like one.
+static void test_identifier_draw_failure_refuses(void **state) {
+    (void) state;
+    sskr_group_descriptor_t groups[1] = {{MEMBER_THRESHOLD, MEMBER_COUNT}};
+    uint8_t output[(SECRET_LEN + SSKR_METADATA_LENGTH_BYTES) * MEMBER_COUNT];
+    uint8_t shard_len = 0xFF;
+
+    memset(output, 0xEE, sizeof(output));
+    fail_on_call = 1;
+    call_count = 0;
+
+    int16_t result = sskr_generate_shards(1, groups, 1, master_secret, SECRET_LEN,
+                                          &shard_len, output, sizeof(output), flaky_rng);
+
+    assert_int_equal(result, SSKR_ERROR_RNG_FAILURE);
+    assert_int_equal(shard_len, 0);
+    assert_int_equal(call_count, 1);  // stops at the first failed draw
+}
+
+// sss_split_secret() reports its own code, from the disjoint SSS_* range, and
+// sskr_generate_shards() has to propagate it rather than collapse it -- the
+// property tests/unit/tests/sskr_generate_error_contract.c holds for the other
+// families.
+static void test_split_draw_failure_propagates_sss_code(void **state) {
+    (void) state;
+    uint8_t result_buffer[SECRET_LEN * MEMBER_COUNT];
+    uint8_t poisoned[SECRET_LEN * MEMBER_COUNT];
+
+    memset(result_buffer, 0xEE, sizeof(result_buffer));
+    memset(poisoned, 0, sizeof(poisoned));
+
+    // Fail the first draw sss_split_secret() itself makes.
+    fail_on_call = 1;
+    call_count = 0;
+
+    int16_t result = sss_split_secret(MEMBER_THRESHOLD, MEMBER_COUNT, master_secret,
+                                      SECRET_LEN, result_buffer, flaky_rng);
+
+    assert_int_equal(result, SSS_ERROR_RNG_FAILURE);
+    assert_memory_equal(result_buffer, poisoned, sizeof(result_buffer));
+}
+
+// The control: the same generator, never failing, still produces a full set.
+// Without this, every assertion above would also pass against a function that
+// refused unconditionally.
+static void test_working_rng_still_generates(void **state) {
+    (void) state;
+    sskr_group_descriptor_t groups[1] = {{MEMBER_THRESHOLD, MEMBER_COUNT}};
+    uint8_t output[(SECRET_LEN + SSKR_METADATA_LENGTH_BYTES) * MEMBER_COUNT];
+    uint8_t shard_len = 0;
+
+    fail_on_call = 0;  // never fires
+    call_count = 0;
+
+    int16_t result = sskr_generate_shards(1, groups, 1, master_secret, SECRET_LEN,
+                                          &shard_len, output, sizeof(output), flaky_rng);
+
+    assert_int_equal(result, MEMBER_COUNT);
+    assert_int_equal(shard_len, SECRET_LEN + SSKR_METADATA_LENGTH_BYTES);
+    assert_true(call_count > 0);
+}
+
+int main(void) {
+    const struct CMUnitTest tests[] = {
+        cmocka_unit_test(test_rng_failure_is_fail_closed),
+        cmocka_unit_test(test_identifier_draw_failure_refuses),
+        cmocka_unit_test(test_split_draw_failure_propagates_sss_code),
+        cmocka_unit_test(test_working_rng_still_generates),
+    };
+    return cmocka_run_group_tests(tests, NULL, NULL);
+}

--- a/tests/unit/tests/sskr_generate_split_error.c
+++ b/tests/unit/tests/sskr_generate_split_error.c
@@ -64,7 +64,7 @@ static void test_generate_reports_the_split_error_instead_of_succeeding(void **s
 
     int16_t result = sskr_generate_shards(1, groups, 1, master_secret,
                                           SECRET_LEN, &share_len, share_buffer,
-                                          share_buffer_len, cx_rng);
+                                          share_buffer_len, test_rng);
 
     assert_int_equal(result, SSS_ERROR_TOO_MANY_SHARES);
     assert_int_equal(share_len, 0);
@@ -89,7 +89,7 @@ static void test_generate_accepts_a_group_at_capacity(void **state) {
 
     int16_t result = sskr_generate_shards(1, groups, 1, master_secret,
                                           SECRET_LEN, &share_len, share_buffer,
-                                          share_buffer_len, cx_rng);
+                                          share_buffer_len, test_rng);
 
     assert_int_equal(result, SHARDS_CAPACITY);
 }

--- a/tests/unit/tests/sskr_hex_check_guards.c
+++ b/tests/unit/tests/sskr_hex_check_guards.c
@@ -274,6 +274,16 @@ static void test_hex_check_rejects_a_stride_under_the_metadata(void** state) {
  * other side of the bound above: it must refuse a stride it cannot read
  * safely and accept the first one it can, or it would be satisfied by a
  * function that refuses everything.
+ *
+ * The initial byte is 0x40 -- major type 2, additional information 0, a byte
+ * string of length zero -- and not 0x55 as it was while this function ignored
+ * the declared length. 0x55 declares 21 bytes of payload in a frame that
+ * carries none, which is now refused: the declared length, the header and the
+ * CRC-32 have to add up to the stride or the frame is not the share its header
+ * says it is (sskr_input_validation_guards.c). A zero-length byte string is
+ * still not a *shard*, which is exactly the division of responsibility this
+ * test was written to record -- so the control keeps its meaning, on a frame
+ * that is self-consistent.
  */
 static void test_hex_check_accepts_the_smallest_checkable_stride(void** state) {
     (void)state;
@@ -285,7 +295,7 @@ static void test_hex_check_accepts_the_smallest_checkable_stride(void** state) {
         frame[0] = 0xD9;
         frame[1] = 0x9D;
         frame[2] = 0x75;
-        frame[3] = 0x55;
+        frame[3] = 0x40;
         seal(frame, 4);
     }
 

--- a/tests/unit/tests/sskr_input_validation_guards.c
+++ b/tests/unit/tests/sskr_input_validation_guards.c
@@ -1,0 +1,201 @@
+/*
+ * Two input guards that were documented but not made, and one that was made in
+ * the wrong place.
+ *
+ * 1. bolos_ux_sskr_hex_check() and the CBOR initial byte.
+ *
+ *    That byte is three bits of major type and five of additional information
+ *    (RFC 8949 section 3). The major type was already tested. The additional
+ *    information was not: 25 to 31 are reserved -- two, four and eight-byte
+ *    lengths, one reserved value and indefinite length -- and none of them
+ *    carries a length this function can act on, yet all seven were accepted.
+ *    So was a declared length that disagreed with the frame it arrived in.
+ *
+ *    Nothing broke, because two mechanisms one layer away caught it:
+ *    bolos_ux_sskr_entry_header_update() leaves the share count at zero for a
+ *    reserved value and the zero-count bound refuses the frame, while
+ *    bolos_ux_sskr_combine() bounds the declared length itself. Both are real
+ *    and both stay. What they are not is this function -- and this function is
+ *    the one the entry paths call to ask whether what was typed is a share.
+ *
+ *    These cases therefore call it directly, with a count of their own, which
+ *    is exactly the shape of caller the side effect above does not protect.
+ *
+ * 2. bolos_ux_sskr_size_get() and bip39_type.
+ *
+ *    *share_len came back as bip39_type * 4 / 3 + 5 whatever bip39_type was,
+ *    and the caller sizes a buffer from it. Every comparable entry point in
+ *    this file bounds its parameters; this one did not.
+ */
+
+#include <cmocka.h>
+#include <cx.h>
+#include <setjmp.h>
+#include <stdarg.h>
+#include <stdbool.h>
+#include <stddef.h>
+#include <stdint.h>
+#include <string.h>
+
+// testutils.h first: it defines WIDE, which the SSKR wordlist declaration in
+// seed_rom_variables.h needs and which only the device build gets from os.h.
+/* clang-format off */
+#include "testutils.h"
+#include "constants.h"
+#include "sskr/common_sskr.h"
+#include "sskr/seed_sskr_internal.h"
+#include "sskr/sskr-constants.h"
+/* clang-format on */
+
+// A 21-byte shard: 5 metadata bytes plus a 16-byte value, the short form every
+// 128-bit seed produces.
+#define SHARD_LEN  21
+#define HEADER_LEN 4
+#define CRC_LEN    4
+#define FRAME_LEN  (HEADER_LEN + SHARD_LEN + CRC_LEN)
+
+// CBOR tag #6.40309, the v2 `sskr` tag.
+static void build_frame(unsigned char *buf, uint8_t initial_byte, uint8_t shard_len) {
+    buf[0] = 0xD9;
+    buf[1] = 0x9D;
+    buf[2] = 0x75;
+    buf[3] = initial_byte;
+    memset(buf + 4, 0x11, shard_len);
+    buf[4] = 0x4b;  // identifier high
+    buf[5] = 0xbf;  // identifier low
+    buf[6] = 0x00;  // group-threshold - 1 = 0, group-count - 1 = 0
+    buf[7] = 0x00;  // group-index = 0, member-threshold - 1 = 0
+    buf[8] = 0x00;  // reserved = 0, member-index = 0
+
+    // Bytewords standard form: a big-endian CRC32 of everything before it. The
+    // frames below are all otherwise well-formed, so the checksum never gets to
+    // be the reason one is refused.
+    uint32_t crc = cx_crc32(buf, 4u + shard_len);
+    buf[4 + shard_len + 0] = (unsigned char) (crc >> 24);
+    buf[4 + shard_len + 1] = (unsigned char) (crc >> 16);
+    buf[4 + shard_len + 2] = (unsigned char) (crc >> 8);
+    buf[4 + shard_len + 3] = (unsigned char) (crc);
+}
+
+// The control. Without it every refusal below would also be satisfied by a
+// function that refused everything.
+static void test_well_formed_frame_is_accepted(void **state) {
+    (void) state;
+    unsigned char frame[FRAME_LEN];
+    build_frame(frame, 0x40 | SHARD_LEN, SHARD_LEN);
+    assert_int_equal(bolos_ux_sskr_hex_check(frame, FRAME_LEN, 1), 1);
+}
+
+static void test_reserved_additional_info_is_refused(void **state) {
+    (void) state;
+    for (unsigned info = 25; info <= 31; info++) {
+        unsigned char frame[FRAME_LEN];
+        build_frame(frame, (uint8_t) (0x40 | info), SHARD_LEN);
+
+        assert_int_equal(bolos_ux_sskr_hex_check(frame, FRAME_LEN, 1), 0);
+
+        // Refused frames are erased, like every other rejection in this
+        // function: what was typed is not left sitting in the caller's buffer.
+        for (size_t i = 0; i < FRAME_LEN; i++) {
+            assert_int_equal(frame[i], 0);
+        }
+    }
+}
+
+// Additional information 24 means "one length byte follows", which is a
+// different frame shape, not a reserved value -- it has to keep working.
+static void test_long_form_is_still_accepted(void **state) {
+    (void) state;
+    // 4 tag/header bytes + 1 length byte + 24-byte shard + 4 CRC.
+    const uint8_t long_shard = 24;
+    unsigned char frame[5 + 24 + 4];
+
+    frame[0] = 0xD9;
+    frame[1] = 0x9D;
+    frame[2] = 0x75;
+    frame[3] = 0x40 | 24;   // additional information 24
+    frame[4] = long_shard;  // the declared length
+    memset(frame + 5, 0x11, long_shard);
+    frame[5] = 0x4b;
+    frame[6] = 0xbf;
+    frame[7] = 0x00;
+    frame[8] = 0x00;
+    frame[9] = 0x00;
+    uint32_t crc = cx_crc32(frame, 5u + long_shard);
+    frame[5 + long_shard + 0] = (unsigned char) (crc >> 24);
+    frame[5 + long_shard + 1] = (unsigned char) (crc >> 16);
+    frame[5 + long_shard + 2] = (unsigned char) (crc >> 8);
+    frame[5 + long_shard + 3] = (unsigned char) (crc);
+
+    assert_int_equal(bolos_ux_sskr_hex_check(frame, sizeof(frame), 1), 1);
+}
+
+// A frame whose header declares one length while the frame it arrived in is
+// another. Both directions, because the sum is what has to match, not a bound.
+static void test_declared_length_must_match_the_frame(void **state) {
+    (void) state;
+    const uint8_t mismatched[] = {20, 22, 16, 23};
+
+    for (size_t i = 0; i < sizeof(mismatched) / sizeof(mismatched[0]); i++) {
+        unsigned char frame[FRAME_LEN];
+        // The frame still holds SHARD_LEN bytes and a CRC over them; only the
+        // declared length in the header disagrees.
+        build_frame(frame, (uint8_t) (0x40 | mismatched[i]), SHARD_LEN);
+        assert_int_equal(bolos_ux_sskr_hex_check(frame, FRAME_LEN, 1), 0);
+    }
+}
+
+// bip39_type reaches bolos_ux_sskr_size_get() as the multiplicand of the shard
+// length the caller sizes a buffer from.
+static void test_size_get_refuses_unknown_bip39_type(void **state) {
+    (void) state;
+    // 2-of-3: threshold 1 with a count above 1 is refused as a singleton member,
+    // which would mask what these cases are actually about.
+    unsigned int descriptor[2] = {2, 3};
+
+    const unsigned int rejected[] = {0, 1, 11, 13, 15, 21, 23, 25, 32, 190, 191, 255};
+    for (size_t i = 0; i < sizeof(rejected) / sizeof(rejected[0]); i++) {
+        uint8_t share_len = 0xFF;
+        int16_t count = bolos_ux_sskr_size_get((uint8_t) rejected[i], 1, descriptor, 1,
+                                               &share_len);
+        assert_int_equal(count, SSKR_ERROR_INVALID_BIP39_TYPE);
+        // The output the caller sizes a buffer from, defined on the failure
+        // path as well as the success one.
+        assert_int_equal(share_len, 0);
+    }
+}
+
+static void test_size_get_accepts_the_three_offered_lengths(void **state) {
+    (void) state;
+    // 2-of-3: threshold 1 with a count above 1 is refused as a singleton member,
+    // which would mask what these cases are actually about.
+    unsigned int descriptor[2] = {2, 3};
+    const struct {
+        uint8_t words;
+        uint8_t shard_len;
+    } accepted[] = {
+        {BIP39_MNEMONIC_SIZE_12, 16 + SSKR_METADATA_LENGTH_BYTES},
+        {BIP39_MNEMONIC_SIZE_18, 24 + SSKR_METADATA_LENGTH_BYTES},
+        {BIP39_MNEMONIC_SIZE_24, 32 + SSKR_METADATA_LENGTH_BYTES},
+    };
+
+    for (size_t i = 0; i < sizeof(accepted) / sizeof(accepted[0]); i++) {
+        uint8_t share_len = 0;
+        int16_t count =
+            bolos_ux_sskr_size_get(accepted[i].words, 1, descriptor, 1, &share_len);
+        assert_int_equal(count, 3);
+        assert_int_equal(share_len, accepted[i].shard_len);
+    }
+}
+
+int main(void) {
+    const struct CMUnitTest tests[] = {
+        cmocka_unit_test(test_well_formed_frame_is_accepted),
+        cmocka_unit_test(test_reserved_additional_info_is_refused),
+        cmocka_unit_test(test_long_form_is_still_accepted),
+        cmocka_unit_test(test_declared_length_must_match_the_frame),
+        cmocka_unit_test(test_size_get_refuses_unknown_bip39_type),
+        cmocka_unit_test(test_size_get_accepts_the_three_offered_lengths),
+    };
+    return cmocka_run_group_tests(tests, NULL, NULL);
+}

--- a/tests/unit/tests/sskr_threshold_three_roundtrip.c
+++ b/tests/unit/tests/sskr_threshold_three_roundtrip.c
@@ -50,7 +50,7 @@ static void generate_three_of_five(uint8_t output[SHARD_LEN * MEMBER_COUNT],
 
     int16_t shard_count = sskr_generate_shards(
         1, groups, 1, master_secret, sizeof(master_secret), shard_len, output,
-        SHARD_LEN * MEMBER_COUNT, cx_rng);
+        SHARD_LEN * MEMBER_COUNT, test_rng);
 
     assert_int_equal(shard_count, MEMBER_COUNT);
     assert_int_equal(*shard_len, SHARD_LEN);

--- a/tests/unit/tests/sss.c
+++ b/tests/unit/tests/sss.c
@@ -225,7 +225,7 @@ static void test_sss_split(void **state) {
                                           seed,
                                           seed_length,
                                           result,
-                                          cx_rng);
+                                          test_rng);
 
     assert_int_equal(ret_val, share_count);
     assert_memory_equal(result, shares, sizeof(result));
@@ -236,7 +236,7 @@ static void test_sss_split(void **state) {
                                   seed,
                                   seed_length,
                                   result,
-                                  cx_rng);
+                                  test_rng);
 
     assert_int_equal(ret_val, SSS_ERROR_INVALID_THRESHOLD);
 }

--- a/tests/unit/tests/sss_split_erase_on_failure.c
+++ b/tests/unit/tests/sss_split_erase_on_failure.c
@@ -91,9 +91,9 @@
 /* Stands in for cx_rng. A fixed non-zero pattern rather than real
  * randomness: "the buffer is all zero afterwards" then means the erase ran,
  * not that the generator happened to hand back zeros. */
-static unsigned char* fill_with_pattern(uint8_t* buffer, size_t length) {
+static bool fill_with_pattern(uint8_t* buffer, size_t length) {
     memset(buffer, PATTERN, length);
-    return buffer;
+    return true;
 }
 
 /* threshold 2: the first loop runs zero times, so interpolate() fails

--- a/tests/unit/tests/sss_validate_parameters.c
+++ b/tests/unit/tests/sss_validate_parameters.c
@@ -42,7 +42,7 @@ static void split_expecting(uint8_t secret_length, int16_t expected) {
     memset(result, 0x00, sizeof(result));
 
     int16_t error = sss_split_secret(THRESHOLD, SHARE_COUNT, secret,
-                                     secret_length, result, cx_rng);
+                                     secret_length, result, test_rng);
 
     assert_int_equal(error, expected);
 }


### PR DESCRIPTION
Two related gaps in how SSKR handles values it does not control: the randomness it is given, and the lengths it is told.

## Share generation could not tell a failed randomness draw from a successful one

Generation draws randomness three times — the 16-bit share-set identifier, the `threshold - 2` leading shares of each split, and the random half of the integrity digest. None of the three was checked, and none of them *could* be: the generator parameter is typed `unsigned char *(*)(uint8_t *, size_t)`, which has no channel for a failure, and the BOLOS entry point it was given, `cx_rng()`, calls `cx_rng_no_throw()`, which returns `void`. Every function in `lcx_rng.h` is the same shape — `void`, or the buffer it was handed. There was no error being ignored, which is why nothing looked wrong.

What a failed draw produced was worse than an error. The identifier stayed at its zero initialiser, the coefficients and the digest padding kept whatever the previous stack frame had left in those buffers, and the shares built on them still recombined to the correct secret. Generation reported success and the user wrote down a backup that works — while the secrecy Shamir exists to provide was gone. Two shares of a 3-of-5 set drawn from stack residue are not two unknowns. Nothing on the device, in the return value or in a trace said so.

Reproduced with a generator that writes nothing, which is exactly what `cx_rng()` leaves behind on a failed draw:

```
sskr_generate_shards returned : 3        <- success
shard_len                     : 21
first shard bytes             : 00000001005cff748c6b7643a173f2d3fba243da90
                                ^^^^ identifier = 0x0000
shares from a failed RNG still recombine: YES
```

Consecutive runs give different share bytes from identical inputs, which is what confirms the values come from uninitialised stack rather than from any defined source.

`cx_get_random_bytes()` (`os_random.h`) is the same TRNG behind a syscall that returns `cx_err_t`, and it is available on every SDK this application targets, `nanos` included. `seed_sskr.c` now goes through it, the generator type carries a `bool`, and all three draw sites stop on a failed draw — erasing the output buffer, the digest and the coordinate arrays on the way out, the same cleanup the interpolation-failure path beside them already does.

`sskr_generate_shards()` needed no change: it already sets `*shard_len` to 0 up front, propagates a negative code and erases the whole output buffer, so the new `SSKR_ERROR_RNG_FAILURE` and `SSS_ERROR_RNG_FAILURE` travel out on the path the other families already use.

After the change the same reproduction gives `-19`, `shard_len = 0`, and no shares — stopping at the first failed draw rather than continuing through the split.

## Four inputs that reached an index or a buffer size unbounded

**`bolos_ux_sskr_hex_check()` and the CBOR initial byte.** That byte is three bits of major type and five of additional information (RFC 8949 section 3). The major type was tested; the additional information was not. Values 25 to 31 are reserved — two, four and eight-byte lengths, one reserved value and indefinite length — and none of them carries a length this function can act on, yet all seven were accepted. So was a declared length that disagreed with the frame it arrived in.

Nothing broke, because the refusal happened one layer away: `bolos_ux_sskr_entry_header_update()` leaves the share count at zero for a reserved value and the zero-count bound refuses the frame, while `bolos_ux_sskr_combine()` bounds the declared length itself. Both are real and both stay. What they are not is *this* function — and this is the one the entry paths call to ask whether what was typed is a share, so a caller arriving with a count of its own was handed a frame nothing had checked the shape of. It now refuses reserved additional information, and requires the declared length, the header and the CRC-32 to add up to the stride.

**`bolos_ux_sskr_size_get()` and `bip39_type`.** `*share_len` came back as `bip39_type * 4 / 3 + 5` for any `bip39_type` at all, and both callers size a buffer from it — above 190 that expression also wraps the `uint8_t` holding it. Every comparable entry point in this file bounds its parameters; this one did not. It now accepts 12, 18 and 24, and leaves `*share_len` at zero otherwise, which is the contract the rest of the file already keeps.

**`bolos_ux_bip39_mnemonic_to_seed()` and `mnemonic_length`.** The `memcpy` into `mnemonic_hash[257]` fits by an arithmetic coincidence spread over three files — `WORDS_BUFFER_MAX_SIZE_B` is also 257, `BIP39_MNEMONIC_MAX_LENGTH` is 216 — that nothing holds together. The function that owns the buffer is the one that can.

**`key_press_callback()` and `textToEnter`.** What keeps the write inside the array is the keyboard mask: `get_keyboard_mask()` disables every letter once no wordlist entry extends the prefix, and the longest BIP-39 word is eight characters. That is a guard computed elsewhere, for another purpose, that this write happens to benefit from.

Also bounded, though no path can currently reach it: `display_check_result_page()` indexes a five-element row with `1 + tool_type * 2 + seed_match`, and `TOOL_TYPE_BIP85` would give 5 or 6. The BIP85 flow goes to `display_generic_review()` and never asks for a verdict.

## Tests

`tests/unit/tests/sskr_generate_rng_failure.c` walks the whole sequence of draws a 3-of-5 split makes, failing one at a time, and holds that each comes back with a negative code, `*shard_len` at 0 and an output buffer erased in full.

`tests/unit/tests/sskr_input_validation_guards.c` calls the two SSKR entry points directly, with a count and a `bip39_type` of its own — the shape of caller the side effects above do not protect.

Both files end on a control: the same generator never failing still produces a set, and a well-formed frame is still accepted. Without those, either file would also pass against a function that refused unconditionally.

Each guard was removed again in a scratch tree to confirm the tests actually fail without it — three of four cases in the first file, three of six in the second, with the controls staying green in both.

## Two changes worth flagging in review

`sskr.h` and `sss/sss.h` did not include `<stdbool.h>`. They compiled only because every file using them had already pulled it in; the `bool` in these prototypes is what made that visible.

`test_hex_check_accepts_the_smallest_checkable_stride` built its stride-8 control frame with an initial byte of `0x55`, declaring 21 bytes of payload in a frame carrying none — which only passed because the declared length was never read. It is `0x40` now, a zero-length byte string: self-consistent, and still not a shard. The division of responsibility that test records, between framing here and shard length in `bolos_ux_sskr_combine()`, is unchanged.

`tests/unit` now builds with `src/` on the include path, the way `APP_SOURCE_PATH` puts it there for the device build, so an application source can include `"constants.h"` as it already does elsewhere.

`fuzzing/extra/host_syscalls.c` gains a stand-in for `cx_get_random_bytes()` beside the one it already has for `cx_rng_no_throw()`. Without it `libseedparsers.a` carries an undefined reference and every fuzz target fails to link.

The last commit is unrelated to the rest: `src/bagl/nanox_enter_phrase.c` is already failing `clang-format --dry-run --Werror` on `bip85`, so the lint job is red before this branch touches anything. It is pure line wrapping with no semantic change, fixed here only so this can be read against a green CI — happy to split it out.

## Verification

- six declared targets build, zero application-source warnings on each
- unit suite 77/77
- functional suite 11/11 on `stax` and `flex`, 2 passed / 9 skipped on `nanox` and `nanos+`
- fuzz targets link, and `cx_get_random_bytes` resolves inside `libseedparsers.a`
- ASan + UBSan clean over the changed code at `-O0` and `-O2`
- each new guard falsified by removing it and watching the matching test go red
