### PR TITLE
fix: bound bolos_ux_sskr_combine() by the frame it was handed

### DIFF
--- a/src/common/sskr/seed_sskr.c
+++ b/src/common/sskr/seed_sskr.c
@@ -177,8 +177,8 @@ unsigned int bolos_ux_sskr_combine(unsigned char* sskr_shares_hex,
         return 0;
     }
     const unsigned int header_len = 4u + (additional_info == 24);
-    uint8_t sskr_share_len = (additional_info == 24) ? sskr_shares_hex[4]
-                                                     : (uint8_t)additional_info;
+    uint8_t sskr_share_len =
+        (additional_info == 24) ? sskr_shares_hex[4] : (uint8_t)additional_info;
 
     // The length comes from the entered data. A serialized shard is
     // SSKR_METADATA_LENGTH_BYTES plus a SSKR_MIN_STRENGTH_BYTES..

--- a/src/common/sskr/seed_sskr.c
+++ b/src/common/sskr/seed_sskr.c
@@ -135,6 +135,24 @@ unsigned int bolos_ux_sskr_combine(unsigned char* sskr_shares_hex,
         memzero(sskr_shares_hex, sskr_shares_hex_length);
         return 0;
     }
+    // The distance from one share to the next, and the only thing that says
+    // how much of the buffer belongs to each. The count bound above constrains
+    // the divisor; nothing so far has constrained the dividend, so without
+    // this every read below is off a buffer of unknown length.
+    //
+    // bolos_ux_sskr_hex_check() derives the same guarantee from the same
+    // quotient -- a stride of at least five with a share count of at least one
+    // leaves bytes 3 and 4 inside the first share -- and that guard was never
+    // carried over here. Every path in the application reaches this function
+    // through hex_check(), which refuses a short frame first, so what this
+    // closes is the contract of the function rather than a reachable path;
+    // see tests/unit/tests/sskr_combine_frame_length.c.
+    const unsigned int stride = sskr_shares_hex_length / sskr_shares_count;
+    if (stride < 5) {
+        memzero(sskr_shares_hex, sskr_shares_hex_length);
+        return 0;
+    }
+
     // The shard length is read out of the low five bits of byte 3 below, which
     // is only a length if that byte is a CBOR byte-string header. A share is
     // one; anything else is not a share, and its low five bits mean something
@@ -143,10 +161,24 @@ unsigned int bolos_ux_sskr_combine(unsigned char* sskr_shares_hex,
         memzero(sskr_shares_hex, sskr_shares_hex_length);
         return 0;
     }
-    uint8_t sskr_share_len = sskr_shares_hex[3] & 0x1F;
-    if (sskr_share_len > 23) {
-        sskr_share_len = sskr_shares_hex[4];
+
+    // RFC 8949 section 3 gives additional information 0..23 the meaning "this
+    // is the length" and 24 "one length byte follows"; 25..31 are two-, four-
+    // and eight-byte lengths, a reserved value and the indefinite form, none
+    // of which a share may use. Refused for the same reason hex_check()
+    // refuses them: the form is what decides where the shard starts, and a
+    // reserved one carries no length this function could act on. Deriving the
+    // header length from the additional information rather than from the
+    // decoded length is what makes the two agree -- a long form declaring 21
+    // to 23 bytes put the shard at offset 4 here and at offset 5 there.
+    const unsigned int additional_info = sskr_shares_hex[3] & 0x1F;
+    if (additional_info > 24) {
+        memzero(sskr_shares_hex, sskr_shares_hex_length);
+        return 0;
     }
+    const unsigned int header_len = 4u + (additional_info == 24);
+    uint8_t sskr_share_len = (additional_info == 24) ? sskr_shares_hex[4]
+                                                     : (uint8_t)additional_info;
 
     // The length comes from the entered data. A serialized shard is
     // SSKR_METADATA_LENGTH_BYTES plus a SSKR_MIN_STRENGTH_BYTES..
@@ -166,10 +198,26 @@ unsigned int bolos_ux_sskr_combine(unsigned char* sskr_shares_hex,
         return 0;
     }
 
+    // The declared shard has to fit in the share it was declared in.
+    // sskr_combine_shards() reads sskr_share_len bytes from each pointer built
+    // below, so on the last share that read ends at
+    // (count - 1) * stride + header_len + sskr_share_len, and the buffer only
+    // guarantees count * stride. The bound above says the length is one a
+    // shard may have, not one this frame can hold: a ten-byte buffer whose
+    // byte 3 declares 21 satisfies it and then hands sskr_combine_shards()
+    // eleven bytes it does not own.
+    //
+    // hex_check() states the same requirement as an equality, declared plus
+    // header plus the four CRC bytes being exactly the stride. Stated here as
+    // the inequality it needs, because this function never looks at the CRC
+    // and has no reason to insist a frame carry one.
+    if (sskr_share_len + header_len > stride) {
+        memzero(sskr_shares_hex, sskr_shares_hex_length);
+        return 0;
+    }
+
     for (uint8_t i = 0; i < (uint8_t)sskr_shares_count; i++) {
-        ptr_sskr_shares[i] = sskr_shares_hex +
-                             (i * sskr_shares_hex_length / sskr_shares_count) +
-                             4 + (sskr_share_len > 23);
+        ptr_sskr_shares[i] = sskr_shares_hex + (i * stride) + header_len;
     }
 
     int16_t output_len = sskr_combine_shards(ptr_sskr_shares, sskr_share_len,

--- a/tests/unit/CMakeLists.txt
+++ b/tests/unit/CMakeLists.txt
@@ -377,6 +377,17 @@ target_compile_options(test_sskr_hex_check_guards PRIVATE -fsanitize=address -fn
 target_link_options(test_sskr_hex_check_guards PRIVATE -fsanitize=address)
 target_link_libraries(test_sskr_hex_check_guards PUBLIC cmocka gcov sskr sss testutils)
 
+# The bound bolos_ux_sskr_combine() places on the buffer its share count
+# divides, as opposed to the one on the count itself that test_sskr_combine_
+# bounds holds. Built with AddressSanitizer, and the frames are allocated at
+# exactly their own length so that the overreads it is about are heap
+# overflows ASan reports rather than reads of adjacent padding.
+add_executable(test_sskr_combine_frame_length ./tests/sskr_combine_frame_length.c ../../src/common/bip39/seed_rom_variables.c ../../src/common/bip39/seed_bip39.c ../../src/common/sskr/seed_rom_variables.c ../../src/common/sskr/seed_sskr.c)
+target_include_directories(test_sskr_combine_frame_length PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/../../src/common)
+target_compile_options(test_sskr_combine_frame_length PRIVATE -fsanitize=address -fno-omit-frame-pointer)
+target_link_options(test_sskr_combine_frame_length PRIVATE -fsanitize=address)
+target_link_libraries(test_sskr_combine_frame_length PUBLIC cmocka gcov sskr sss testutils)
+
 # The other half of the bound test_sskr_share_len holds: what happens in
 # sskr_deserialize_shard() when a length that far out reaches it anyway.
 # Built with AddressSanitizer, and with sskr.c compiled into the test itself

--- a/tests/unit/tests/sskr_combine_frame_length.c
+++ b/tests/unit/tests/sskr_combine_frame_length.c
@@ -1,0 +1,171 @@
+/*
+ * bolos_ux_sskr_combine() against the length of the buffer it was handed.
+ *
+ * sskr_combine_bounds.c holds the other bound of the same function, on the
+ * share count. This one is about the buffer that count divides.
+ *
+ * The function reads byte 3 of the frame, and byte 4 when the CBOR header is
+ * the long form, before anything has said the frame is that long. It then
+ * hands sskr_combine_shards() one pointer per share and a shard length taken
+ * out of those bytes, and that function reads the whole shard from each
+ * pointer. Neither of the bounds already there says anything about how much
+ * buffer exists: the share-count bound constrains the divisor of the stride,
+ * and the shard-length bound says the declared length is one a shard may have,
+ * not one this frame can hold.
+ *
+ * bolos_ux_sskr_hex_check() bounds the same quotient for the same reason and
+ * says so where it does it -- "Reading byte 3 is in bounds because of the
+ * stride bound" -- but that guard was never carried over to this function.
+ *
+ * Nothing in the application reaches it: both entry paths call hex_check()
+ * first, and its bounds are stricter. That is why this file calls
+ * bolos_ux_sskr_combine() directly, the same way sskr_hex_check_guards.c calls
+ * hex_check() directly to hold a bound its own callers make unreachable. A
+ * guard nothing can currently violate is still one the next caller relies on.
+ *
+ * Every frame below is allocated at exactly its own length rather than inside
+ * a padded array, so that a read one byte past it is a heap-buffer-overflow
+ * AddressSanitizer reports rather than a read of adjacent padding it cannot
+ * see. Run against the function before these bounds existed, the two
+ * truncated-header cases abort under ASan instead of merely answering wrongly.
+ */
+
+#include <cmocka.h>
+#include <setjmp.h>
+#include <stdarg.h>
+#include <stddef.h>
+#include <stdint.h>
+#include <stdlib.h>
+#include <string.h>
+
+/* testutils.h has to come first: it defines WIDE, which
+ * sskr/seed_rom_variables.h uses without defining. Not sorted, hence the
+ * clang-format exclusion. */
+// clang-format off
+#include "testutils.h"
+#include "sskr/common_sskr.h"
+#include "sskr/sskr-constants.h"
+// clang-format on
+
+/* The same 2-of-3 share set over a 128-bit secret that sskr_share_len.c uses,
+ * generated with Blockchain Commons' bc-sskr: 21-byte shards, so the short
+ * CBOR header, plus four bytes of CRC-32 each. The control at the end of this
+ * file combines it, so that the bounds added here are shown to refuse
+ * malformed frames without refusing well-formed ones. */
+#define SHORT_WIRE (4 + 21 + 4)
+
+static const uint8_t k_valid_shares[2 * SHORT_WIRE] = {
+    0xD9, 0x9D, 0x75, 0x55, 0x01, 0x00, 0x00, 0x01, 0x00, 0x72, 0x79, 0x90,
+    0x3D, 0xCB, 0x83, 0x3F, 0x4B, 0xF7, 0xD4, 0x33, 0xFD, 0xAE, 0x81, 0x59,
+    0x13, 0x5E, 0xF3, 0xB3, 0x38, 0xD9, 0x9D, 0x75, 0x55, 0x01, 0x00, 0x00,
+    0x01, 0x01, 0x1B, 0x3F, 0x98, 0x69, 0x92, 0x4E, 0x46, 0x03, 0x14, 0x4D,
+    0x4A, 0x40, 0x84, 0xF0, 0x90, 0xCC, 0xAE, 0x60, 0x76, 0x65};
+
+static const uint8_t k_secret[16] = {0x59, 0xF2, 0x29, 0x3A, 0x5B, 0xCE,
+                                     0x7D, 0x4D, 0xE5, 0x9E, 0x71, 0xB4,
+                                     0x20, 0x7A, 0xC5, 0xD2};
+
+/* Calls bolos_ux_sskr_combine() on a buffer owning exactly `length` bytes. */
+static unsigned int combine_exactly(const uint8_t *frame, size_t length,
+                                    unsigned int share_count) {
+    uint8_t output[SSKR_MAX_STRENGTH_BYTES] = {0};
+    /* malloc(0) may return a pointer that owns nothing, which is exactly what
+     * the zero-length case has to hand over. */
+    uint8_t *wire = malloc(length ? length : 1);
+    assert_non_null(wire);
+    memcpy(wire, frame, length);
+
+    unsigned int result =
+        bolos_ux_sskr_combine(wire, (unsigned int) length, share_count, output);
+
+    free(wire);
+    return result;
+}
+
+static void test_combine_refuses_a_frame_shorter_than_its_header(void **state) {
+    (void) state;
+
+    /* Every truncation of what is otherwise the start of a real share. Below
+     * length 4 byte 3 does not exist; at exactly 4 it does and byte 4 does
+     * not. */
+    for (size_t length = 0; length <= 4; length++) {
+        assert_int_equal(combine_exactly(k_valid_shares, length, 1), 0);
+    }
+}
+
+static void test_combine_refuses_a_long_form_length_it_cannot_read(
+    void **state) {
+    (void) state;
+
+    /* CBOR additional information 24, "one length byte follows". That byte is
+     * byte 4, and this frame ends at byte 3. The shard-length bound cannot
+     * prevent this read: it is applied to the value read, which is too late. */
+    const uint8_t truncated_long_form[4] = {0xD9, 0x9D, 0x75, 0x58};
+
+    assert_int_equal(
+        combine_exactly(truncated_long_form, sizeof(truncated_long_form), 1),
+        0);
+}
+
+static void test_combine_refuses_a_shard_longer_than_its_frame(void **state) {
+    (void) state;
+
+    /* A well-formed header declaring the shortest shard SSKR allows, 21 bytes,
+     * in a frame with nowhere near that much room. The shard-length bound
+     * accepts 21 -- it is SSKR_MIN_SERIALIZED_LENGTH_BYTES exactly -- so
+     * without a bound tying the declared length to the frame,
+     * sskr_combine_shards() is handed a pointer at offset 4 and told to read
+     * 21 bytes out of a buffer holding ten. This is the wider of the two
+     * overreads: eleven bytes past the end rather than one. */
+    const uint8_t short_frame[10] = {0xD9, 0x9D, 0x75, 0x55, 0x01,
+                                     0x00, 0x00, 0x01, 0x00, 0x72};
+
+    assert_int_equal(combine_exactly(short_frame, sizeof(short_frame), 1), 0);
+}
+
+static void test_combine_refuses_reserved_cbor_additional_info(void **state) {
+    (void) state;
+
+    /* 25 to 31 are the two-, four- and eight-byte lengths, the reserved value
+     * and the indefinite form. None is a length this function can act on, and
+     * none may appear in a share; hex_check() already refuses them. Treated as
+     * merely "greater than 23", the length would be taken from byte 4, which
+     * is not where a two-byte length lives.
+     *
+     * The frame is long enough that nothing is overread either way, so this
+     * asserts the refusal itself rather than a bound. */
+    uint8_t reserved_form[SHORT_WIRE];
+    memcpy(reserved_form, k_valid_shares, sizeof(reserved_form));
+    reserved_form[3] = 0x59;
+
+    assert_int_equal(combine_exactly(reserved_form, sizeof(reserved_form), 1),
+                     0);
+}
+
+static void test_combine_still_accepts_a_well_formed_set(void **state) {
+    (void) state;
+
+    /* The control. Bounds that refused everything would satisfy every
+     * assertion above. */
+    uint8_t wire[sizeof(k_valid_shares)];
+    uint8_t output[SSKR_MAX_STRENGTH_BYTES] = {0};
+
+    memcpy(wire, k_valid_shares, sizeof(wire));
+
+    assert_int_equal(bolos_ux_sskr_combine(wire, sizeof(wire), 2, output),
+                     sizeof(k_secret));
+    assert_memory_equal(output, k_secret, sizeof(k_secret));
+}
+
+int main(void) {
+    const struct CMUnitTest tests[] = {
+        cmocka_unit_test(test_combine_refuses_a_frame_shorter_than_its_header),
+        cmocka_unit_test(
+            test_combine_refuses_a_long_form_length_it_cannot_read),
+        cmocka_unit_test(test_combine_refuses_a_shard_longer_than_its_frame),
+        cmocka_unit_test(test_combine_refuses_reserved_cbor_additional_info),
+        cmocka_unit_test(test_combine_still_accepts_a_well_formed_set),
+    };
+
+    return cmocka_run_group_tests(tests, NULL, NULL);
+}


### PR DESCRIPTION
The function reads byte 3 of the frame, and byte 4 when the CBOR header is
the long form, before anything has said the frame is that long. It then
hands sskr_combine_shards() one pointer per share and a shard length taken
out of those bytes, and that function reads the whole shard from each.

Neither bound already there covers this. The share-count bound constrains
the divisor of the stride, not the buffer it divides; the shard-length
bound says the declared length is one a shard may have, not one this frame
can hold. A ten-byte frame whose byte 3 declares the 21-byte minimum
satisfies both and then has twenty-one bytes read out of it.

bolos_ux_sskr_hex_check() bounds the same quotient for the same reason and
says so where it does it -- "Reading byte 3 is in bounds because of the
stride bound" -- but that guard was never carried over. Four things are
brought across:

  * a stride of at least five, so that bytes 3 and 4 are inside the first
    share;
  * CBOR additional information above 24 refused, those being the two-,
    four- and eight-byte lengths, the reserved value and the indefinite
    form, none of which carries a length this function can act on;
  * the header length derived from the additional information rather than
    from the decoded length, which is what makes the two functions agree:
    a long form declaring 21 to 23 bytes put the shard at offset 4 here
    and at offset 5 there;
  * the declared shard required to fit in its stride. Stated as an
    inequality rather than as hex_check()'s equality, because this
    function never looks at the CRC and has no reason to insist a frame
    carry one -- the 256-bit share set in the test data does not.

No path in the application reaches any of this: both entry points call
hex_check() first and its bounds are stricter. What is closed is the
contract of the function, for the next caller rather than for a current
one.

tests/unit/tests/sskr_combine_frame_length.c holds all four, calling
bolos_ux_sskr_combine() directly the way sskr_hex_check_guards.c calls
hex_check() directly, and allocating every frame at exactly its own length
so that a read one byte past it is a heap overflow AddressSanitizer
reports rather than a read of adjacent padding. Without the bounds it
aborts under ASan; the whole suite is 79/79 with them.
