### PR TITLE
tests: cover SSKR generation on the two-button devices

### DIFF
--- a/tests/functional/nano.py
+++ b/tests/functional/nano.py
@@ -125,6 +125,30 @@ def select_in_menu(navigator, label, timeout=30):
                                   screen_change_before_first_instruction=False)
 
 
+def choose_in_flow(backend, label, timeout_clicks=None):
+    """Walk a bounded UX_FLOW to the step showing `label`, then validate it.
+
+    select_in_menu() above is Ragger's navigate_until_text(), which is right
+    for a menu list: those loop, so a click always changes the screen. The
+    verdict flows do not loop -- ux_bip39_match_flow and its neighbours in
+    src/bagl/ux_nano.c are three fixed steps -- so a right click on the last
+    one changes nothing, and navigate_until_text() cannot tell that from a
+    screen that has stopped responding. It reports the second as the first.
+
+    _click() returns whether anything moved, which is what makes the
+    difference visible here.
+    """
+    limit = timeout_clicks if timeout_clicks is not None else _MAX_CLICKS
+    for _ in range(limit):
+        if any(text.startswith(label) for text in _texts(backend)):
+            _click(backend, "both")
+            return
+        if not _click(backend, "right"):
+            break
+    raise AssertionError(
+        f"{label!r} is not on any step of this flow; last saw {_texts(backend)}")
+
+
 def confirm(backend):
     """Click through a screen that only asks to be acknowledged.
 
@@ -134,6 +158,36 @@ def confirm(backend):
     helpers below apply to it.
     """
     _click(backend, "both")
+
+
+def choose_in_carousel(backend, label):
+    """Walk a menu carousel onto `label` and validate it.
+
+    The share-count and threshold menus (UX_STEP_MENULIST, src/bagl/ux_sskr.c)
+    put several entries on the screen at once and select one of them, the same
+    shape as the letter carousel below and, for the same reason, not something
+    `select_in_menu()` can drive: navigate_until_text() finds "3" on the very
+    first screen, where "1" is the entry actually selected, and validates the
+    wrong one.
+
+    Unlike the letters these are not ordered in a way this can exploit -- "10"
+    sorts before "2" as a string -- so it only ever walks right, and stops when
+    the carousel does.
+
+    Each of these menus is preceded by an instruction step carrying no
+    carousel; a right click moves off it, which is what the first iterations do
+    while `current` is None.
+    """
+    for _ in range(_MAX_CLICKS):
+        current = _carousel_current(backend)
+        if current == label:
+            _click(backend, "both")
+            return
+        if not _click(backend, "right"):
+            raise AssertionError(
+                f"{label!r} is not offered by this menu; it stopped at "
+                f"{current!r}")
+    raise AssertionError(f"could not reach {label!r} in the menu")
 
 
 def enter_letter(backend, letter):

--- a/tests/functional/test_sskr_generate_two_button.py
+++ b/tests/functional/test_sskr_generate_two_button.py
@@ -1,0 +1,66 @@
+"""
+Generating SSKR shares on the two-button devices.
+
+test_sskr_128bit.py and test_sskr_256bit.py generate shares on the touch
+devices and skip on Nano X and Nano S+, so this half of the feature had no
+end-to-end coverage there at all -- neither the two menus that pick the share
+count and the threshold (src/bagl/ux_sskr.c) nor generate_sskr() behind them.
+
+What that path runs is not UI code. It reaches bolos_ux_bip39_to_sskr_convert()
+and through it the Shamir split, its randomness, and the CBOR and ByteWords
+encoding of every share. None of that is device-specific, but the arguments it
+is called with are: the two-button screens compute them in their own file, from
+their own context fields, and a mistake there is invisible to the touch tests.
+
+The shares themselves cannot be asserted: the 16-bit share-set identifier is
+drawn at random, so two runs of the same split produce different ByteWords.
+What is fixed is everything in front of it -- the CBOR tag #6.40309 (`d9 9d 75`)
+and the byte-string header of a 21-byte shard (`0x55`), which is what a 12-word
+seed always produces. Those four bytes are "tuna next keep gyro", the same
+prefix test_sskr_128bit.py asserts on the touch devices.
+"""
+
+from pytest import fixture
+from pytest import mark
+from pytest import skip
+from ledgered.devices import DeviceType
+from ragger.conftest import configuration
+import nano
+
+# https://github.com/BlockchainCommons/crypto-commons/blob/master/Docs/sskr-test-vector.md#128-bit-seed
+DEVICE_PHRASE = "fly mule excess resource treat plunge nose soda reflect adult ramp planet"
+
+SHARE_COUNT = 3
+THRESHOLD = 2
+
+
+@fixture(scope='session')
+def set_seed():
+    configuration.OPTIONAL.CUSTOM_SEED = DEVICE_PHRASE
+
+
+@mark.use_on_backend("speculos")
+def test_sskr_generate_two_button(device, backend, navigator, set_seed):
+    if device.type == DeviceType.NANOS:
+        skip("Nano S is not emulated by the current Speculos")
+    if device.type not in (DeviceType.NANOX, DeviceType.NANOSP):
+        skip("Two-button devices only; the touch path is covered elsewhere")
+
+    nano.select_in_menu(navigator, "Check BIP39")
+    nano.select_in_menu(navigator, "12 words")
+    nano.enter_phrase(backend, DEVICE_PHRASE)
+
+    # The phrase is the device's, so the verdict is a match -- and only the
+    # match flow offers to generate shares (ux_bip39_match_flow,
+    # src/bagl/ux_nano.c). Asserting it here is what makes the rest of this
+    # test mean "generation from a verified phrase" rather than "generation".
+    nano.wait_for_lines(backend, "BIP39 Phrase", "is correct")
+
+    nano.choose_in_flow(backend, "Generate")
+    nano.choose_in_carousel(backend, str(SHARE_COUNT))
+    nano.choose_in_carousel(backend, str(THRESHOLD))
+
+    # The tag and the byte-string header of a 21-byte shard, which is what a
+    # 12-word seed produces. Everything after them is the shard, and the
+    # share-set identifier inside it is random.
+    nano.wait_for_lines(backend, "tuna next keep gyro")


### PR DESCRIPTION
Share generation on the two-button devices had no end-to-end coverage. `test_sskr_128bit.py` and `test_sskr_256bit.py` generate shares on the touch devices and skip on Nano X and Nano S+, so neither the two menus that pick the share count and the threshold (`src/bagl/ux_sskr.c`) nor `generate_sskr()` behind them was ever reached there.

That path is not screen code. It goes through `bolos_ux_bip39_to_sskr_convert()` to the Shamir split, its randomness, and the CBOR and ByteWords encoding of every share. None of that is device-specific, but the arguments it is called with are: the two-button screens compute them in their own file, from their own context fields, and a mistake there is invisible to the touch tests.

The shares themselves cannot be asserted — the share-set identifier is drawn at random, so two runs of the same split produce different ByteWords. What is fixed is everything in front of it: the CBOR tag #6.40309 and the byte-string header of a 21-byte shard, which is what a 12-word seed always produces, and which is the `tuna next keep gyro` the touch tests already assert. Changing one byte of that tag in `bolos_ux_bip39_to_sskr_convert()` turns this test red, so it is reading generated output rather than a screen that happens to say the right thing.

The verdict is asserted before the generation menus are opened, both of its lines. Only the match flow offers to generate, which is what makes this "generation from a phrase the device agreed with" rather than just "generation".

## Two helpers

Neither is a wrapper around `navigate_until_text()`, for the reason `nano.py` exists at all.

`choose_in_flow()` walks a bounded `UX_FLOW`. The verdict flows are three fixed steps with no loop, so a right click on the last one changes nothing — `navigate_until_text()` cannot tell that from a screen that has stopped responding, and reports the second.

`choose_in_carousel()` walks a `UX_STEP_MENULIST`. Those put several entries on the screen and select one of them, so "3 is on the screen" is not the condition to stop on: on the first screen of the share-count menu it is true while "1" is the entry that would be validated. Same reason `enter_letter()` beside it tests the position rather than the text.

## Verification

- Nano X and Nano S+ build and the new test passes on both
- checked against a deliberately broken CBOR tag, where it fails as described

## Not covered

The successful path only. The error paths on these devices — an invalid phrase, invalid shares, a wrong CRC, too few shares, a duplicated share, a threshold the scheme refuses — remain uncovered, as does the rest of the suite that still skips there.
