### PR TITLE
fix: let only a tag pushed to this repository create a release

### DIFF
--- a/.github/workflows/release-workflow.yml
+++ b/.github/workflows/release-workflow.yml
@@ -10,7 +10,42 @@ on:
 jobs:
   create_release:
     name: Create Release
-    if: github.event.workflow_run.conclusion == 'success' && startsWith(github.event.workflow_run.head_branch, 'v') && github.ref == 'refs/heads/develop'
+    # `workflow_run` fires for every run of "Compilation & tests", and that
+    # workflow runs on `pull_request` -- including pull requests opened from a
+    # fork. The run it fires for is untrusted; this job is not. It holds
+    # `contents: write` and publishes release assets, so what it agrees to act
+    # on has to be pinned down here.
+    #
+    # `github.ref == 'refs/heads/develop'` used to be the third condition and
+    # was not one. A `workflow_run` job always runs from the default branch of
+    # this repository, with `github.ref` set to it, so on a repository whose
+    # default branch is `develop` that comparison is true for every trigger
+    # whatever the run that caused it. The two past runs of this workflow both
+    # report `develop` for exactly that reason.
+    #
+    # That left `startsWith(head_branch, 'v')` as the only real filter, over a
+    # value the author of a fork branch chooses. Naming a fork branch after a
+    # tag this repository already has -- v1.8.1 exists -- satisfies it, makes
+    # the checkout below resolve against this repository's tag, and hands
+    # `ncipollo/release-action` (`allowUpdates: true`, `makeLatest: true`) an
+    # artifact built from the fork's own source, to publish over a released
+    # version.
+    #
+    # So the trigger is bounded by where the run came from rather than by what
+    # it is called:
+    #
+    #   event == 'push'                 a release is cut by pushing a tag; a
+    #                                   pull request never is.
+    #   head_repository == repository   the push happened here, so whoever made
+    #                                   it already has write access.
+    #
+    # The tag-name check stays, as the last of the three rather than the only
+    # one: it says which pushes are releases, not who may cause one.
+    if: >-
+      github.event.workflow_run.conclusion == 'success'
+      && github.event.workflow_run.event == 'push'
+      && github.event.workflow_run.head_repository.full_name == github.repository
+      && startsWith(github.event.workflow_run.head_branch, 'v')
     runs-on: ubuntu-latest
     permissions:
       contents: write
@@ -20,11 +55,19 @@ jobs:
         with:
           ref: ${{ github.event.workflow_run.head_branch }}
 
+      # The tag name reaches the shell through the environment rather than
+      # through `${{ }}`. Interpolated into the script it would be pasted into
+      # the text of the command before bash reads it, and a Git ref may hold
+      # `;`, `|`, `&`, `$` and backticks -- none of them among the characters
+      # git refuses in a ref name -- so a tag called `v1$(...)` ran whatever it
+      # contained, in a job holding `contents: write`. Read from the
+      # environment and quoted, it is data.
       - name: Set VERSION variable from tag
+        env:
+          HEAD_BRANCH: ${{ github.event.workflow_run.head_branch }}
         run: |
-          HEAD_BRANCH=${{ github.event.workflow_run.head_branch }}
-          echo "VERSION_NUMBER=${HEAD_BRANCH#v}" >> ${GITHUB_ENV}
-          echo "VERSION_NAME=${HEAD_BRANCH//./_}" >> ${GITHUB_ENV}
+          echo "VERSION_NUMBER=${HEAD_BRANCH#v}" >> "${GITHUB_ENV}"
+          echo "VERSION_NAME=${HEAD_BRANCH//./_}" >> "${GITHUB_ENV}"
 
       - name: Download app binaries
         uses: dawidd6/action-download-artifact@v6
@@ -36,8 +79,12 @@ jobs:
           workflow_conclusion: success
           skip_unpack: true
 
+      # Quoted for the same reason as the step above, one step further along
+      # the same value: VERSION_NAME is the tag with its dots replaced, so it
+      # is still the ref name, and unquoted it is subject to word splitting and
+      # globbing. Reported by shellcheck through actionlint as SC2086.
       - name: Rename app binaries
-        run: ls -la ./bin/ && sudo mv ./bin/compiled_app_binaries.zip ./bin/compiled_app_binaries.${VERSION_NAME}.zip && ls -la ./bin/
+        run: ls -la ./bin/ && sudo mv ./bin/compiled_app_binaries.zip "./bin/compiled_app_binaries.${VERSION_NAME}.zip" && ls -la ./bin/
 
       - name: Create Release
         uses: ncipollo/release-action@v1


### PR DESCRIPTION
The release job triggers on `workflow_run` of "Compilation & tests", and
that workflow runs on `pull_request` -- including pull requests opened from
a fork. The run it fires for is untrusted; this job is not. It holds
`contents: write` and publishes release assets.

Of its three conditions, one was not a condition. A `workflow_run` job
always runs from the default branch of the repository with `github.ref` set
to it, so on a repository whose default branch is `develop` the comparison
`github.ref == 'refs/heads/develop'` is true for every trigger, whatever
run caused it. Both past runs of this workflow report `develop` for that
reason.

That left `startsWith(head_branch, 'v')` as the only filter, over a value
whoever opens the pull request chooses. Naming a fork branch after a tag
this repository already has -- v1.7.3, v1.7.4, v1.8.0 and v1.8.1 all exist
-- satisfies it and makes the checkout resolve against this repository's
tag rather than failing, so the job proceeds to download the artifact built
from the fork's own source and hand it to ncipollo/release-action, which
runs with `allowUpdates: true` and `makeLatest: true`. The assets of a
published release are replaced.

The trigger is now bounded by where the run came from rather than by what
it is called:

  event == 'push'                 a release is cut by pushing a tag, never
                                  by opening a pull request
  head_repository == repository   the push happened here, so whoever made
                                  it already has write access

The tag-name check stays, as the last of the three rather than the only
one: it says which pushes are releases, not who may cause one.

Checked against the payloads GitHub has already recorded for this
repository, rather than by attempting the sequence. Every "Compilation &
tests" run from a pull request, including the ones for this repository's
own recent branches, carries event=pull_request and a head_repository that
is not aido/app-seed-tool; the run for the v1.8.1 tag carries event=push,
head_repository=aido/app-seed-tool and head_branch=v1.8.1. The new
conditions reject the first and admit the second.

Two shell issues on the same value are fixed with it. The tag name reached
the script through `${{ }}`, which pastes it into the command text before
bash reads it, and a Git ref may hold `;`, `|`, `&`, `$` and backticks --
none of them among the characters git refuses in a ref name -- so a tag
called `v1$(...)` ran whatever it contained in a job holding
`contents: write`. It now arrives through the environment, quoted. The
rename step expanded the same value unquoted one step further along, which
actionlint reports as SC2086.
