### PR TITLE
fix: bound the two-button entry writes, and split the field they depend on

### DIFF
--- a/src/bagl/nanos_enter_phrase.c
+++ b/src/bagl/nanos_enter_phrase.c
@@ -193,8 +193,20 @@ const bagl_element_t* screen_onboarding_restore_word_keyboard_callback(
                 }
             } else {
                 // validate next letter of the word
-                G_ux.string_buffer[16 + strlen(G_ux.string_buffer + 16)] =
-                    G_ux.string_buffer[32 +
+                //
+                // The stem cannot reach the candidate letters at offset 32
+                // while the keyboard only offers letters that extend a real
+                // prefix, because no word in either list is that long. This
+                // is the same bound expressed where the write happens, so
+                // that it does not depend on the wordlist staying that shape.
+                const size_t stem_length =
+                    strlen(G_ux.string_buffer + RESTORE_STEM_OFFSET);
+                if (stem_length >= RESTORE_STEM_MAX_LENGTH) {
+                    return NULL;
+                }
+
+                G_ux.string_buffer[RESTORE_STEM_OFFSET + stem_length] =
+                    G_ux.string_buffer[RESTORE_CANDIDATES_OFFSET +
                                        G_bolos_ux_context.hslider3_current];
 
                 // continue displaying until less than X words matches the stem
@@ -395,6 +407,18 @@ void compare_recovery_phrase_and_display_result(void) {
 
 void screen_onboarding_restore_word_validate(void) {
     if (G_bolos_ux_context.tool_type == TOOL_TYPE_BIP39) {
+        // The SSKR branch below bounds its own buffer; this one did not.
+        // bolos_ux_bip39_idx_strcpy() writes a word and a terminator at
+        // words_buffer_length, and what keeps that inside words_buffer is
+        // bip39_type -- which the SSKR entry path also writes, with a share
+        // length of its own (see the loop bound in this file). The menu
+        // always resets it before a BIP-39 entry, so the two never meet
+        // today; this is the bound that does not rely on them not meeting.
+        if (G_bolos_ux_context.words_buffer_length + BIP39_MAX_WORD_LENGTH + 1 >
+            WORDS_BUFFER_MAX_SIZE_B) {
+            return;
+        }
+
         bolos_ux_bip39_idx_strcpy(
             G_bolos_ux_context.onboarding_index +
                 G_bolos_ux_context.hslider3_current,
@@ -432,6 +456,24 @@ void screen_onboarding_restore_word_validate(void) {
     G_bolos_ux_context.onboarding_step++;
 
     if (G_bolos_ux_context.tool_type == TOOL_TYPE_BIP39) {
+        // bip39_type carries two unrelated meanings. The 12/18/24 menu writes
+        // the word count here, and the SSKR entry path writes the wire length
+        // of a share -- up to SSKR_SHARE_MAX_WIRE_LENGTH -- into the same
+        // field, a few lines above. It is what bounds this loop, and through
+        // it the writes into words_buffer.
+        //
+        // The two never collide today: number_of_bip39_words_selector() always
+        // reassigns bip39_type before screen_onboarding_bip39_restore_init(),
+        // and generate_sskr() is unreachable from the SSKR flow. Both are
+        // properties of the screen graph, held nowhere near this line. If
+        // either stops holding, this stops the entry rather than letting the
+        // loop run to a share length.
+        if (G_bolos_ux_context.bip39_type != BIP39_MNEMONIC_SIZE_12 &&
+            G_bolos_ux_context.bip39_type != BIP39_MNEMONIC_SIZE_18 &&
+            G_bolos_ux_context.bip39_type != BIP39_MNEMONIC_SIZE_24) {
+            return;
+        }
+
         if (G_bolos_ux_context.onboarding_step ==
             G_bolos_ux_context.bip39_type) {
             unsigned char valid;
@@ -464,7 +506,13 @@ void screen_onboarding_restore_word_validate(void) {
                     PROCESSING_COMPARE_RECOVERY_PHRASE;
             }
         } else {
-            // add a space before next word
+            // add a space before next word, if there is room for it and for
+            // the word that follows
+            if (G_bolos_ux_context.words_buffer_length + BIP39_MAX_WORD_LENGTH +
+                    2 >
+                WORDS_BUFFER_MAX_SIZE_B) {
+                return;
+            }
             G_bolos_ux_context
                 .words_buffer[G_bolos_ux_context.words_buffer_length++] = ' ';
 

--- a/src/bagl/nanos_enter_phrase.c
+++ b/src/bagl/nanos_enter_phrase.c
@@ -410,10 +410,8 @@ void screen_onboarding_restore_word_validate(void) {
         // The SSKR branch below bounds its own buffer; this one did not.
         // bolos_ux_bip39_idx_strcpy() writes a word and a terminator at
         // words_buffer_length, and what keeps that inside words_buffer is
-        // bip39_type -- which the SSKR entry path also writes, with a share
-        // length of its own (see the loop bound in this file). The menu
-        // always resets it before a BIP-39 entry, so the two never meet
-        // today; this is the bound that does not rely on them not meeting.
+        // bip39_type, which is now written only by the 12/18/24 menu. This
+        // is the bound that does not rely on that staying true.
         if (G_bolos_ux_context.words_buffer_length + BIP39_MAX_WORD_LENGTH + 1 >
             WORDS_BUFFER_MAX_SIZE_B) {
             return;
@@ -441,13 +439,13 @@ void screen_onboarding_restore_word_validate(void) {
             .sskr_words_buffer[G_bolos_ux_context.sskr_words_buffer_length] =
             G_bolos_ux_context.onboarding_index +
             G_bolos_ux_context.hslider3_current;
-        size_t final_size = G_bolos_ux_context.bip39_type;
+        size_t final_size = G_bolos_ux_context.sskr_share_word_count;
         bolos_ux_sskr_entry_header_update(
             (const uint8_t*)G_bolos_ux_context.sskr_words_buffer,
             G_bolos_ux_context.sskr_words_buffer_length,
             G_bolos_ux_context.onboarding_step, &final_size,
             &G_bolos_ux_context.sskr_share_count);
-        G_bolos_ux_context.bip39_type = (unsigned int)final_size;
+        G_bolos_ux_context.sskr_share_word_count = (unsigned int)final_size;
 
         G_bolos_ux_context.sskr_words_buffer_length++;
     }
@@ -456,18 +454,12 @@ void screen_onboarding_restore_word_validate(void) {
     G_bolos_ux_context.onboarding_step++;
 
     if (G_bolos_ux_context.tool_type == TOOL_TYPE_BIP39) {
-        // bip39_type carries two unrelated meanings. The 12/18/24 menu writes
-        // the word count here, and the SSKR entry path writes the wire length
-        // of a share -- up to SSKR_SHARE_MAX_WIRE_LENGTH -- into the same
-        // field, a few lines above. It is what bounds this loop, and through
-        // it the writes into words_buffer.
-        //
-        // The two never collide today: number_of_bip39_words_selector() always
-        // reassigns bip39_type before screen_onboarding_bip39_restore_init(),
-        // and generate_sskr() is unreachable from the SSKR flow. Both are
-        // properties of the screen graph, held nowhere near this line. If
-        // either stops holding, this stops the entry rather than letting the
-        // loop run to a share length.
+        // bip39_type is what bounds this loop, and through it the writes into
+        // words_buffer. Only number_of_bip39_words_selector() writes it, and
+        // only with these three values -- but that is a property of the screen
+        // graph, held nowhere near this line, and a screen that reached word
+        // entry without passing through the menu would run the loop to
+        // whatever the field happened to hold.
         if (G_bolos_ux_context.bip39_type != BIP39_MNEMONIC_SIZE_12 &&
             G_bolos_ux_context.bip39_type != BIP39_MNEMONIC_SIZE_18 &&
             G_bolos_ux_context.bip39_type != BIP39_MNEMONIC_SIZE_24) {
@@ -524,7 +516,7 @@ void screen_onboarding_restore_word_validate(void) {
         }
     } else if (G_bolos_ux_context.tool_type == TOOL_TYPE_SSKR) {
         if (G_bolos_ux_context.onboarding_step ==
-            G_bolos_ux_context.bip39_type) {
+            G_bolos_ux_context.sskr_share_word_count) {
             G_bolos_ux_context.sskr_share_index++;
 
             if (G_bolos_ux_context.sskr_share_index <
@@ -663,6 +655,12 @@ void screen_onboarding_restore_word_init(unsigned int firstWord) {
                 G_bolos_ux_context.words_buffer_length);
         G_bolos_ux_context.words_buffer_length = 0;
         G_bolos_ux_context.sskr_words_buffer_length = 0;
+        // Not yet known: it comes out of the CBOR header of the first share,
+        // four words in. Reset here and not when moving to the next share of
+        // the same set, which reaches this function with
+        // RESTORE_WORD_ACTION_REENTER_WORD precisely so that the shape read
+        // from the first share is kept.
+        G_bolos_ux_context.sskr_share_word_count = 0;
     }
 
     memzero(G_ux.string_buffer, sizeof(G_ux.string_buffer));

--- a/src/bagl/nanox_enter_phrase.c
+++ b/src/bagl/nanox_enter_phrase.c
@@ -173,8 +173,20 @@ const bagl_element_t* screen_onboarding_restore_word_keyboard_callback(
                 }
             } else {
                 // validate next letter of the word
-                G_ux.string_buffer[16 + strlen(G_ux.string_buffer + 16)] =
-                    G_ux.string_buffer[32 +
+                //
+                // The stem cannot reach the candidate letters at offset 32
+                // while the keyboard only offers letters that extend a real
+                // prefix, because no word in either list is that long. This
+                // is the same bound expressed where the write happens, so
+                // that it does not depend on the wordlist staying that shape.
+                const size_t stem_length =
+                    strlen(G_ux.string_buffer + RESTORE_STEM_OFFSET);
+                if (stem_length >= RESTORE_STEM_MAX_LENGTH) {
+                    return NULL;
+                }
+
+                G_ux.string_buffer[RESTORE_STEM_OFFSET + stem_length] =
+                    G_ux.string_buffer[RESTORE_CANDIDATES_OFFSET +
                                        G_bolos_ux_context.hslider3_current];
 
                 // continue displaying until less than X words matches the stem
@@ -365,6 +377,18 @@ screen_onboarding_restore_word_before_element_display_callback(
 
 void screen_onboarding_restore_word_validate(void) {
     if (G_bolos_ux_context.tool_type == TOOL_TYPE_BIP39) {
+        // The SSKR branch below bounds its own buffer; this one did not.
+        // bolos_ux_bip39_idx_strcpy() writes a word and a terminator at
+        // words_buffer_length, and what keeps that inside words_buffer is
+        // bip39_type -- which the SSKR entry path also writes, with a share
+        // length of its own (see the loop bound in this file). The menu
+        // always resets it before a BIP-39 entry, so the two never meet
+        // today; this is the bound that does not rely on them not meeting.
+        if (G_bolos_ux_context.words_buffer_length + BIP39_MAX_WORD_LENGTH + 1 >
+            WORDS_BUFFER_MAX_SIZE_B) {
+            return;
+        }
+
         bolos_ux_bip39_idx_strcpy(
             G_bolos_ux_context.onboarding_index +
                 G_bolos_ux_context.hslider3_current,
@@ -402,6 +426,24 @@ void screen_onboarding_restore_word_validate(void) {
     G_bolos_ux_context.onboarding_step++;
 
     if (G_bolos_ux_context.tool_type == TOOL_TYPE_BIP39) {
+        // bip39_type carries two unrelated meanings. The 12/18/24 menu writes
+        // the word count here, and the SSKR entry path writes the wire length
+        // of a share -- up to SSKR_SHARE_MAX_WIRE_LENGTH -- into the same
+        // field, a few lines above. It is what bounds this loop, and through
+        // it the writes into words_buffer.
+        //
+        // The two never collide today: number_of_bip39_words_selector() always
+        // reassigns bip39_type before screen_onboarding_bip39_restore_init(),
+        // and generate_sskr() is unreachable from the SSKR flow. Both are
+        // properties of the screen graph, held nowhere near this line. If
+        // either stops holding, this stops the entry rather than letting the
+        // loop run to a share length.
+        if (G_bolos_ux_context.bip39_type != BIP39_MNEMONIC_SIZE_12 &&
+            G_bolos_ux_context.bip39_type != BIP39_MNEMONIC_SIZE_18 &&
+            G_bolos_ux_context.bip39_type != BIP39_MNEMONIC_SIZE_24) {
+            return;
+        }
+
         if (G_bolos_ux_context.onboarding_step ==
             G_bolos_ux_context.bip39_type) {
             unsigned char valid;
@@ -435,8 +477,7 @@ void screen_onboarding_restore_word_validate(void) {
                 bool reconstructed = true;
                 // Against VERDICT_MATCH, not "not zero": every other value,
                 // corrupted or not, is a mismatch. See common.h.
-                if (compare_recovery_phrase(&reconstructed) ==
-                    VERDICT_MATCH) {
+                if (compare_recovery_phrase(&reconstructed) == VERDICT_MATCH) {
                     ux_flow_init(0, &ux_bip39_match_flow, NULL);
                 } else {
                     memzero(G_bolos_ux_context.words_buffer,
@@ -445,7 +486,13 @@ void screen_onboarding_restore_word_validate(void) {
                 }
             }
         } else {
-            // add a space before next word
+            // add a space before next word, if there is room for it and for
+            // the word that follows
+            if (G_bolos_ux_context.words_buffer_length + BIP39_MAX_WORD_LENGTH +
+                    2 >
+                WORDS_BUFFER_MAX_SIZE_B) {
+                return;
+            }
             G_bolos_ux_context
                 .words_buffer[G_bolos_ux_context.words_buffer_length++] = ' ';
 
@@ -482,9 +529,8 @@ void screen_onboarding_restore_word_validate(void) {
                     ux_flow_init(0, ux_load_flow, NULL);
                     bool reconstructed = true;
                     // Against VERDICT_MATCH, as above.
-                    const bool match =
-                        (compare_recovery_phrase(&reconstructed) ==
-                         VERDICT_MATCH);
+                    const bool match = (compare_recovery_phrase(
+                                            &reconstructed) == VERDICT_MATCH);
                     if (!reconstructed) {
                         // shards were well-formed but could not be combined
                         ux_flow_init(0, &ux_sskr_invalid_flow, NULL);

--- a/src/bagl/nanox_enter_phrase.c
+++ b/src/bagl/nanox_enter_phrase.c
@@ -380,10 +380,8 @@ void screen_onboarding_restore_word_validate(void) {
         // The SSKR branch below bounds its own buffer; this one did not.
         // bolos_ux_bip39_idx_strcpy() writes a word and a terminator at
         // words_buffer_length, and what keeps that inside words_buffer is
-        // bip39_type -- which the SSKR entry path also writes, with a share
-        // length of its own (see the loop bound in this file). The menu
-        // always resets it before a BIP-39 entry, so the two never meet
-        // today; this is the bound that does not rely on them not meeting.
+        // bip39_type, which is now written only by the 12/18/24 menu. This
+        // is the bound that does not rely on that staying true.
         if (G_bolos_ux_context.words_buffer_length + BIP39_MAX_WORD_LENGTH + 1 >
             WORDS_BUFFER_MAX_SIZE_B) {
             return;
@@ -411,13 +409,13 @@ void screen_onboarding_restore_word_validate(void) {
             .sskr_words_buffer[G_bolos_ux_context.sskr_words_buffer_length] =
             G_bolos_ux_context.onboarding_index +
             G_bolos_ux_context.hslider3_current;
-        size_t final_size = G_bolos_ux_context.bip39_type;
+        size_t final_size = G_bolos_ux_context.sskr_share_word_count;
         bolos_ux_sskr_entry_header_update(
             (const uint8_t*)G_bolos_ux_context.sskr_words_buffer,
             G_bolos_ux_context.sskr_words_buffer_length,
             G_bolos_ux_context.onboarding_step, &final_size,
             &G_bolos_ux_context.sskr_share_count);
-        G_bolos_ux_context.bip39_type = (unsigned int)final_size;
+        G_bolos_ux_context.sskr_share_word_count = (unsigned int)final_size;
 
         G_bolos_ux_context.sskr_words_buffer_length++;
     }
@@ -426,18 +424,12 @@ void screen_onboarding_restore_word_validate(void) {
     G_bolos_ux_context.onboarding_step++;
 
     if (G_bolos_ux_context.tool_type == TOOL_TYPE_BIP39) {
-        // bip39_type carries two unrelated meanings. The 12/18/24 menu writes
-        // the word count here, and the SSKR entry path writes the wire length
-        // of a share -- up to SSKR_SHARE_MAX_WIRE_LENGTH -- into the same
-        // field, a few lines above. It is what bounds this loop, and through
-        // it the writes into words_buffer.
-        //
-        // The two never collide today: number_of_bip39_words_selector() always
-        // reassigns bip39_type before screen_onboarding_bip39_restore_init(),
-        // and generate_sskr() is unreachable from the SSKR flow. Both are
-        // properties of the screen graph, held nowhere near this line. If
-        // either stops holding, this stops the entry rather than letting the
-        // loop run to a share length.
+        // bip39_type is what bounds this loop, and through it the writes into
+        // words_buffer. Only number_of_bip39_words_selector() writes it, and
+        // only with these three values -- but that is a property of the screen
+        // graph, held nowhere near this line, and a screen that reached word
+        // entry without passing through the menu would run the loop to
+        // whatever the field happened to hold.
         if (G_bolos_ux_context.bip39_type != BIP39_MNEMONIC_SIZE_12 &&
             G_bolos_ux_context.bip39_type != BIP39_MNEMONIC_SIZE_18 &&
             G_bolos_ux_context.bip39_type != BIP39_MNEMONIC_SIZE_24) {
@@ -502,7 +494,7 @@ void screen_onboarding_restore_word_validate(void) {
         }
     } else if (G_bolos_ux_context.tool_type == TOOL_TYPE_SSKR) {
         if (G_bolos_ux_context.onboarding_step ==
-            G_bolos_ux_context.bip39_type) {
+            G_bolos_ux_context.sskr_share_word_count) {
             G_bolos_ux_context.sskr_share_index++;
 
             if (G_bolos_ux_context.sskr_share_index <
@@ -617,6 +609,12 @@ void screen_onboarding_restore_word_init(unsigned int firstWord) {
                 G_bolos_ux_context.words_buffer_length);
         G_bolos_ux_context.words_buffer_length = 0;
         G_bolos_ux_context.sskr_words_buffer_length = 0;
+        // Not yet known: it comes out of the CBOR header of the first share,
+        // four words in. Reset here and not when moving to the next share of
+        // the same set, which reaches this function with
+        // RESTORE_WORD_ACTION_REENTER_WORD precisely so that the shape read
+        // from the first share is kept.
+        G_bolos_ux_context.sskr_share_word_count = 0;
     }
 
     memzero(G_ux.string_buffer, sizeof(G_ux.string_buffer));

--- a/src/bagl/ux_nano.h
+++ b/src/bagl/ux_nano.h
@@ -30,6 +30,21 @@ void bolos_ux_hslider3_set_current(unsigned int current);
 void bolos_ux_hslider3_next(void);
 void bolos_ux_hslider3_previous(void);
 
+// Layout of G_ux.string_buffer while a word is being entered, as
+// screen_onboarding_restore_word_init() describes it: display scratch at 0,
+// the stem entered so far at 16, the candidate next letters at 32.
+//
+// The stem therefore has RESTORE_STEM_MAX_LENGTH characters before its
+// terminator would land on the first candidate. What keeps it inside that
+// today is the wordlist -- the longest BIP-39 word is BIP39_MAX_WORD_LENGTH
+// characters, a ByteWord is SSKR_BYTEWORD_LENGTH, and the keyboard only offers
+// letters that extend a real prefix. That is a bound computed in another file,
+// for another purpose, that these writes happen to benefit from; the names
+// below are the buffer's own.
+#define RESTORE_STEM_OFFSET       16
+#define RESTORE_CANDIDATES_OFFSET 32
+#define RESTORE_STEM_MAX_LENGTH   (RESTORE_CANDIDATES_OFFSET - RESTORE_STEM_OFFSET - 1)
+
 // all screens
 void screen_onboarding_bip39_restore_init(void);
 void screen_onboarding_sskr_restore_init(void);

--- a/src/bagl/ux_nano.h
+++ b/src/bagl/ux_nano.h
@@ -53,8 +53,22 @@ void screen_onboarding_restore_word_display_auto_complete(void);
 
 // bolos ux context (not mandatory if redesigning a bolos ux)
 typedef struct bolos_ux_context {
-    // 12, 18 or 24 word BIP39
+    // 12, 18 or 24 word BIP39. Written by the 12/18/24 menu and by nothing
+    // else: the SSKR entry path used to store a share length here too, which
+    // made the field mean two things and left the bound on words_buffer
+    // depending on which screen had been visited last.
     unsigned int bip39_type;
+
+    // How many ByteWords one SSKR share holds, taken from the CBOR header of
+    // the first share as it is typed.
+    //
+    // Zero until the fourth word of that share has been entered, which is the
+    // earliest bolos_ux_sskr_entry_header_update() can know it -- and zero is
+    // a safe "not yet": the entry loop compares it against a step count that
+    // has already been incremented, so it never matches before the header has
+    // been read. Every share of a set has the same shape, so it is read once
+    // and kept for the shares that follow.
+    unsigned int sskr_share_word_count;
 
     // Type of tool we are using (BIP39 or SSKR)
     unsigned int tool_type;

--- a/tests/functional/nano.py
+++ b/tests/functional/nano.py
@@ -125,6 +125,17 @@ def select_in_menu(navigator, label, timeout=30):
                                   screen_change_before_first_instruction=False)
 
 
+def confirm(backend):
+    """Click through a screen that only asks to be acknowledged.
+
+    The SSKR flow opens on such a screen -- an instruction step whose callback
+    starts the share entry (`ux_sskr_instruction_step`, src/bagl/ui.c) -- and
+    it carries no carousel, so neither `select_in_menu()` nor the two carousel
+    helpers below apply to it.
+    """
+    _click(backend, "both")
+
+
 def enter_letter(backend, letter):
     """Move the letter carousel onto `letter` and validate it.
 

--- a/tests/functional/test_sskr_entry_two_button.py
+++ b/tests/functional/test_sskr_entry_two_button.py
@@ -1,0 +1,70 @@
+"""
+Entering SSKR shares on the two-button devices.
+
+test_sskr_128bit.py and test_sskr_256bit.py enter the same shares on the touch
+devices and skip on Nano X and Nano S+, so the two-button share-entry path --
+src/bagl/nanox_enter_phrase.c and src/bagl/nanos_enter_phrase.c, which is a
+different implementation of the same screen, not a different rendering of one
+-- had no end-to-end coverage at all.
+
+That path is where the shape of a share is worked out while it is being typed:
+the fourth ByteWord of the first share carries the CBOR byte-string header, and
+`bolos_ux_sskr_entry_header_update()` reads how many words the share holds out
+of it. The entry loop then runs to that count, for this share and for the ones
+after it. Nothing else on the device decides when a share is complete.
+
+The shares below are the ones test_sskr_128bit.py enters, for the same seed:
+two 2-of-3 shards of the 128-bit Blockchain Commons test vector. Any valid pair
+would do -- what is being checked is that the two-button screens accept them
+and reach the same verdict the touch screens do.
+"""
+
+from pytest import fixture
+from pytest import mark
+from pytest import skip
+from ledgered.devices import DeviceType
+from ragger.conftest import configuration
+import nano
+
+# https://github.com/BlockchainCommons/crypto-commons/blob/master/Docs/sskr-test-vector.md#128-bit-seed
+DEVICE_PHRASE = "fly mule excess resource treat plunge nose soda reflect adult ramp planet"
+
+# Two of the three shards of a 2-of-3 split of that seed, as
+# test_sskr_128bit.py enters them.
+SHARDS = [
+    "tuna next keep gyro paid claw able acid able jowl chef drum judo pool "
+    "lion keep idle cusp iced rust fact view twin very pose epic whiz jump jury",
+    "tuna next keep gyro paid claw able acid acid gray quad kiln wall kept "
+    "deli mild epic race fuel dice blue game yank fern bulb gear jade navy cost",
+]
+
+
+@fixture(scope='session')
+def set_seed():
+    configuration.OPTIONAL.CUSTOM_SEED = DEVICE_PHRASE
+
+
+@mark.use_on_backend("speculos")
+def test_sskr_entry_two_button(device, backend, navigator, set_seed):
+    if device.type == DeviceType.NANOS:
+        # Speculos has dropped Nano S; the build is still produced and this
+        # test would drive it unchanged if the emulator returns.
+        skip("Nano S is not emulated by the current Speculos")
+    if device.type not in (DeviceType.NANOX, DeviceType.NANOSP):
+        skip("Two-button devices only; the touch path is covered elsewhere")
+
+    nano.select_in_menu(navigator, "Check SSKR")
+    # The SSKR flow opens on an instruction screen whose callback starts the
+    # entry; the BIP-39 flow reaches the keyboard through its word-count menu
+    # instead, which is why the other two-button test needs no equivalent.
+    nano.confirm(backend)
+
+    for shard in SHARDS:
+        for word in shard.split():
+            nano.enter_word(backend, word)
+
+    # The verdict, both lines. The first one alone is shared with the screen
+    # that says the phrase does not match, so asserting it on its own would
+    # assert nothing about the answer -- the same reason
+    # test_bip39_seed_match.py checks two lines.
+    nano.wait_for_lines(backend, "SSKR Phrase", "is correct")


### PR DESCRIPTION
Three writes in the two-button entry screens reach a buffer through a value bounded somewhere else, and one field that carries two unrelated meanings is what most of them are bounded by.

## The writes

**The stem.** Each accepted letter is appended at `G_ux.string_buffer[16 + strlen(G_ux.string_buffer + 16)]`, and the candidate letters begin at offset 32. Nothing at the write says so. What keeps the two apart is the wordlist — the longest BIP-39 word is eight characters, a ByteWord is four, and the keyboard only offers letters that extend a real prefix — so the stem stops growing long before it reaches them. The layout is now named in `ux_nano.h` and the write checks against it.

**The mnemonic buffer.** `bolos_ux_bip39_idx_strcpy()` writes a word and a terminator at `words_buffer_length`, and the separator that follows is written with a bare post-increment. Neither was bounded. The SSKR branch immediately below, in the same function, does bound its own buffer and says why; this one was left as it was.

Neither guard can fire on any input the screens can produce today. That is the point: they hold what the wordlist already holds, at the place where the write happens rather than three files away.

## The field

What bounded the mnemonic buffer was `bip39_type`, and `bip39_type` held two unrelated things. The 12/18/24 menu wrote a word count into it, and the SSKR entry path wrote the wire length of a share — taken from the CBOR byte-string header as it is typed, up to `SSKR_SHARE_MAX_WIRE_LENGTH` — into the same field a few lines above. A word count of 46 would have run the BIP-39 entry loop 46 times over a 257-byte buffer.

**The two never met**, and that was traced in each direction rather than assumed:

- `number_of_bip39_words_selector()` always reassigns `bip39_type` before `screen_onboarding_bip39_restore_init()`, so a BIP-39 entry never starts on a share length;
- `generate_sskr()` is reachable only from `ux_bip39_match_flow`; after an SSKR check the only offer is `recover_bip39()`, which displays and nothing more.

Both are properties of the screen graph, held nowhere near the writes that depend on them. A flow that offered "generate shares" after an SSKR recovery — a natural thing to add — would have broken both at once.

`sskr_share_word_count` now carries the share length. `bip39_type` is written by the menu and by nothing else, so what bounds the BIP-39 entry no longer depends on which screen was visited last. The entry loop additionally refuses a `bip39_type` that is not one of the three word counts, so a screen that ever reached word entry without passing through the menu stops rather than running the loop to whatever the field happened to hold.

The new field starts at zero, which is also why zero is the right "not yet known": the loop compares it against a step count that has already been incremented, so it cannot match before the header has been read at the fourth word. It is reset only on `RESTORE_WORD_ACTION_FIRST_WORD` — moving to the next share of a set arrives with `REENTER_WORD` precisely so that the shape read from the first share is kept.

## The test that was missing

Share entry on the two-button screens is a separate implementation of that screen, not a different rendering of one, and it had no end-to-end coverage: every SSKR test skips on Nano X and Nano S+. It is also the only path that exercises the field this branch introduces.

`tests/functional/test_sskr_entry_two_button.py` enters the shares `test_sskr_128bit.py` enters, on both devices, and asserts both lines of the verdict — the first one is shared with the screen that says the phrase does not match, so asserting it alone would assert nothing about the answer.

It was checked against a broken field rather than assumed to cover it: setting the initial value to 2 stops the entry at the third word and turns the test red, while 5 leaves it green. That difference is the header-read timing described above, and it is what makes the test meaningful.

`nano.confirm()` clicks through a screen that only asks to be acknowledged. The SSKR flow opens on one; the BIP-39 flow reaches the keyboard through its word-count menu instead.

## Share generation on the same devices

The other half of the feature had the same gap, for the same reason: the two
menus that pick the share count and the threshold, and `generate_sskr()` behind
them, are two-button code that no test reached. That path is not screen code —
it goes through `bolos_ux_bip39_to_sskr_convert()` to the Shamir split, its
randomness, and the CBOR and ByteWords encoding of every share.

`tests/functional/test_sskr_generate_two_button.py` covers it. The shares
cannot be asserted, since the share-set identifier is random, but the CBOR tag
and the byte-string header in front of them are fixed for a 12-word seed — the
same `tuna next keep gyro` the touch tests assert. Changing one byte of that
tag turns the test red, so it is reading generated output.

Two helpers were needed, neither a wrapper around `navigate_until_text()`:
`choose_in_flow()` for the bounded verdict flows, where a right click on the
last step changes nothing and `navigate_until_text()` reports that as a stuck
screen; and `choose_in_carousel()` for `UX_STEP_MENULIST`, which shows several
entries and selects one, so "3 is on the screen" is true while "1" is the entry
that would be validated.

## Verification

- six declared targets build, zero application-source warnings on each
- `clang-format --dry-run --Werror` clean over `src/`
- functional suite: Nano X and Nano S+ go from 2 passing to 4; Stax and Flex unchanged at 11
- unit suite 75/75
- both new tests falsified against a deliberately broken build, as described above

## Not covered

Share entry and generation on the two-button screens are exercised for the successful path only. The error paths — an invalid phrase, invalid shares, a wrong CRC, too few shares, a duplicated share, a threshold the scheme refuses — remain uncovered there, as does the rest of the suite that still skips on those devices.
