### PR TITLE
fix: make the public headers self-contained, define two outputs, pin the third-party actions

### DIFF
--- a/.github/workflows/lint-workflow.yml
+++ b/.github/workflows/lint-workflow.yml
@@ -29,7 +29,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803  # v6
 
       # PRINTF is compiled out at DEBUG=0, which is the default and what is
       # released -- but at DEBUG=1 it leaves the Nano targets over SEPROXYHAL,

--- a/.github/workflows/release-workflow.yml
+++ b/.github/workflows/release-workflow.yml
@@ -16,7 +16,7 @@ jobs:
       contents: write
     steps:
       - name: Clone
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262  # v4
         with:
           ref: ${{ github.event.workflow_run.head_branch }}
 
@@ -27,7 +27,7 @@ jobs:
           echo "VERSION_NAME=${HEAD_BRANCH//./_}" >> ${GITHUB_ENV}
 
       - name: Download app binaries
-        uses: dawidd6/action-download-artifact@v6
+        uses: dawidd6/action-download-artifact@bf251b5aa9c2f7eeb574a96ee720e24f801b7c11  # v6
         with:
           name: compiled_app_binaries
           path: ./bin/
@@ -40,7 +40,7 @@ jobs:
         run: ls -la ./bin/ && sudo mv ./bin/compiled_app_binaries.zip ./bin/compiled_app_binaries.${VERSION_NAME}.zip && ls -la ./bin/
 
       - name: Create Release
-        uses: ncipollo/release-action@v1
+        uses: ncipollo/release-action@339a81892b84b4eeb0f6e744e4574d79d0d9b8dd  # v1
         with:
           name: Seed Tool application for Ledger - Release ${{ env.VERSION_NUMBER }}
           artifacts: ./bin/*.zip

--- a/.github/workflows/unit-tests-matrix.yml
+++ b/.github/workflows/unit-tests-matrix.yml
@@ -80,7 +80,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803  # v6
 
       - name: Build OpenSSL dependency (no matrix flags)
         working-directory: tests/unit

--- a/src/common/bip39/common_bip39.h
+++ b/src/common/bip39/common_bip39.h
@@ -17,6 +17,10 @@
 
 #pragma once
 
+#include <stdbool.h>
+#include <stddef.h>
+#include <stdint.h>
+
 // Hashes an over-long mnemonic down to 64 bytes in its own frame, so that the
 // pbkdf2 call in bolos_ux_bip39_mnemonic_to_seed() does not carry this one's
 // locals. Kept out of line and with external linkage for that reason -- static

--- a/src/common/common.h
+++ b/src/common/common.h
@@ -17,6 +17,9 @@
 
 #pragma once
 
+#include <stdbool.h>
+#include <stdint.h>
+
 #define ALPHABET_LENGTH 27
 #define KBD_LETTERS     "qwertyuiopasdfghjklzxcvbnm"
 

--- a/src/common/sskr/common_sskr.h
+++ b/src/common/sskr/common_sskr.h
@@ -17,6 +17,10 @@
 
 #pragma once
 
+#include <stdbool.h>
+#include <stddef.h>
+#include <stdint.h>
+
 // SSKR helpers
 #include "./seed_rom_variables.h"
 #include "./sskr-constants.h"

--- a/src/common/sskr/seed_sskr.c
+++ b/src/common/sskr/seed_sskr.c
@@ -306,6 +306,13 @@ unsigned int bolos_ux_bip39_to_sskr_convert(
     unsigned int bip39_type, unsigned int* group_descriptor,
     uint8_t* share_count, unsigned char* share_words_buffer,
     unsigned int* share_words_buffer_length) {
+    // Defined before anything can fail. Every early exit below already sets
+    // it, but the branch that does not run at all -- a mnemonic the decoder
+    // refuses -- used to leave the caller's count at whatever it held, and
+    // both callers keep it in a struct that outlives the call. The count is
+    // how many share screens the review then pages through.
+    *share_count = 0;
+
     // get seed from bip39 mnemonic
     uint8_t seed_len = bip39_type * 4 / 3;
     uint8_t seed_buffer[SSKR_MAX_STRENGTH_BYTES + 1];

--- a/src/common/sskr/sss/sss.c
+++ b/src/common/sskr/sss/sss.c
@@ -84,6 +84,14 @@ uint8_t* sss_create_digest(const uint8_t* random_data, uint32_t rdlen,
         result[j] = buf[j];
     }
 
+    // Four of the thirty-two bytes are the digest; the other twenty-eight are
+    // the rest of an HMAC over the secret, and they were left on the stack.
+    // They are not the secret -- HMAC does not run backwards -- but every
+    // other local in this file is erased, including the digest and the
+    // coordinate arrays a few lines below, and this one had no reason to be
+    // the exception.
+    memzero(buf, sizeof(buf));
+
     return result;
 }
 

--- a/src/common/sskr/sss/sss.h
+++ b/src/common/sskr/sss/sss.h
@@ -8,6 +8,7 @@
 #ifndef SSS_H
 #define SSS_H
 
+#include <stddef.h>
 #include <stdint.h>
 #include <stdbool.h>
 #include "sss-constants.h"

--- a/tests/unit/CMakeLists.txt
+++ b/tests/unit/CMakeLists.txt
@@ -281,6 +281,53 @@ target_link_libraries(test_sskr_to_seed_convert PUBLIC cmocka gcov sskr sss test
 add_executable(test_sskr_generate_combine_guards tests/sskr_generate_combine_guards.c)
 target_link_libraries(test_sskr_generate_combine_guards PUBLIC cmocka gcov testutils sskr sss)
 
+# Every public header of src/common/, each compiled as the first thing in a
+# translation unit of its own.
+#
+# One file including them all in turn does not work: the second header is
+# satisfied by whatever the first one included. Hence one object library per
+# header, all of them the same source with a different HEADER_UNDER_TEST, and
+# an executable that only has to depend on them -- compiling is the test.
+set(SEED_PUBLIC_HEADERS
+    bip39/common_bip39.h
+    sskr/common_sskr.h
+    sskr/sskr.h
+    sskr/sskr-constants.h
+    sskr/group.h
+    sskr/shard.h
+    sskr/sss/sss.h
+    sskr/sss/sss-constants.h
+    bip85/common_bip85.h
+    bip85/bip85_internal.h
+    common.h)
+
+add_executable(test_header_self_contained tests/header_self_contained_main.c)
+target_link_libraries(test_header_self_contained PUBLIC cmocka gcov testutils)
+
+foreach(hdr ${SEED_PUBLIC_HEADERS})
+    string(MAKE_C_IDENTIFIER "${hdr}" hdr_id)
+    add_library(hdrchk_${hdr_id} OBJECT tests/header_self_contained.c)
+    target_compile_definitions(hdrchk_${hdr_id} PRIVATE HEADER_UNDER_TEST="${hdr}")
+    # cx_errors.h includes <stdint.h>, so it goes in front of only the header
+    # that needs cx_err_t. In front of all of them it would satisfy the very
+    # dependency this check exists to find.
+    if(hdr STREQUAL "common.h")
+        target_compile_definitions(hdrchk_${hdr_id} PRIVATE HEADER_NEEDS_CX_ERRORS)
+    endif()
+    # The project's own include path, the same one the application build
+    # gives these files. What is being checked is that a caller does not have
+    # to supply <stdint.h> and friends, not that a header resolves its
+    # neighbours without help: sskr-constants.h includes sss-constants.h by
+    # bare name, and does so in the device build too.
+    target_include_directories(hdrchk_${hdr_id} PRIVATE
+        ${CMAKE_CURRENT_SOURCE_DIR}/../../src/common
+        ${CMAKE_CURRENT_SOURCE_DIR}/../../src/common/sskr
+        ${CMAKE_CURRENT_SOURCE_DIR}/../../src/common/sskr/sss
+        ${CMAKE_CURRENT_SOURCE_DIR}/lib
+        $ENV{LEDGER_SECURE_SDK}/lib_cxng/include)
+    add_dependencies(test_header_self_contained hdrchk_${hdr_id})
+endforeach()
+
 add_executable(test_sskr_threshold_three_roundtrip tests/sskr_threshold_three_roundtrip.c)
 target_link_libraries(test_sskr_threshold_three_roundtrip PUBLIC cmocka gcov testutils sskr sss)
 

--- a/tests/unit/tests/header_self_contained.c
+++ b/tests/unit/tests/header_self_contained.c
@@ -1,0 +1,57 @@
+/*
+ * One public header of src/common/, included first and with nothing before it.
+ *
+ * A header that uses uint8_t, size_t or bool without including <stdint.h>,
+ * <stddef.h> or <stdbool.h> compiles anywhere its callers happened to pull
+ * those in first, and nowhere else. Four of them were in that state, and it
+ * only showed when a new translation unit put one of them at the top: the
+ * `bool` added to sskr.h and sss/sss.h for the randomness callback would not
+ * compile, and neither would a file whose first include was common_bip39.h.
+ *
+ * Nothing already in this suite can hold that. Every file that includes these
+ * headers also includes os.h, cx.h or the standard headers ahead of them, so
+ * the whole suite stays green with the dependency unmet.
+ *
+ * Neither can one file that includes them all in turn -- the first honest
+ * attempt at this check was exactly that, and it did not work: the second
+ * header in the list is satisfied by whatever the first one included, so
+ * deleting the includes from common_sskr.h left it compiling. Each header
+ * needs a translation unit to itself, which is what CMakeLists.txt builds by
+ * compiling this same file once per header with a different
+ * HEADER_UNDER_TEST.
+ *
+ * `WIDE` is a separate matter and deliberately outside the claim. It is the
+ * SDK's storage qualifier, supplied by arch.h through os.h on the device and
+ * by lib/testutils.h here; two of the three seed_rom_variables.h define a
+ * fallback for it, sskr's does not. What these headers must not require of a
+ * caller is the *standard* types.
+ *
+ * There is nothing to run. If every one of these objects compiles, the
+ * property holds; the executable that depends on them is in
+ * header_self_contained_main.c.
+ */
+
+#ifndef HEADER_UNDER_TEST
+#error "HEADER_UNDER_TEST must name the header this translation unit checks"
+#endif
+
+#define WIDE
+
+/* cx_err_t, which common.h needs for compare_recovery_phrase_finish(). A
+ * device type rather than a standard one, so it is outside the claim -- but it
+ * is pulled in only for the header that needs it, because cx_errors.h includes
+ * <stdint.h> and would otherwise satisfy every header under test. That is
+ * exactly what the second attempt at this check got wrong: with cx_errors.h in
+ * front of all of them, stripping the includes from any header still
+ * compiled. */
+#ifdef HEADER_NEEDS_CX_ERRORS
+/* common.h is the one header this check cannot falsify. It needs cx_err_t, so
+ * cx_errors.h has to precede it, and cx_errors.h brings <stdint.h> and (through
+ * ledger_assert.h) <stdbool.h> with it -- deleting common.h's own includes
+ * still compiles. They are kept there because they state what the header uses,
+ * but no test holds them. Every other header in the list is genuinely
+ * falsifiable, and was checked that way. */
+#include <cx_errors.h>
+#endif
+
+#include HEADER_UNDER_TEST

--- a/tests/unit/tests/header_self_contained_main.c
+++ b/tests/unit/tests/header_self_contained_main.c
@@ -1,0 +1,25 @@
+/*
+ * The executable that carries the header checks. The work is done at compile
+ * time by the object libraries this depends on -- see header_self_contained.c
+ * and the loop that builds one of them per header in CMakeLists.txt. If they
+ * compile, the property holds.
+ */
+
+#include <cmocka.h>
+#include <setjmp.h>
+#include <stdarg.h>
+#include <stddef.h>
+
+static void test_headers_are_self_contained(void **state) {
+    (void) state;
+    /* Reaching here means every header compiled as the first thing in a
+     * translation unit of its own. */
+    assert_true(1);
+}
+
+int main(void) {
+    const struct CMUnitTest tests[] = {
+        cmocka_unit_test(test_headers_are_self_contained),
+    };
+    return cmocka_run_group_tests(tests, NULL, NULL);
+}


### PR DESCRIPTION
Three small things, each one an output or a dependency that was left to whatever happened to be around it.

## The public headers of `src/common` did not stand on their own

`common_bip39.h`, `common_sskr.h` and `common.h` use `uint8_t`, `size_t` and `bool` without including `<stdint.h>`, `<stddef.h>` or `<stdbool.h>`; `sss/sss.h` uses `size_t` without `<stddef.h>`. They compile anywhere their callers pull those in first, and nowhere else. It showed twice recently: the `bool` added to `sskr.h` and `sss/sss.h` for the randomness callback did not compile, and neither did a file whose first include was `common_bip39.h`.

Nothing already in the suite could hold this — every file that includes these headers also includes `os.h`, `cx.h` or the standard headers ahead of them, so the property stays green while unmet.

`tests/unit/tests/header_self_contained.c` is one translation unit per header: the same source compiled once for each with a different `HEADER_UNDER_TEST`. Compiling is the whole test.

Two earlier shapes of that check did not work, which is why it looks like this:

- one file including every header in turn passes with the dependency unmet, because the second header is satisfied by whatever the first one included — stripping the includes back out of `common_sskr.h` left it compiling;
- putting `cx_errors.h` in front of all of them has the same effect from another direction, since it includes `<stdint.h>` itself.

So `cx_errors.h` now precedes only `common.h`, which needs `cx_err_t`. That makes **`common.h` the one header this cannot falsify**: `cx_errors.h` brings `<stdint.h>` and, through `ledger_assert.h`, `<stdbool.h>`, so deleting its own includes still compiles. They are kept because they state what it uses, and the file says plainly that no test holds them. The other ten were each checked by deleting their includes and watching the build fail.

## Two outputs left undefined

`bolos_ux_bip39_to_sskr_convert()` writes `*share_count` only inside the branch that runs when the mnemonic decodes. A mnemonic the decoder refuses skips the whole body and returns 1, leaving the caller's count at whatever it held — and both callers keep it in a struct that outlives the call, where it is the number of share screens the review then pages through. Not reachable today, since the phrase is checked before this is called, but it is the one output of this function that was undefined on a path out of it.

`sss_create_digest()` copies four bytes of an HMAC into the caller's buffer and left the other twenty-eight on the stack. They are not the secret — HMAC does not run backwards — but every other local in that file is erased, including the digest and the coordinate arrays a few lines below.

## Third-party actions pinned

`dawidd6/action-download-artifact` and `ncipollo/release-action` were on major version tags, which are mutable, and both run inside the release job — the one holding `contents: write` that downloads a build artefact and publishes it. `actions/checkout` is pinned alongside them, at the two versions the workflows already used. Each SHA carries its tag as a comment so the version stays readable and Dependabot can still offer updates.

The reusable workflows under `LedgerHQ/ledger-app-workflows` stay on `@v1`: that is Ledger's convention for their applications, and pinning them here would freeze this repository against fixes made on their side.

## Verification

- six declared targets build, zero application-source warnings on each
- `clang-format` clean over `src/`, `actionlint` reports nothing new
- unit suite 78/78, functional suite unchanged on every device
- ten of the eleven headers falsified individually; the eleventh is documented above
