### PR TITLE
tests: read the SSKR refusals and the generated shares off the screen

### DIFF
--- a/tests/functional/nano.py
+++ b/tests/functional/nano.py
@@ -103,6 +103,16 @@ def _title(backend):
     return min(events, key=lambda e: e["y"]).get("text", "")
 
 
+def _lines(backend):
+    """The screen's text, topmost line first.
+
+    Ordered by y rather than by the order the events arrive in, which is what
+    separates a `bnnn_paging` title from the body underneath it.
+    """
+    events = [e for e in _events(backend) if e.get("y") is not None]
+    return [e.get("text", "") for e in sorted(events, key=lambda e: e["y"])]
+
+
 def select_in_menu(navigator, label, timeout=30):
     """Walk a one-item-at-a-time list until `label` is on screen, then choose it.
 
@@ -258,6 +268,41 @@ def enter_phrase(backend, phrase):
     """Enter a whole BIP-39 phrase."""
     for word in phrase.split():
         enter_word(backend, word)
+
+
+def collect_shares(backend, limit=60):
+    """Read the generated SSKR shares off the screen, as lists of ByteWords.
+
+    Generation ends on `dynamic_flow` (src/bagl/ux_sskr.c), which shows one
+    share at a time through a `bnnn_paging` step titled "SSKR Share #N (p/q)"
+    and splits a share over as many pages as it needs. Walking right goes
+    through the pages of a share, then on to the next share, and reaches a
+    "Quit" step once the last one has been shown -- which is where this stops.
+
+    Going on past that step would not start over. The flow loops, but
+    `get_next_data()` clamps the share index instead of wrapping it, so the
+    walk comes back to the last share and stays there. The "Quit" step is
+    therefore the only honest end marker, and running out of clicks without
+    reaching it is an error rather than a reason to return a short list.
+
+    Returns one list of words per share, in share order.
+    """
+    shares = {}
+    for _ in range(limit):
+        lines = _lines(backend)
+        if not lines:
+            raise AssertionError("the screen went blank while reading shares")
+        title = lines[0]
+        if not title.startswith("SSKR Share #"):
+            # The "Quit" step, i.e. every share has been shown.
+            return [words for _, words in sorted(shares.items())]
+        index = int(title.split("#", 1)[1].split(maxsplit=1)[0])
+        shares.setdefault(index, []).extend(
+            word for line in lines[1:] for word in line.split())
+        _click(backend, "right")
+    raise AssertionError(
+        f"the share display never reached its last step; read {len(shares)} "
+        f"share(s)")
 
 
 def wait_for_lines(backend, *lines, timeout=10.0):

--- a/tests/functional/test_sskr_duplicate_share_two_button.py
+++ b/tests/functional/test_sskr_duplicate_share_two_button.py
@@ -1,0 +1,79 @@
+"""
+Entering the same SSKR share twice, on the two-button devices.
+
+This covers the outcome of the share-entry screen that sits between the two
+obvious ones. Shares that reconstruct the onboarded seed are entered by
+test_sskr_entry_two_button.py, and shares whose CRC is wrong are refused in
+test_two_button_refusals.py before anything is combined. What had no
+end-to-end test on any device is the case in between -- shares that are
+individually well-formed and still cannot be combined.
+
+The distinction is the point. `bolos_ux_sskr_hex_check()` accepts a share pair
+made of the same share twice, and does so deliberately: the shares carry a
+valid CBOR header, identical cross-share metadata and genuine CRC-32s, so
+there is nothing in the frame to reject. That acceptance is pinned by
+tests/unit/tests/sskr_duplicate_member_index.c, which also pins the refusal
+one layer down -- sskr_combine_shards() answers
+SSKR_ERROR_DUPLICATE_MEMBER_INDEX and bolos_ux_sskr_combine() answers 0.
+
+What no test pinned is the screen the user is then shown. In
+src/bagl/nanox_enter_phrase.c the answer runs through `reconstructed`, a flag
+distinct from the verdict itself:
+
+    if (!reconstructed)   -> ux_sskr_invalid_flow   "SSKR Recovery"/"phrase invalid"
+    else if (match)       -> ux_sskr_match_flow     "SSKR Phrase"/"is correct"
+    else                  -> ux_sskr_nomatch_flow   "SSKR Phrase"/"doesn't match"
+
+Collapsing the first branch into the third is the failure this test exists to
+catch, and it is a plausible one -- combination failed, so the reconstructed
+seed does not match, and reporting a mismatch looks locally reasonable. It
+would be the wrong answer: "doesn't match" tells the user their shares belong
+to some other seed, sending them to look for the wrong shares, when what
+actually happened is that they entered one share twice and need a second,
+different share. Both branches refuse; only one of them says something true.
+
+The two lines are both asserted because the two screens differ on both of
+them, so either line alone would leave the other branch passing.
+"""
+
+from pytest import fixture
+from pytest import mark
+from pytest import skip
+from ledgered.devices import DeviceType
+from ragger.conftest import configuration
+import nano
+
+# https://github.com/BlockchainCommons/crypto-commons/blob/master/Docs/sskr-test-vector.md#128-bit-seed
+DEVICE_PHRASE = "fly mule excess resource treat plunge nose soda reflect adult ramp planet"
+
+# The first shard of the 2-of-3 split of that seed used by
+# test_sskr_128bit.py and test_sskr_entry_two_button.py. Entered twice below.
+# Its member-threshold nibble is what tells the device to ask for two shares,
+# so the entry loop runs to completion exactly as it would for a genuine pair.
+SHARD = ("tuna next keep gyro paid claw able acid able jowl chef drum judo pool "
+         "lion keep idle cusp iced rust fact view twin very pose epic whiz jump jury")
+
+
+@fixture(scope='session')
+def set_seed():
+    configuration.OPTIONAL.CUSTOM_SEED = DEVICE_PHRASE
+
+
+@mark.use_on_backend("speculos")
+def test_sskr_duplicate_share_is_refused_as_invalid(device, backend, navigator,
+                                                    set_seed):
+    if device.type == DeviceType.NANOS:
+        # Speculos has dropped Nano S; the build is still produced and this
+        # test would drive it unchanged if the emulator returns.
+        skip("Nano S is not emulated by the current Speculos")
+    if device.type not in (DeviceType.NANOX, DeviceType.NANOSP):
+        skip("Two-button devices only; the touch path is covered elsewhere")
+
+    nano.select_in_menu(navigator, "Check SSKR")
+    nano.confirm(backend)
+
+    for _ in range(2):
+        for word in SHARD.split():
+            nano.enter_word(backend, word)
+
+    nano.wait_for_lines(backend, "SSKR Recovery", "phrase invalid")

--- a/tests/functional/test_sskr_generate_two_button.py
+++ b/tests/functional/test_sskr_generate_two_button.py
@@ -14,10 +14,26 @@ their own context fields, and a mistake there is invisible to the touch tests.
 
 The shares themselves cannot be asserted: the 16-bit share-set identifier is
 drawn at random, so two runs of the same split produce different ByteWords.
-What is fixed is everything in front of it -- the CBOR tag #6.40309 (`d9 9d 75`)
-and the byte-string header of a 21-byte shard (`0x55`), which is what a 12-word
-seed always produces. Those four bytes are "tuna next keep gyro", the same
-prefix test_sskr_128bit.py asserts on the touch devices.
+Their shape can be, and it is what a split has to get right. Each share is
+read back off the display and held to four things:
+
+  * three shares come out when three were asked for;
+  * each is 29 ByteWords -- the CBOR tag #6.40309 (`d9 9d 75`), the byte-string
+    header of a 21-byte shard (`0x55`), 5 metadata bytes and 16 of share value
+    inside it, then a 4-byte CRC-32. Those first four bytes are "tuna next keep
+    gyro", the same prefix test_sskr_128bit.py asserts on the touch devices;
+  * all three carry the same first eight words, so they belong to one share
+    set -- shares of different sets would never combine;
+  * their ninth words are "able", "acid" and "also", ByteWords for 0x00, 0x01
+    and 0x02. That byte is the reserved nibble followed by the member index
+    (BCR-2020-011), so this says both that the reserved nibble is zero and
+    that the three shares are numbered rather than being three copies of one
+    share -- which is the failure that would make the split worthless while
+    still looking like a split.
+
+This flow ends on a step that quits the application, so the shares cannot be
+fed back into "Check SSKR" without a second run of the emulator, and no
+round-trip is attempted here.
 """
 
 from pytest import fixture
@@ -32,6 +48,7 @@ DEVICE_PHRASE = "fly mule excess resource treat plunge nose soda reflect adult r
 
 SHARE_COUNT = 3
 THRESHOLD = 2
+SHARE_LENGTH = 29
 
 
 @fixture(scope='session')
@@ -60,7 +77,19 @@ def test_sskr_generate_two_button(device, backend, navigator, set_seed):
     nano.choose_in_carousel(backend, str(SHARE_COUNT))
     nano.choose_in_carousel(backend, str(THRESHOLD))
 
-    # The tag and the byte-string header of a 21-byte shard, which is what a
-    # 12-word seed produces. Everything after them is the shard, and the
-    # share-set identifier inside it is random.
-    nano.wait_for_lines(backend, "tuna next keep gyro")
+    shares = nano.collect_shares(backend)
+
+    assert len(shares) == SHARE_COUNT, \
+        f"asked for {SHARE_COUNT} shares, {len(shares)} were displayed"
+
+    for index, words in enumerate(shares, start=1):
+        assert len(words) == SHARE_LENGTH, \
+            f"share #{index} is {len(words)} words, expected {SHARE_LENGTH}"
+        assert words[:4] == ["tuna", "next", "keep", "gyro"], \
+            f"share #{index} does not open on the SSKR tag: {words[:4]}"
+
+    assert len({tuple(words[:8]) for words in shares}) == 1, \
+        "the shares do not carry a common share-set header"
+
+    assert [words[8] for words in shares] == ["able", "acid", "also"], \
+        f"unexpected member-index bytes: {[words[8] for words in shares]}"

--- a/tests/functional/test_sskr_threshold_refusal_two_button.py
+++ b/tests/functional/test_sskr_threshold_refusal_two_button.py
@@ -1,0 +1,70 @@
+"""
+Asking for a 1-of-3 SSKR split, on the two-button devices.
+
+A threshold of 1 over more than one share is refused: each share would on its
+own reconstruct the seed, so the split would hand out three copies of the
+secret while looking like a split. `sskr_threshold_selector()` in
+src/bagl/ux_sskr.c stops there and shows ux_threshold_warn_flow instead of
+generating anything.
+
+The refusal had no test that reads the screen. test_sskr_unsupported_values.py
+drives the equivalent touch path, but its assertion on the message is
+commented out, with the reason given in the file: the touch status page lasts
+three seconds and the test cannot catch it in time. What it asserts instead is
+that the application comes back to the "Generate SSKR" screen -- which a
+build that silently ignored the choice and returned would also satisfy. So on
+no device did anything check that the user is told why nothing was generated.
+
+On the two-button devices the refusal is not a transient status page but an
+ordinary flow that waits for the user, so the message can simply be read, and
+that is what this test does.
+
+The other half of the guarantee is structural and already holds: the threshold
+list is built by `sskr_threshold_getter()`, which bounds itself by the share
+count the user has just chosen, so a threshold above the number of shares
+cannot be offered in the first place and there is no screen to assert about
+it.
+"""
+
+from pytest import fixture
+from pytest import mark
+from pytest import skip
+from ledgered.devices import DeviceType
+from ragger.conftest import configuration
+import nano
+
+# Same seed as the other functional tests.
+# https://github.com/BlockchainCommons/crypto-commons/blob/master/Docs/sskr-test-vector.md#128-bit-seed
+DEVICE_PHRASE = "fly mule excess resource treat plunge nose soda reflect adult ramp planet"
+
+
+@fixture(scope='session')
+def set_seed():
+    configuration.OPTIONAL.CUSTOM_SEED = DEVICE_PHRASE
+
+
+@mark.use_on_backend("speculos")
+def test_sskr_threshold_of_one_is_refused(device, backend, navigator, set_seed):
+    if device.type == DeviceType.NANOS:
+        # Speculos has dropped Nano S; the build is still produced and this
+        # test would drive it unchanged if the emulator returns.
+        skip("Nano S is not emulated by the current Speculos")
+    if device.type not in (DeviceType.NANOX, DeviceType.NANOSP):
+        skip("Two-button devices only; the touch path is covered elsewhere")
+
+    # Generation is only reachable through a phrase the device agrees with,
+    # so the phrase below is the one it was seeded with.
+    nano.select_in_menu(navigator, "Check BIP39")
+    nano.select_in_menu(navigator, "12 words")
+    nano.enter_phrase(backend, DEVICE_PHRASE)
+    nano.wait_for_lines(backend, "BIP39 Phrase", "is correct")
+
+    # The verdict flow carries the entry into generation on its last step.
+    nano.choose_in_flow(backend, "Generate")
+
+    nano.choose_in_carousel(backend, "3")
+    nano.choose_in_carousel(backend, "1")
+
+    # Both lines, because the flow's second step is another warning screen and
+    # the first line alone would not say which one was reached.
+    nano.wait_for_lines(backend, "1-of-m shares", "where m > 1")


### PR DESCRIPTION
Two ways the SSKR flow can refuse had never been read off a screen, on any
device, and the generation test asserted only the first four words of the first
share.

### A share entered twice — new

`bolos_ux_sskr_hex_check()` accepts a pair made of the same share twice, and
does so deliberately: valid CBOR header, identical cross-share metadata,
genuine CRC-32s — there is nothing in the frame to reject. Combination is what
fails, so the screen the user is shown is decided by `reconstructed` rather
than by the verdict:

```
if (!reconstructed)   -> "SSKR Recovery"/"phrase invalid"
else if (match)       -> "SSKR Phrase"/"is correct"
else                  -> "SSKR Phrase"/"doesn't match"
```

Collapsing the first branch into the third is a plausible mistake — combination
failed, so the seed does not match, and reporting a mismatch looks locally
reasonable. It would be the wrong answer: "doesn't match" tells the user their
shares belong to some other seed, sending them to look for the wrong shares,
when what happened is that they entered one share twice and need a different
one. The unit tests pin the refusal at the SSKR layer; nothing pinned the
screen. `test_two_button_refusals.py` covers the neighbouring case, a share
whose CRC is wrong, which is refused one layer earlier.

### A threshold of 1 — new

`test_sskr_unsupported_values.py` drives the equivalent touch path, but its
assertion on the message is commented out — the touch status page lasts three
seconds and the test cannot catch it. What it asserts instead is that the
application returns to the "Generate SSKR" screen, which a build that silently
ignored the choice would also satisfy. On these devices the refusal is an
ordinary flow that waits for the user, so the message can simply be read.

The other half of that guarantee is structural and already holds:
`sskr_threshold_getter()` bounds the threshold list by the share count just
chosen, so a threshold above the number of shares is never offered and there is
no screen to assert about it.

### Generation — strengthened

`test_sskr_generate_two_button.py` generated a 2-of-3 split and asserted "tuna
next keep gyro", the CBOR tag and byte-string header. That leaves the split
itself unchecked: the same four words come out of any share of any set.

The shares still cannot be pinned — the 16-bit share-set identifier is drawn at
random, so two runs produce different ByteWords — but their shape can, so each
share is now read back off the display and held to four things:

* three shares come out when three were asked for;
* each is 29 ByteWords — 4 of tag and header, 21 of shard, 4 of CRC-32;
* all three carry the same first eight words, so they belong to one share set;
* their ninth words are `able`, `acid`, `also` — ByteWords for `0x00`, `0x01`,
  `0x02`. That byte is the reserved nibble followed by the member index
  (BCR-2020-011), so this says both that the reserved nibble is zero and that
  the three shares are numbered rather than being three copies of one share,
  which would make the split worthless while still looking like a split.

The flow ends on a step that quits the application, so the shares cannot be fed
back into "Check SSKR" without a second run of the emulator; no round-trip is
attempted.

### Helpers

`nano.py` gains `collect_shares()`, which reads a share back across the pages
`bnnn_paging` splits it over, and `_lines()` under it, ordering the screen by y
so that a title can be told from the body. Walking stops at the "Quit" step:
the flow loops, but `get_next_data()` clamps the share index rather than
wrapping it, so going further comes back to the last share and stays there.

### Checking

Each test was run against a deliberately broken build and confirmed to fail
there. The binary is compared by hash before and after each mutation, because a
build that fails to recompile leaves the previous one in place and turns a
falsification into a test that passes for no reason:

| Test | Mutation | Result |
| --- | --- | --- |
| duplicate share | `!reconstructed` sent to the no-match flow | fails |
| threshold refusal | the 1-of-m guard made unreachable | fails |
| generation | share count taken as `idx` instead of `idx + 1` | fails |

The duplicate-share mutation touches only the `!reconstructed` branch and
leaves the `hex_check()` one alone, so its failure also confirms which of the
two the pair actually goes through.
