### PR TITLE
refactor: single source for both stacks' interface text

### DIFF
--- a/src/bagl/nanos_enter_phrase.c
+++ b/src/bagl/nanos_enter_phrase.c
@@ -18,6 +18,7 @@
 #include <lcx_hmac.h>
 #include <os_io_seproxyhal.h>
 
+#include "common/ui_strings.h"
 #include "constants.h"
 // For app_ticker_event_callback()'s declaration: defining it below without one
 // would leave nothing to check the definition against, since the SDK calls it
@@ -62,7 +63,7 @@ const bagl_element_t screen_onboarding_restore_word_select_elements[] = {
      (const char*)&C_icon_back},
     {{BAGL_LABELINE, 0x05, 41, 12, 128, 32, 0, 0, 0, 0xFFFFFF, 0x000000,
       BAGL_FONT_OPEN_SANS_EXTRABOLD_11px, 0},
-     "Restart from"},
+     UI_STR_BAGL_NANOS_RESTART_FROM},
     {{BAGL_LABELINE, 0x06, 41, 26, 128, 32, 0, 0, 0, 0xFFFFFF, 0x000000,
       BAGL_FONT_OPEN_SANS_EXTRABOLD_11px, 0},
      G_ux.string_buffer},
@@ -88,7 +89,7 @@ UX_STEP_NOCB_POSTINIT(processing_step, pb,
                       screen_processing_postinit(stack_slot),
                       {
                           &C_icon_loader_16px,
-                          "Processing",
+                          UI_STR_BAGL_PROCESSING,
                       });
 
 UX_FLOW(processing_flow, &processing_step);
@@ -285,7 +286,8 @@ const bagl_element_t* screen_onboarding_restore_word_keyboard_callback(
             if (value < 8) {
                 G_ux.tmp_element.component.x += 5;
                 // prefix word stem with "%d:" with the current word index
-                snprintf(G_ux.string_buffer + 2, 5, "#%d ",
+                snprintf(G_ux.string_buffer + 2, 5,
+                         UI_STR_BAGL_NANOS_WORD_INDEX_PREFIX,
                          G_bolos_ux_context.onboarding_step + 1);
                 // ensure font is left aligned
                 G_ux.tmp_element.text = G_ux.string_buffer;
@@ -318,7 +320,7 @@ screen_onboarding_restore_word_before_element_display_callback(
                     G_bolos_ux_context.onboarding_words_checked) {
                 return NULL;
             }
-            SPRINTF(G_ux.string_buffer, "Word #%d",
+            SPRINTF(G_ux.string_buffer, UI_STR_BAGL_NANOS_WORD_HEADER,
                     G_bolos_ux_context.onboarding_step + 1);
             break;
 
@@ -369,7 +371,7 @@ screen_onboarding_restore_word_before_element_display_callback(
                     G_bolos_ux_context.onboarding_words_checked) {
                 return NULL;
             }
-            SPRINTF(G_ux.string_buffer, "word #%d",
+            SPRINTF(G_ux.string_buffer, UI_STR_BAGL_NANOS_WORD_HEADER_LOWER,
                     G_bolos_ux_context.hslider3_total -
                         G_bolos_ux_context.hslider3_current);
             break;
@@ -671,9 +673,9 @@ void screen_onboarding_restore_word_init(unsigned int firstWord) {
 
     // elements to be displayed
     (G_bolos_ux_context.tool_type == TOOL_TYPE_BIP39)
-        ? SPRINTF(G_ux.string_buffer, "word #%d",
+        ? SPRINTF(G_ux.string_buffer, UI_STR_BAGL_NANOS_WORD_HEADER_LOWER,
                   G_bolos_ux_context.onboarding_step + 1)
-        : SPRINTF(G_ux.string_buffer, "Share#%d Word#%d",
+        : SPRINTF(G_ux.string_buffer, UI_STR_BAGL_NANOS_ENTER_SSKR_WORD,
                   G_bolos_ux_context.sskr_share_index + 1,
                   G_bolos_ux_context.onboarding_step + 1);
     ux_flow_init(0, &ux_restore_flow, NULL);

--- a/src/bagl/nanox_enter_phrase.c
+++ b/src/bagl/nanox_enter_phrase.c
@@ -18,6 +18,7 @@
 #include <lcx_hmac.h>
 #include <lcx_rng.h>
 
+#include "common/ui_strings.h"
 #include "constants.h"
 #include "ui.h"
 
@@ -36,13 +37,13 @@ const bagl_element_t screen_onboarding_restore_word_intro_elements[] = {
 
     {{BAGL_LABELINE, 0x31, 0, 12, 128, 32, 0, 0, 0, 0xFFFFFF, 0x000000,
       BAGL_FONT_OPEN_SANS_REGULAR_11px | BAGL_FONT_ALIGNMENT_CENTER, 0},
-     "Enter first letters"},
+     UI_STR_BAGL_NANOX_INTRO_L1},
     {{BAGL_LABELINE, 0x32, 0, 12, 128, 32, 0, 0, 0, 0xFFFFFF, 0x000000,
       BAGL_FONT_OPEN_SANS_REGULAR_11px | BAGL_FONT_ALIGNMENT_CENTER, 0},
-     "Next, enter letters"},
+     UI_STR_BAGL_NANOX_INTRO_L2},
     {{BAGL_LABELINE, 0x33, 0, 12, 128, 32, 0, 0, 0, 0xFFFFFF, 0x000000,
       BAGL_FONT_OPEN_SANS_REGULAR_11px | BAGL_FONT_ALIGNMENT_CENTER, 0},
-     "Finally, enter letters"},
+     UI_STR_BAGL_NANOX_INTRO_L3},
     {{BAGL_LABELINE, 0x30, 0, 26, 128, 32, 0, 0, 0, 0xFFFFFF, 0x000000,
       BAGL_FONT_OPEN_SANS_REGULAR_11px | BAGL_FONT_ALIGNMENT_CENTER, 0},
      G_ux.string_buffer},
@@ -67,7 +68,7 @@ const bagl_element_t screen_onboarding_restore_word_select_elements[] = {
      (const char*)&C_icon_clear_14px},
     {{BAGL_LABELINE, 0x24, 0, 43, 128, 32, 0, 0, 0, 0xFFFFFF, 0x000000,
       BAGL_FONT_OPEN_SANS_EXTRABOLD_11px | BAGL_FONT_ALIGNMENT_CENTER, 0},
-     "Clear word"},
+     UI_STR_BAGL_NANOX_CLEAR_WORD},
 
     // left/rights icons
     {{BAGL_ICON, 0x22, 2, 28, 4, 7, 0, 0, 0, 0xFFFFFF, 0x000000, 0, 0},
@@ -76,7 +77,7 @@ const bagl_element_t screen_onboarding_restore_word_select_elements[] = {
      (const char*)&C_icon_right},
 };
 
-UX_STEP_NOCB(ux_load_step, pn, {&C_icon_loader_14px, "Processing"});
+UX_STEP_NOCB(ux_load_step, pn, {&C_icon_loader_14px, UI_STR_BAGL_PROCESSING});
 UX_FLOW(ux_load_flow, &ux_load_step);
 
 extern const ux_flow_step_t* const ux_bip39_match_flow;
@@ -110,10 +111,11 @@ void screen_onboarding_restore_word_display_auto_complete(void) {
     (G_bolos_ux_context.tool_type == TOOL_TYPE_BIP39)
         ? snprintf(G_ux.string_buffer + 32 + auto_complete_count + 1,
                    sizeof(G_ux.string_buffer) - 32 - auto_complete_count - 1,
-                   "Enter word #%d", G_bolos_ux_context.onboarding_step + 1)
+                   UI_STR_BAGL_NANOX_ENTER_BIP39_WORD,
+                   G_bolos_ux_context.onboarding_step + 1)
         : snprintf(G_ux.string_buffer + 32 + auto_complete_count + 1,
                    sizeof(G_ux.string_buffer) - 32 - auto_complete_count - 1,
-                   "Enter Share#%d word#%d",
+                   UI_STR_BAGL_NANOX_ENTER_SSKR_WORD,
                    G_bolos_ux_context.sskr_share_index + 1,
                    G_bolos_ux_context.onboarding_step + 1);
 
@@ -299,7 +301,7 @@ screen_onboarding_restore_word_before_element_display_callback(
     switch (element->component.userid) {
         case 0x30:
             // word index
-            SPRINTF(G_ux.string_buffer, "of word #%d",
+            SPRINTF(G_ux.string_buffer, UI_STR_BAGL_NANOX_OF_WORD,
                     G_bolos_ux_context.onboarding_step + 1);
             break;
 
@@ -336,7 +338,7 @@ screen_onboarding_restore_word_before_element_display_callback(
             goto not_on_last_item;
 
         case 0x21:
-            SPRINTF(G_ux.string_buffer, "Select word #%d",
+            SPRINTF(G_ux.string_buffer, UI_STR_BAGL_NANOX_SELECT_WORD,
                     G_bolos_ux_context.onboarding_step + 1);
             goto not_on_last_item;
 
@@ -365,7 +367,7 @@ screen_onboarding_restore_word_before_element_display_callback(
             break;
         case 0x25:
             // word index
-            SPRINTF(G_ux.string_buffer, "Enter word #%d",
+            SPRINTF(G_ux.string_buffer, UI_STR_BAGL_NANOX_ENTER_BIP39_WORD,
                     G_bolos_ux_context.onboarding_step + 1);
             break;
     }

--- a/src/bagl/ui.c
+++ b/src/bagl/ui.c
@@ -21,6 +21,7 @@
 
 #if defined(HAVE_BAGL)
 
+#include "common/ui_strings.h"
 #include "constants.h"
 
 //////////////////////////////////////////////////////////////////////
@@ -31,10 +32,10 @@ void screen_onboarding_bip39_restore_init(void) {
 }
 
 const char* const number_of_bip39_words_values[] = {
-    "12 words",
-    "18 words",
-    "24 words",
-    "Back",
+    UI_STR_WORDS_12,
+    UI_STR_WORDS_18,
+    UI_STR_WORDS_24,
+    UI_STR_BAGL_BIP39_LENGTH_BACK,
 };
 
 const char* number_of_bip39_words_getter(unsigned int idx) {
@@ -64,13 +65,15 @@ void number_of_bip39_words_selector(unsigned int idx) {
 }
 
 #if defined(TARGET_NANOS)
-UX_STEP_NOCB(ux_bip39_instruction_step, nn, {"Enter number", "of BIP39 words"});
+UX_STEP_NOCB(ux_bip39_instruction_step, nn,
+             {UI_STR_BAGL_BIP39_LENGTH_TITLE_L1_NANOS,
+              UI_STR_BAGL_BIP39_LENGTH_TITLE_L2_NANOS});
 #else
 UX_STEP_NOCB(ux_bip39_instruction_step, nnn,
              {
-                 "Select the number of",
-                 "words written on",
-                 "your Recovery Sheet",
+                 UI_STR_BAGL_BIP39_LENGTH_TITLE_L1,
+                 UI_STR_BAGL_BIP39_LENGTH_TITLE_L2,
+                 UI_STR_BAGL_BIP39_LENGTH_TITLE_L3,
              });
 #endif
 
@@ -89,17 +92,17 @@ void screen_onboarding_sskr_restore_init(void) {
 #if defined(TARGET_NANOS)
 UX_STEP_CB(ux_sskr_instruction_step, nn, screen_onboarding_sskr_restore_init(),
            {
-               "Enter SSKR",
-               "recovery phrase",
+               UI_STR_BAGL_SSKR_START_TITLE_L1_NANOS,
+               UI_STR_BAGL_SSKR_START_TITLE_L2_NANOS,
            });
 #else
 UX_STEP_CB(ux_sskr_instruction_step, nnn,
            G_bolos_ux_context.tool_type = TOOL_TYPE_SSKR;
            screen_onboarding_restore_word_init(RESTORE_WORD_ACTION_FIRST_WORD);
            , {
-                 "Enter first word of",
-                 "first share of SSKR",
-                 "recovery phrase",
+                 UI_STR_BAGL_SSKR_START_TITLE_L1,
+                 UI_STR_BAGL_SSKR_START_TITLE_L2,
+                 UI_STR_BAGL_SSKR_START_TITLE_L3,
              });
 #endif
 
@@ -110,25 +113,25 @@ UX_FLOW(ux_sskr_flow, &ux_sskr_instruction_step);
 UX_STEP_VALID(ux_idle_flow_1_step, pbb, ux_flow_init(0, ux_bip39_flow, NULL),
               {
                   &BIP39_ICON,
-                  "Check BIP39",
-                  "recovery phrase",
+                  UI_STR_BAGL_IDLE_BIP39_L1,
+                  UI_STR_BAGL_IDLE_BIP39_L2,
               });
 UX_STEP_VALID(ux_idle_flow_2_step, pbb, ux_flow_init(0, ux_sskr_flow, NULL),
               {
                   &SSKR_ICON,
-                  "Check SSKR",
-                  "recovery phrase",
+                  UI_STR_BAGL_IDLE_SSKR_L1,
+                  UI_STR_BAGL_IDLE_SSKR_L2,
               });
 
 UX_STEP_NOCB(ux_idle_flow_3_step, bn,
              {
-                 "Version",
+                 UI_STR_VERSION_LABEL,
                  APPVERSION,
              });
 UX_STEP_VALID(ux_idle_flow_4_step, pb, os_sched_exit(-1),
               {
                   &C_icon_dashboard_x,
-                  "Quit",
+                  UI_STR_QUIT,
               });
 UX_FLOW(ux_idle_flow, &ux_idle_flow_1_step, &ux_idle_flow_2_step,
         &ux_idle_flow_3_step, &ux_idle_flow_4_step);

--- a/src/bagl/ux_bip39.c
+++ b/src/bagl/ux_bip39.c
@@ -19,14 +19,16 @@
 
 #if defined(HAVE_BAGL)
 
+#include "common/ui_strings.h"
+
 UX_STEP_NOCB(step_display_bip39, bnnn_paging,
              {
-                 .title = "BIP39 Phrase",
+                 .title = UI_STR_BIP39_PHRASE_TITLE,
                  .text = G_bolos_ux_context.words_buffer,
              });
 
 UX_STEP_CB(step_bip39_clean_exit, pb, clean_exit(0),
-           {&C_icon_dashboard_x, "Quit"});
+           {&C_icon_dashboard_x, UI_STR_QUIT});
 
 UX_FLOW(display_bip39_flow, &step_display_bip39, &step_bip39_clean_exit,
         FLOW_LOOP);

--- a/src/bagl/ux_nano.c
+++ b/src/bagl/ux_nano.c
@@ -19,6 +19,8 @@
 
 #if defined(HAVE_BAGL)
 
+#include "common/ui_strings.h"
+
 bolos_ux_context_t G_bolos_ux_context;
 
 void clean_exit(bolos_task_status_t exit_code) {
@@ -147,57 +149,65 @@ void bolos_ux_hslider3_previous(void) {
 
 UX_STEP_CB(ux_restore_step_1, nn,
            screen_onboarding_restore_word_display_auto_complete();
-           , {"Enter", G_ux.string_buffer});
+           , {UI_STR_BAGL_ENTER_LABEL, G_ux.string_buffer});
 
 UX_FLOW(ux_restore_flow, &ux_restore_step_1);
 
-UX_STEP_CB(ux_quit_step, pb, clean_exit(0), {&C_icon_dashboard_x, "Quit"});
+UX_STEP_CB(ux_quit_step, pb, clean_exit(0), {&C_icon_dashboard_x, UI_STR_QUIT});
 UX_STEP_VALID(ux_return_step, pb, ui_idle_init(),
-              {&C_icon_back_x, "Return to menu"});
+              {&C_icon_back_x, UI_STR_BAGL_RETURN_TO_MENU});
 UX_STEP_NOCB(ux_invalid_step_2, nn,
              {
-                 "Check length,",
-                 "order and spelling",
+                 UI_STR_BAGL_INVALID_ADVICE_L1,
+                 UI_STR_BAGL_INVALID_ADVICE_L2,
              });
 
 UX_STEP_NOCB(ux_bip39_invalid_step_1, pbb,
-             {&C_icon_crossmark, "BIP39 Recovery", "phrase invalid"});
+             {&C_icon_crossmark, UI_STR_BAGL_BIP39_INVALID_TITLE_L1,
+              UI_STR_BAGL_BIP39_INVALID_TITLE_L2});
 UX_STEP_VALID(ux_bip39_invalid_step_3, pb,
               screen_onboarding_bip39_restore_init();
-              , {&C_icon_back_x, "Re-enter phrase"});
+              , {&C_icon_back_x, UI_STR_BAGL_BIP39_REENTER_PHRASE});
 
 UX_FLOW(ux_bip39_invalid_flow, &ux_bip39_invalid_step_1, &ux_invalid_step_2,
         &ux_bip39_invalid_step_3, &ux_return_step);
 
 UX_STEP_NOCB(ux_bip39_nomatch_step_1, pbb,
-             {&C_icon_warning, "BIP39 Phrase", "doesn't match"});
+             {&C_icon_warning, UI_STR_BIP39_PHRASE_TITLE,
+              UI_STR_BAGL_BIP39_NOMATCH_TITLE_L2});
 
 UX_FLOW(ux_bip39_nomatch_flow, &ux_bip39_nomatch_step_1, &ux_return_step);
 
 UX_STEP_NOCB(ux_bip39_match_step_1, pbb,
-             {&C_icon_validate_14, "BIP39 Phrase", "is correct"});
+             {&C_icon_validate_14, UI_STR_BIP39_PHRASE_TITLE,
+              UI_STR_BAGL_BIP39_MATCH_TITLE_L2});
 UX_STEP_CB(ux_bip39_recover_step_1, pbb, set_sskr_descriptor_values();
-           , {&SSKR_ICON, "Generate", "SSKR phrases"});
+           , {&SSKR_ICON, UI_STR_BAGL_GENERATE_SSKR_L1,
+              UI_STR_BAGL_GENERATE_SSKR_L2});
 
 UX_FLOW(ux_bip39_match_flow, &ux_bip39_match_step_1, &ux_quit_step,
         &ux_bip39_recover_step_1);
 
 UX_STEP_NOCB(ux_sskr_invalid_step_1, pbb,
-             {&C_icon_crossmark, "SSKR Recovery", "phrase invalid"});
+             {&C_icon_crossmark, UI_STR_BAGL_SSKR_INVALID_TITLE_L1,
+              UI_STR_BAGL_SSKR_INVALID_TITLE_L2});
 UX_STEP_VALID(ux_sskr_invalid_step_3, pb, screen_onboarding_sskr_restore_init();
-              , {&C_icon_back_x, "Re-enter shares"});
+              , {&C_icon_back_x, UI_STR_BAGL_SSKR_REENTER_SHARES});
 
 UX_FLOW(ux_sskr_invalid_flow, &ux_sskr_invalid_step_1, &ux_invalid_step_2,
         &ux_sskr_invalid_step_3, &ux_return_step);
 
 UX_STEP_NOCB(ux_sskr_nomatch_step_1, pbb,
-             {&C_icon_warning, "SSKR Phrase", "doesn't match"});
+             {&C_icon_warning, UI_STR_BAGL_SSKR_NOMATCH_TITLE_L1,
+              UI_STR_BAGL_SSKR_NOMATCH_TITLE_L2});
 
 UX_STEP_NOCB(ux_sskr_match_step_1, pbb,
-             {&C_icon_validate_14, "SSKR Phrase", "is correct"});
+             {&C_icon_validate_14, UI_STR_BAGL_SSKR_MATCH_TITLE_L1,
+              UI_STR_BAGL_SSKR_MATCH_TITLE_L2});
 
 UX_STEP_CB(ux_sskr_recover_step_1, pbb, recover_bip39();
-           , {&BIP39_ICON, "Recover", "BIP39 phrase"});
+           , {&BIP39_ICON, UI_STR_BAGL_RECOVER_BIP39_L1,
+              UI_STR_BAGL_RECOVER_BIP39_L2});
 
 UX_FLOW(ux_sskr_nomatch_flow, &ux_sskr_nomatch_step_1, &ux_quit_step,
         &ux_sskr_recover_step_1);

--- a/src/bagl/ux_sskr.c
+++ b/src/bagl/ux_sskr.c
@@ -24,6 +24,7 @@
 #if defined(HAVE_BAGL)
 
 #include "./ux_sskr_menu.h"
+#include "common/ui_strings.h"
 
 bool get_next_data(bool share_step) {
     size_t offset;
@@ -34,7 +35,7 @@ bool get_next_data(bool share_step) {
                                   G_bolos_ux_context.sskr_share_count,
                                   G_bolos_ux_context.sskr_share_index - 1,
                                   &offset, &length)) {
-        SPRINTF(G_bolos_ux_context.string_buffer, "SSKR Share #%d",
+        SPRINTF(G_bolos_ux_context.string_buffer, UI_STR_SSKR_SHARE_HEADER,
                 G_bolos_ux_context.sskr_share_index);
         memcpy(G_bolos_ux_context.words_buffer,
                G_bolos_ux_context.sskr_words_buffer + offset, length);
@@ -109,7 +110,7 @@ UX_STEP_NOCB(step_display_shares, bnnn_paging,
 UX_STEP_INIT(step_lower_delimiter, NULL, NULL, { display_next_state(false); });
 
 UX_STEP_CB(step_sskr_clean_exit, pb, clean_exit(0),
-           {&C_icon_dashboard_x, "Quit"});
+           {&C_icon_dashboard_x, UI_STR_QUIT});
 
 UX_FLOW(dynamic_flow, &step_upper_delimiter, &step_display_shares,
         &step_lower_delimiter, &step_sskr_clean_exit, FLOW_LOOP);
@@ -159,15 +160,15 @@ void generate_sskr(void) {
 UX_STEP_NOCB(ux_threshold_warn_step_1, pnn,
              {
                  &C_icon_warning,
-                 "1-of-m shares",
-                 "where m > 1",
+                 UI_STR_BAGL_SSKR_ONE_OF_M_WARN_L1,
+                 UI_STR_BAGL_SSKR_ONE_OF_M_WARN_L2,
              });
 
 UX_STEP_NOCB(ux_threshold_warn_step_2, pbb,
              {
                  &C_icon_warning,
-                 "Not",
-                 "Supported",
+                 UI_STR_BAGL_SSKR_ONE_OF_M_NOT_L1,
+                 UI_STR_BAGL_SSKR_ONE_OF_M_NOT_L2,
              });
 
 UX_FLOW(ux_threshold_warn_flow, &ux_threshold_warn_step_1,
@@ -198,7 +199,9 @@ void sskr_threshold_selector(unsigned int idx) {
     }
 }
 
-UX_STEP_NOCB(ux_threshold_instruction_step, nn, {"Select", "threshold"});
+UX_STEP_NOCB(ux_threshold_instruction_step, nn,
+             {UI_STR_BAGL_SSKR_THRESHOLD_TITLE_L1,
+              UI_STR_BAGL_SSKR_THRESHOLD_TITLE_L2});
 
 UX_STEP_MENULIST(ux_threshold_menu_step, sskr_threshold_getter,
                  sskr_threshold_selector);
@@ -216,7 +219,8 @@ void sskr_shares_number_selector(unsigned int idx) {
 }
 
 UX_STEP_NOCB(ux_shares_number_instruction_step, nn,
-             {"Select number", "of shares"});
+             {UI_STR_BAGL_SSKR_NUMSHARES_TITLE_L1,
+              UI_STR_BAGL_SSKR_NUMSHARES_TITLE_L2});
 
 UX_STEP_MENULIST(ux_shares_number_menu_step, sskr_shares_number_getter,
                  sskr_shares_number_selector);

--- a/src/common/ui_strings.h
+++ b/src/common/ui_strings.h
@@ -1,0 +1,282 @@
+/*******************************************************************************
+ *   Ledger Seed Tool application
+ *   (c) 2016-2026 Ledger SAS
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ ********************************************************************************/
+
+#pragma once
+
+/*
+ * Every user-visible string in the application, for both interface stacks --
+ * BAGL (the three Nano targets) and NBGL (the touch targets). Nothing here
+ * changes what a screen says; this header only gives the two stacks one place
+ * to read their wording from, so a future change to one is not made without
+ * seeing whether the other needs it too.
+ *
+ * The two stacks do not cut their text the same way. NBGL carries a full
+ * sentence per screen; BAGL splits the same idea across the 2-4 lines of a
+ * UX_STEP, and often uses different words entirely -- the two stacks already
+ * diverged before this header existed (see the PR this header was added in).
+ * Where the concept is shared but the wording is not, both forms are declared
+ * here, next to each other, under one comment. Nothing is deduplicated by
+ * inventing a shared string and a splitting algorithm: the divergence stays
+ * visible, in this file, rather than being hidden by code that reconciles it.
+ *
+ * Where the wording happens to already be byte-identical between the two
+ * stacks -- "Quit" on every BAGL screen that has it, "SSKR Share #%d" on
+ * both -- a single macro serves every call site.
+ *
+ * `#define` rather than a table of `extern const char[]`: a string literal
+ * behind a macro costs nothing beyond what the literal itself costs, and the
+ * linker merges identical literals; an array of pointers would cost 4 bytes
+ * of flash and a relocation per entry, everywhere it is linked in, including
+ * `nanos`, which has the least flash of the six targets. The one thing a
+ * table buys -- enumerating every string in a test -- is recovered without
+ * that cost by tests/unit/test_ui_strings.c, which declares its own table
+ * naming every macro below; nothing in this header needs to be enumerable
+ * from device code.
+ *
+ * Two BAGL-only literals are deliberately not here:
+ *   - the "1".."16" share-count menu labels in src/bagl/ux_sskr_menu.c are a
+ *     generated table, not authored wording, and are sized by the
+ *     TARGET_NANOS-conditional _Static_assert against SSS_MAX_SHARE_COUNT
+ *     immediately above them in that file; moving the labels out would
+ *     separate them from the invariant that bounds them;
+ *   - PRINTF trace strings, on both stacks, which the user never sees.
+ */
+
+/*
+ * Common to both stacks, byte-identical -- one macro, several call sites.
+ */
+#define UI_STR_QUIT               "Quit"
+#define UI_STR_VERSION_LABEL      "Version"
+#define UI_STR_BIP39_PHRASE_TITLE "BIP39 Phrase"
+#define UI_STR_SSKR_SHARE_HEADER  "SSKR Share #%d"
+#define UI_STR_WORDS_12           "12 words"
+#define UI_STR_WORDS_18           "18 words"
+#define UI_STR_WORDS_24           "24 words"
+
+/*
+ * "Processing", shown on nanos while a blocking comparison or SSKR
+ * generation runs (src/bagl/nanos_enter_phrase.c), and on nanox/nanos+ for
+ * the same wait (src/bagl/nanox_enter_phrase.c). Not used on NBGL, which has
+ * no equivalent blocking step.
+ */
+#define UI_STR_BAGL_PROCESSING "Processing"
+
+/*
+ * Home / tool selection
+ */
+
+/* NBGL: three buttons on the "select a tool" screen (src/nbgl/ui.c). */
+#define UI_STR_NBGL_TOOL_BIP39        "BIP39 Check"
+#define UI_STR_NBGL_TOOL_SSKR         "SSKR Check"
+#define UI_STR_NBGL_TOOL_BIP85        "BIP85 Generate"
+#define UI_STR_NBGL_SELECT_TOOL_TITLE "Select the tool\nyou wish to use"
+
+/*
+ * BAGL: the equivalent two entries on the Nano idle menu
+ * (src/bagl/ui.c). BAGL's idle menu has no third entry for BIP85 -- that
+ * flow has no BAGL screens at all, on any Nano.
+ */
+#define UI_STR_BAGL_IDLE_BIP39_L1 "Check BIP39"
+#define UI_STR_BAGL_IDLE_BIP39_L2 "recovery phrase"
+#define UI_STR_BAGL_IDLE_SSKR_L1  "Check SSKR"
+#define UI_STR_BAGL_IDLE_SSKR_L2  "recovery phrase"
+
+/* NBGL home screen description and action (src/nbgl/ui.c). */
+#define UI_STR_NBGL_HOME_DESCRIPTION \
+    "This Ledger application\nprovides some useful seed\nmanagement utilities."
+#define UI_STR_NBGL_HOME_ACTION    "Select Tool"
+#define UI_STR_NBGL_HOME_COPYRIGHT "(c) 2018-2026 Ledger"
+
+/*
+ * BIP39 phrase length selection
+ *
+ * display_bip39_select_phrase_length_page() (src/nbgl/ui.c) serves two
+ * different callers, distinguished by tool_type: checking an existing phrase
+ * and generating a new one. BAGL has one screen for the same choice
+ * (src/bagl/ui.c), worded for the Check flow only, and split 2 lines on
+ * nanos, 3 lines on nanox/nanos+.
+ */
+#define UI_STR_NBGL_BIP39_LENGTH_TITLE_CHECK    "How long is your\nBIP39 Recovery\nPhrase?"
+#define UI_STR_NBGL_BIP39_LENGTH_TITLE_DERIVE   "Length of BIP39\nphrase to\ngenerate?"
+#define UI_STR_BAGL_BIP39_LENGTH_TITLE_L1_NANOS "Enter number"
+#define UI_STR_BAGL_BIP39_LENGTH_TITLE_L2_NANOS "of BIP39 words"
+#define UI_STR_BAGL_BIP39_LENGTH_TITLE_L1       "Select the number of"
+#define UI_STR_BAGL_BIP39_LENGTH_TITLE_L2       "words written on"
+#define UI_STR_BAGL_BIP39_LENGTH_TITLE_L3       "your Recovery Sheet"
+#define UI_STR_BAGL_BIP39_LENGTH_BACK           "Back"
+
+/*
+ * SSKR entry start (src/bagl/ui.c). nanos gets 2 lines, nanox/nanos+ get 3
+ * and start the flow directly from the step's own callback rather than a
+ * shared init call -- an existing difference, not introduced here.
+ */
+#define UI_STR_BAGL_SSKR_START_TITLE_L1_NANOS "Enter SSKR"
+#define UI_STR_BAGL_SSKR_START_TITLE_L2_NANOS "recovery phrase"
+#define UI_STR_BAGL_SSKR_START_TITLE_L1       "Enter first word of"
+#define UI_STR_BAGL_SSKR_START_TITLE_L2       "first share of SSKR"
+#define UI_STR_BAGL_SSKR_START_TITLE_L3       "recovery phrase"
+
+/*
+ * Word / share entry keyboard
+ *
+ * NBGL carries one header sentence per keystroke (src/nbgl/ui.c). BAGL
+ * rebuilds a short label into G_ux.string_buffer on every keystroke too, but
+ * the exact wording differs between nanos (src/bagl/nanos_enter_phrase.c)
+ * and nanox/nanos+ (src/bagl/nanox_enter_phrase.c) -- including the
+ * capitalization of "word" and whether "Share" and "#" have a space between
+ * them. None of that is touched here.
+ */
+#define UI_STR_NBGL_ENTER_BIP39_WORD "Enter word n. %d/%d of your\nBIP39 Recovery Phrase"
+#define UI_STR_NBGL_ENTER_SSKR_WORD  "Enter Share %d Word %d\nof your Recovery Phrase"
+
+/*
+ * BAGL nanos (src/bagl/nanos_enter_phrase.c). UI_STR_BAGL_NANOS_WORD_HEADER_LOWER
+ * has two call sites -- the "restart from" label and the entry-screen title
+ * -- with byte-identical text; one macro serves both.
+ */
+#define UI_STR_BAGL_NANOS_WORD_HEADER       "Word #%d"
+#define UI_STR_BAGL_NANOS_WORD_HEADER_LOWER "word #%d"
+#define UI_STR_BAGL_NANOS_ENTER_SSKR_WORD   "Share#%d Word#%d"
+#define UI_STR_BAGL_NANOS_RESTART_FROM      "Restart from"
+#define UI_STR_BAGL_NANOS_WORD_INDEX_PREFIX "#%d "
+
+/* BAGL nanox/nanos+ (src/bagl/nanox_enter_phrase.c). */
+#define UI_STR_BAGL_NANOX_INTRO_L1         "Enter first letters"
+#define UI_STR_BAGL_NANOX_INTRO_L2         "Next, enter letters"
+#define UI_STR_BAGL_NANOX_INTRO_L3         "Finally, enter letters"
+#define UI_STR_BAGL_NANOX_CLEAR_WORD       "Clear word"
+#define UI_STR_BAGL_NANOX_ENTER_BIP39_WORD "Enter word #%d"
+#define UI_STR_BAGL_NANOX_ENTER_SSKR_WORD  "Enter Share#%d word#%d"
+#define UI_STR_BAGL_NANOX_OF_WORD          "of word #%d"
+#define UI_STR_BAGL_NANOX_SELECT_WORD      "Select word #%d"
+
+/*
+ * Restore/entry navigation (src/bagl/ux_nano.c), shared by both the BIP39
+ * and SSKR entry flows on every BAGL target.
+ */
+#define UI_STR_BAGL_ENTER_LABEL    "Enter"
+#define UI_STR_BAGL_RETURN_TO_MENU "Return to menu"
+
+/*
+ * Check result / verdict
+ *
+ * NBGL (src/nbgl/ui.c) gives the "valid but doesn't match" and "valid and
+ * matches" sub-cases the *same* title, "Valid Secret\nRecovery Phrase" --
+ * only the body text differs. BAGL (src/bagl/ux_nano.c) gives them two
+ * different titles, "doesn't match" vs. "is correct", on two distinct flows.
+ * This is one of the two divergences that motivated this header; it is not
+ * corrected here.
+ */
+#define UI_STR_NBGL_RESULT_INVALID_TITLE "Invalid Secret\nRecovery Phrase"
+#define UI_STR_NBGL_RESULT_VALID_TITLE   "Valid Secret\nRecovery Phrase"
+#define UI_STR_NBGL_RESULT_BIP39_INVALID "The BIP39 Recovery Phrase\nyou have entered is not valid"
+#define UI_STR_NBGL_RESULT_SSKR_INVALID  "The SSKR Recovery Phrase\nyou have entered is not valid"
+#define UI_STR_NBGL_RESULT_BIP39_NOMATCH                                                          \
+    "The BIP39 Recovery Phrase\nyou have entered\ndoesn't match the one present\non this Ledger " \
+    "device."
+#define UI_STR_NBGL_RESULT_BIP39_MATCH \
+    "The BIP39 Recovery Phrase\nyou have entered\nmatches the one present\non this Ledger device."
+#define UI_STR_NBGL_RESULT_SSKR_NOMATCH                                                          \
+    "The SSKR Recovery Phrase\nyou have entered\ndoesn't match the one present\non this Ledger " \
+    "device."
+#define UI_STR_NBGL_RESULT_SSKR_MATCH \
+    "The SSKR Recovery Phrase\nyou have entered\nmatches the one present\non this Ledger device."
+#define UI_STR_NBGL_RESULT_TAP_TO_DISMISS "Tap to dismiss"
+
+/*
+ * BAGL invalid-phrase advice (src/bagl/ux_nano.c), shared by the BIP39 and
+ * SSKR invalid flows. NBGL's invalid-result body text above carries no such
+ * advice -- the other divergence that motivated this header.
+ */
+#define UI_STR_BAGL_INVALID_ADVICE_L1 "Check length,"
+#define UI_STR_BAGL_INVALID_ADVICE_L2 "order and spelling"
+
+#define UI_STR_BAGL_BIP39_INVALID_TITLE_L1 "BIP39 Recovery"
+#define UI_STR_BAGL_BIP39_INVALID_TITLE_L2 "phrase invalid"
+#define UI_STR_BAGL_BIP39_REENTER_PHRASE   "Re-enter phrase"
+#define UI_STR_BAGL_BIP39_NOMATCH_TITLE_L2 "doesn't match"
+#define UI_STR_BAGL_BIP39_MATCH_TITLE_L2   "is correct"
+
+#define UI_STR_BAGL_SSKR_INVALID_TITLE_L1 "SSKR Recovery"
+#define UI_STR_BAGL_SSKR_INVALID_TITLE_L2 "phrase invalid"
+#define UI_STR_BAGL_SSKR_REENTER_SHARES   "Re-enter shares"
+#define UI_STR_BAGL_SSKR_NOMATCH_TITLE_L1 "SSKR Phrase"
+#define UI_STR_BAGL_SSKR_NOMATCH_TITLE_L2 "doesn't match"
+#define UI_STR_BAGL_SSKR_MATCH_TITLE_L1   "SSKR Phrase"
+#define UI_STR_BAGL_SSKR_MATCH_TITLE_L2   "is correct"
+
+/*
+ * Recover BIP39 from SSKR / Generate SSKR from BIP39 -- the two choice
+ * screens offered right after a successful verdict.
+ *
+ * NBGL asks with a title + description + two buttons (src/nbgl/ui.c); BAGL
+ * folds the same choice into the verdict flow's own steps
+ * (src/bagl/ux_nano.c). Wording differs; declared together.
+ */
+#define UI_STR_NBGL_RECOVER_BIP39_TITLE "Recover BIP39 Phrase?"
+#define UI_STR_NBGL_RECOVER_BIP39_DESC \
+    "Choose if you wish to\nrecover the BIP39 phrase\nfrom your valid\nSSKR shares."
+#define UI_STR_NBGL_RECOVER_BIP39_CONFIRM "Recover BIP39"
+#define UI_STR_NBGL_DONE                  "Done"
+
+#define UI_STR_NBGL_GENERATE_SSKR_TITLE "Generate SSKR Phrase?"
+#define UI_STR_NBGL_GENERATE_SSKR_DESC \
+    "Choose if you wish to\ngenerate SSKR shares from\nyour valid BIP39 phrase."
+#define UI_STR_NBGL_GENERATE_SSKR_CONFIRM "Generate SSKR"
+
+#define UI_STR_BAGL_GENERATE_SSKR_L1 "Generate"
+#define UI_STR_BAGL_GENERATE_SSKR_L2 "SSKR phrases"
+#define UI_STR_BAGL_RECOVER_BIP39_L1 "Recover"
+#define UI_STR_BAGL_RECOVER_BIP39_L2 "BIP39 phrase"
+
+/*
+ * SSKR share count / threshold selection
+ */
+#define UI_STR_NBGL_SSKR_NUMSHARES_TITLE       "Enter number of SSKR shares\nto generate (1 - 16)"
+#define UI_STR_NBGL_SSKR_NUMSHARES_RANGE_ERROR "Number of SSKR shares must be between 1 and 16"
+#define UI_STR_BAGL_SSKR_NUMSHARES_TITLE_L1    "Select number"
+#define UI_STR_BAGL_SSKR_NUMSHARES_TITLE_L2    "of shares"
+
+#define UI_STR_NBGL_SSKR_THRESHOLD_TITLE      "Enter threshold value"
+#define UI_STR_NBGL_SSKR_THRESHOLD_ZERO_ERROR "Threshold value cannot be 0"
+#define UI_STR_NBGL_SSKR_THRESHOLD_RANGE_ERROR \
+    "Threshold value cannot be greater than number of shares"
+#define UI_STR_NBGL_SSKR_THRESHOLD_ONE_OF_M_ERROR "1-of-m shares where\nm > 1 is not supported"
+#define UI_STR_BAGL_SSKR_THRESHOLD_TITLE_L1       "Select"
+#define UI_STR_BAGL_SSKR_THRESHOLD_TITLE_L2       "threshold"
+#define UI_STR_BAGL_SSKR_ONE_OF_M_WARN_L1         "1-of-m shares"
+#define UI_STR_BAGL_SSKR_ONE_OF_M_WARN_L2         "where m > 1"
+#define UI_STR_BAGL_SSKR_ONE_OF_M_NOT_L1          "Not"
+#define UI_STR_BAGL_SSKR_ONE_OF_M_NOT_L2          "Supported"
+
+/*
+ * BIP85 -- NBGL only. No BAGL target has a BIP85 screen at all.
+ */
+#define UI_STR_NBGL_BIP85_APP_BIP39        "BIP39"
+#define UI_STR_NBGL_BIP85_APP_PWD_BASE64   "Password (Base64)"
+#define UI_STR_NBGL_BIP85_APP_PWD_BASE85   "Password (Base85)"
+#define UI_STR_NBGL_BIP85_SELECT_APP_TITLE "Which BIP85\napplication do you\nwish to use?"
+
+#define UI_STR_NBGL_BIP85_BIP39_HEADER  "BIP39 Phrase (Index #%d)"
+#define UI_STR_NBGL_BIP85_BASE64_HEADER "Base64 Password (Index #%d)"
+#define UI_STR_NBGL_BIP85_BASE85_HEADER "Base85 Password (Index #%d)"
+
+#define UI_STR_NBGL_BIP85_INDEX_TITLE       "Enter index"
+#define UI_STR_NBGL_BIP85_INDEX_RANGE_ERROR "BIP85 index must be between 0 and 9,999,999"
+
+#define UI_STR_NBGL_BIP85_PWD_LENGTH_TITLE       "Enter password length"
+#define UI_STR_NBGL_BIP85_PWD_LENGTH_RANGE_ERROR "BIP85 password length must be between %d and %d"

--- a/src/nbgl/ui.c
+++ b/src/nbgl/ui.c
@@ -32,6 +32,7 @@
 
 #include "../common/bip39/common_bip39.h"
 #include "../common/sskr/common_sskr.h"
+#include "../common/ui_strings.h"
 #include "../ui.h"
 #include "./bip39_mnemonic.h"
 #include "./bip85_app.h"
@@ -88,7 +89,8 @@ enum __attribute__((packed)) select_tool {
     SELECT_TOOL_NB_CHILDREN
 };
 
-static const char* toolType[] = {"BIP39 Check", "SSKR Check", "BIP85 Generate"};
+static const char* toolType[] = {UI_STR_NBGL_TOOL_BIP39, UI_STR_NBGL_TOOL_SSKR,
+                                 UI_STR_NBGL_TOOL_BIP85};
 static void select_tool_callback(nbgl_obj_t* obj, nbgl_touchType_t eventType) {
     nbgl_obj_t** screenChildren = nbgl_screenGetElements(0);
     if (eventType != TOUCHED) {
@@ -125,7 +127,7 @@ static void display_select_tool_page(void) {
         (nbgl_obj_t*)generic_screen_set_title(
             screenChildren[SELECT_TOOL_ICON_INDEX]);
     ((nbgl_text_area_t*)screenChildren[SELECT_TOOL_TEXT_INDEX])->text =
-        "Select the tool\nyou wish to use";
+        UI_STR_NBGL_SELECT_TOOL_TITLE;
     // create nb words buttons
     nbgl_objPoolGetArray(
         BUTTON, ARRAYLEN(toolType), 0,
@@ -165,7 +167,7 @@ static void display_select_tool_page(void) {
 static void select_recover_bip39_choice(bool bip39_rec) {
     nbgl_layoutRelease(layout);
     if (bip39_rec) {
-        SPRINTF(headerText, "BIP39 Phrase");
+        SPRINTF(headerText, UI_STR_BIP39_PHRASE_TITLE);
         strncpy(reviewText, bip39_mnemonic_get(), bip39_mnemonic_length_get());
         // Ensure null termination
         reviewText[bip39_mnemonic_length_get()] = '\0';
@@ -176,10 +178,10 @@ static void select_recover_bip39_choice(bool bip39_rec) {
 }
 
 void display_select_recover_bip39_page(void) {
-    nbgl_useCaseChoice(&BIP39_ICON, "Recover BIP39 Phrase?",
-                       "Choose if you wish to\nrecover the BIP39 phrase\nfrom "
-                       "your valid\nSSKR shares.",
-                       "Recover BIP39", "Done", select_recover_bip39_choice);
+    nbgl_useCaseChoice(&BIP39_ICON, UI_STR_NBGL_RECOVER_BIP39_TITLE,
+                       UI_STR_NBGL_RECOVER_BIP39_DESC,
+                       UI_STR_NBGL_RECOVER_BIP39_CONFIRM, UI_STR_NBGL_DONE,
+                       select_recover_bip39_choice);
 }
 
 /*
@@ -195,10 +197,10 @@ static void select_generate_sskr_choice(bool sskr_gen) {
 }
 
 void display_select_generate_sskr_page(void) {
-    nbgl_useCaseChoice(&SSKR_ICON, "Generate SSKR Phrase?",
-                       "Choose if you wish to\ngenerate SSKR shares from\nyour "
-                       "valid BIP39 phrase.",
-                       "Generate SSKR", "Done", select_generate_sskr_choice);
+    nbgl_useCaseChoice(&SSKR_ICON, UI_STR_NBGL_GENERATE_SSKR_TITLE,
+                       UI_STR_NBGL_GENERATE_SSKR_DESC,
+                       UI_STR_NBGL_GENERATE_SSKR_CONFIRM, UI_STR_NBGL_DONE,
+                       select_generate_sskr_choice);
 }
 
 /*
@@ -215,8 +217,8 @@ enum __attribute__((packed)) select_bip39_phrase_length {
     KBD_TEXT_TOKEN
 };
 
-static const char* bip39_passphraseLength[] = {"12 words", "18 words",
-                                               "24 words"};
+static const char* bip39_passphraseLength[] = {UI_STR_WORDS_12, UI_STR_WORDS_18,
+                                               UI_STR_WORDS_24};
 static void select_bip39_phrase_length_callback(nbgl_obj_t* obj,
                                                 nbgl_touchType_t eventType) {
     nbgl_obj_t** screenChildren = nbgl_screenGetElements(0);
@@ -265,8 +267,8 @@ static void display_bip39_select_phrase_length_page(void) {
             screenChildren[SELECT_BIP39_PHRASE_LENGTH_ICON_INDEX]);
     ((nbgl_text_area_t*)screenChildren[SELECT_BIP39_PHRASE_LENGTH_TEXT_INDEX])
         ->text = tool_type == TOOL_TYPE_BIP39
-                     ? "How long is your\nBIP39 Recovery\nPhrase?"
-                     : "Length of BIP39\nphrase to\ngenerate?";
+                     ? UI_STR_NBGL_BIP39_LENGTH_TITLE_CHECK
+                     : UI_STR_NBGL_BIP39_LENGTH_TITLE_DERIVE;
     // create nb words buttons
     nbgl_objPoolGetArray(BUTTON, ARRAYLEN(bip39_passphraseLength), 0,
                          (nbgl_obj_t**)&screenChildren
@@ -461,13 +463,11 @@ static void display_check_keyboard_page() {
     memzero(buttonTexts, sizeof(buttonTexts[0]) * NB_MAX_SUGGESTION_BUTTONS);
     layout = nbgl_layoutGet(&layoutDescription);
     if (tool_type == TOOL_TYPE_BIP39) {
-        snprintf(headerText, HEADER_SIZE,
-                 "Enter word n. %d/%d of your\nBIP39 Recovery Phrase",
+        snprintf(headerText, HEADER_SIZE, UI_STR_NBGL_ENTER_BIP39_WORD,
                  bip39_mnemonic_current_word_number_get() + 1,
                  bip39_mnemonic_final_size_get());
     } else if (tool_type == TOOL_TYPE_SSKR) {
-        snprintf(headerText, HEADER_SIZE,
-                 "Enter Share %d Word %d\nof your Recovery Phrase",
+        snprintf(headerText, HEADER_SIZE, UI_STR_NBGL_ENTER_SSKR_WORD,
                  sskr_shareindex_get() + 1,
                  sskr_shares_current_word_number_get() + 1);
     }
@@ -508,22 +508,20 @@ static void display_check_keyboard_page() {
  * Home page, infos & dispatcher
  */
 static void display_home_page() {
-    static const char* const infoTypes[] = {"Version", APPNAME};
+    static const char* const infoTypes[] = {UI_STR_VERSION_LABEL, APPNAME};
     static const char* const infoContents[] = {APPVERSION,
-                                               "(c) 2018-2026 Ledger"};
+                                               UI_STR_NBGL_HOME_COPYRIGHT};
     static const nbgl_contentInfoList_t infoList = {
         .nbInfos = 2, .infoTypes = infoTypes, .infoContents = infoContents};
 
     reset_globals();
 
-    nbgl_homeAction_t action = {.text = "Select Tool",
+    nbgl_homeAction_t action = {.text = UI_STR_NBGL_HOME_ACTION,
                                 .callback = PIC(display_select_tool_page)};
 
     nbgl_useCaseHomeAndSettings(APPNAME, &ICON_APP_HOME,
-                                "This Ledger application\nprovides some useful "
-                                "seed\nmanagement utilities.",
-                                INIT_HOME_PAGE, NULL, &infoList, &action,
-                                on_quit);
+                                UI_STR_NBGL_HOME_DESCRIPTION, INIT_HOME_PAGE,
+                                NULL, &infoList, &action, on_quit);
 }
 
 /*
@@ -564,21 +562,11 @@ static void check_result_callback(int token __attribute__((unused)),
 
 static void display_check_result_page(const bool result) {
     static const char* possible_results[2][5] = {
-        {"Invalid Secret\nRecovery Phrase",
-         "The BIP39 Recovery Phrase\nyou have entered is not valid", "",
-         "The SSKR Recovery Phrase\nyou have entered is not valid", ""},
-        {"Valid Secret\nRecovery Phrase",
-         "The BIP39 Recovery Phrase\nyou have entered\ndoesn't match the one "
-         "present\n"
-         "on this Ledger device.",
-         "The BIP39 Recovery Phrase\nyou have entered\nmatches the one "
-         "present\n"
-         "on this Ledger device.",
-         "The SSKR Recovery Phrase\nyou have entered\ndoesn't match the one "
-         "present\n"
-         "on this Ledger device.",
-         "The SSKR Recovery Phrase\nyou have entered\nmatches the one present\n"
-         "on this Ledger device."}};
+        {UI_STR_NBGL_RESULT_INVALID_TITLE, UI_STR_NBGL_RESULT_BIP39_INVALID, "",
+         UI_STR_NBGL_RESULT_SSKR_INVALID, ""},
+        {UI_STR_NBGL_RESULT_VALID_TITLE, UI_STR_NBGL_RESULT_BIP39_NOMATCH,
+         UI_STR_NBGL_RESULT_BIP39_MATCH, UI_STR_NBGL_RESULT_SSKR_NOMATCH,
+         UI_STR_NBGL_RESULT_SSKR_MATCH}};
     static const nbgl_icon_details_t* icons[3] = {
         &DENIED_CIRCLE_ICON, &IMPORTANT_CIRCLE_ICON, &CHECK_CIRCLE_ICON};
 
@@ -601,7 +589,7 @@ static void display_check_result_page(const bool result) {
         .centeredInfo.text3 = NULL,
         .centeredInfo.style = LARGE_CASE_INFO,
         .centeredInfo.offsetY = -16,
-        .footerText = "Tap to dismiss",
+        .footerText = UI_STR_NBGL_RESULT_TAP_TO_DISMISS,
         .footerToken = CHECK_RESULT_TOKEN,
         .bottomButtonStyle = NO_BUTTON_STYLE,
         .tapActionText = NULL,
@@ -635,17 +623,16 @@ static void sskr_sharenum_validate(const uint8_t* sharenumentry,
     if (sskr_sharenum_get() > 0 && sskr_sharenum_get() <= 16) {
         display_sskr_select_threshold_page();
     } else {
-        nbgl_useCaseStatus("Number of SSKR shares must be between 1 and 16",
-                           false, display_select_generate_sskr_page);
+        nbgl_useCaseStatus(UI_STR_NBGL_SSKR_NUMSHARES_RANGE_ERROR, false,
+                           display_select_generate_sskr_page);
     }
 }
 
 void display_sskr_select_numshares_page() {
     // Draw the keypad
-    nbgl_useCaseKeypad("Enter number of SSKR shares\nto generate (1 - 16)", 1,
-                       SSKR_MAX_NUMBER_LENGTH, false, false,
-                       sskr_sharenum_validate,
-                       display_select_generate_sskr_page);
+    nbgl_useCaseKeypad(
+        UI_STR_NBGL_SSKR_NUMSHARES_TITLE, 1, SSKR_MAX_NUMBER_LENGTH, false,
+        false, sskr_sharenum_validate, display_select_generate_sskr_page);
 }
 
 static void review_done(void) {
@@ -668,7 +655,7 @@ static void display_generic_review() {
     pairs[0].item = PIC(headerText);
     pairs[0].value = PIC(reviewText);
 
-    nbgl_useCaseGenericReview(&genericContent, "Done", review_done);
+    nbgl_useCaseGenericReview(&genericContent, UI_STR_NBGL_DONE, review_done);
 }
 
 static void review_sskr_shares_contentGetter(uint8_t index,
@@ -682,7 +669,7 @@ static void review_sskr_shares_contentGetter(uint8_t index,
     genericreview->content.tagValueList.wrapping = true;
     genericreview->content.tagValueList.pairs = (nbgl_layoutTagValue_t*)pairs;
 
-    SPRINTF(headerText, "SSKR Share #%d", index + 1);
+    SPRINTF(headerText, UI_STR_SSKR_SHARE_HEADER, index + 1);
     // Ensure null termination
     headerText[sskr_sharecount_get() > 9 ? sizeof(headerText) - 1
                                          : sizeof(headerText) - 2] = '\0';
@@ -715,7 +702,7 @@ static void display_sskr_shares(void) {
     genericContent.contentGetterCallback = review_sskr_shares_contentGetter;
     genericContent.nbContents = sskr_sharecount_get();
 
-    nbgl_useCaseGenericReview(&genericContent, "Done", review_done);
+    nbgl_useCaseGenericReview(&genericContent, UI_STR_NBGL_DONE, review_done);
 }
 
 static void sskr_threshold_validate(const uint8_t* thresholdentry,
@@ -731,14 +718,13 @@ static void sskr_threshold_validate(const uint8_t* thresholdentry,
     PRINTF("Threshold value entered is '%d'\n", sskr_threshold_get());
 
     if (sskr_threshold_get() < 1) {
-        nbgl_useCaseStatus("Threshold value cannot be 0", false,
+        nbgl_useCaseStatus(UI_STR_NBGL_SSKR_THRESHOLD_ZERO_ERROR, false,
                            display_select_generate_sskr_page);
     } else if (sskr_threshold_get() > sskr_sharenum_get()) {
-        nbgl_useCaseStatus(
-            "Threshold value cannot be greater than number of shares", false,
-            display_select_generate_sskr_page);
+        nbgl_useCaseStatus(UI_STR_NBGL_SSKR_THRESHOLD_RANGE_ERROR, false,
+                           display_select_generate_sskr_page);
     } else if (sskr_threshold_get() == 1 && sskr_sharenum_get() > 1) {
-        nbgl_useCaseStatus("1-of-m shares where\nm > 1 is not supported", false,
+        nbgl_useCaseStatus(UI_STR_NBGL_SSKR_THRESHOLD_ONE_OF_M_ERROR, false,
                            display_select_generate_sskr_page);
     } else {
         display_sskr_shares();
@@ -747,9 +733,9 @@ static void sskr_threshold_validate(const uint8_t* thresholdentry,
 
 void display_sskr_select_threshold_page() {
     // Draw the keypad
-    nbgl_useCaseKeypad("Enter threshold value", 1, SSKR_MAX_NUMBER_LENGTH,
-                       false, false, sskr_threshold_validate,
-                       display_sskr_select_numshares_page);
+    nbgl_useCaseKeypad(
+        UI_STR_NBGL_SSKR_THRESHOLD_TITLE, 1, SSKR_MAX_NUMBER_LENGTH, false,
+        false, sskr_threshold_validate, display_sskr_select_numshares_page);
 }
 
 enum __attribute__((packed)) select_bip85_app {
@@ -762,8 +748,9 @@ enum __attribute__((packed)) select_bip85_app {
     SELECT_BIP85_APP_NB_CHILDREN,
 };
 
-static const char* bip85_select_app[] = {"BIP39", "Password (Base64)",
-                                         "Password (Base85)"};
+static const char* bip85_select_app[] = {UI_STR_NBGL_BIP85_APP_BIP39,
+                                         UI_STR_NBGL_BIP85_APP_PWD_BASE64,
+                                         UI_STR_NBGL_BIP85_APP_PWD_BASE85};
 static void bip85_index_validate(const uint8_t* indexentry, uint8_t length) {
     // Code to validate BIP85 index
 
@@ -796,7 +783,7 @@ static void bip85_index_validate(const uint8_t* indexentry, uint8_t length) {
         switch (bip85_type_get()) {
             case BIP85_APP_BIP39:
                 bip85_app_bip39_gen();
-                SPRINTF(headerText, "BIP39 Phrase (Index #%d)",
+                SPRINTF(headerText, UI_STR_NBGL_BIP85_BIP39_HEADER,
                         bip85_index_get());
                 strncpy(reviewText, bip39_mnemonic_get(),
                         bip39_mnemonic_length_get());
@@ -805,7 +792,7 @@ static void bip85_index_validate(const uint8_t* indexentry, uint8_t length) {
                 display_generic_review();
                 break;
             case BIP85_APP_PWD_BASE64:
-                SPRINTF(headerText, "Base64 Password (Index #%d)",
+                SPRINTF(headerText, UI_STR_NBGL_BIP85_BASE64_HEADER,
                         bip85_index_get());
                 strncpy(reviewText, (const char*)bip85_app_pwd_base64_gen(),
                         bip85_length_get());
@@ -814,7 +801,7 @@ static void bip85_index_validate(const uint8_t* indexentry, uint8_t length) {
                 display_generic_review();
                 break;
             case BIP85_APP_PWD_BASE85:
-                SPRINTF(headerText, "Base85 Password (Index #%d)",
+                SPRINTF(headerText, UI_STR_NBGL_BIP85_BASE85_HEADER,
                         bip85_index_get());
                 strncpy(reviewText, (const char*)bip85_app_pwd_base85_gen(),
                         bip85_length_get());
@@ -827,16 +814,16 @@ static void bip85_index_validate(const uint8_t* indexentry, uint8_t length) {
                 break;
         }
     } else {
-        nbgl_useCaseStatus("BIP85 index must be between 0 and 9,999,999", false,
+        nbgl_useCaseStatus(UI_STR_NBGL_BIP85_INDEX_RANGE_ERROR, false,
                            display_bip39_select_phrase_length_page);
     }
 }
 
 void display_bip85_select_index_page() {
     // Draw the keypad
-    nbgl_useCaseKeypad("Enter index", 1, BIP85_INDEX_MAX_NUMBER_LENGTH, false,
-                       false, bip85_index_validate,
-                       display_bip85_select_app_page);
+    nbgl_useCaseKeypad(UI_STR_NBGL_BIP85_INDEX_TITLE, 1,
+                       BIP85_INDEX_MAX_NUMBER_LENGTH, false, false,
+                       bip85_index_validate, display_bip85_select_app_page);
 }
 
 static void bip85_password_length_validate(const uint8_t* lengthentry,
@@ -861,8 +848,8 @@ static void bip85_password_length_validate(const uint8_t* lengthentry,
         display_bip85_select_index_page();
     } else {
         snprintf(message, sizeof(message),
-                 "BIP85 password length must be between %d and %d",
-                 password_length_min, password_length_max);
+                 UI_STR_NBGL_BIP85_PWD_LENGTH_RANGE_ERROR, password_length_min,
+                 password_length_max);
         nbgl_useCaseStatus((const char*)message, false,
                            display_bip85_select_app_page);
     }
@@ -870,7 +857,7 @@ static void bip85_password_length_validate(const uint8_t* lengthentry,
 
 void display_bip85_select_password_length_page() {
     // Draw the keypad
-    nbgl_useCaseKeypad("Enter password length", 1, 2, false, false,
+    nbgl_useCaseKeypad(UI_STR_NBGL_BIP85_PWD_LENGTH_TITLE, 1, 2, false, false,
                        bip85_password_length_validate,
                        display_bip85_select_app_page);
 }
@@ -916,7 +903,7 @@ static void display_bip85_select_app_page(void) {
         (nbgl_obj_t*)generic_screen_set_title(
             screenChildren[SELECT_BIP85_APP_ICON_INDEX]);
     ((nbgl_text_area_t*)screenChildren[SELECT_BIP39_PHRASE_LENGTH_TEXT_INDEX])
-        ->text = "Which BIP85\napplication do you\nwish to use?";
+        ->text = UI_STR_NBGL_BIP85_SELECT_APP_TITLE;
 
     // create bip85 app buttons
     nbgl_objPoolGetArray(

--- a/tests/unit/CMakeLists.txt
+++ b/tests/unit/CMakeLists.txt
@@ -1064,6 +1064,12 @@ add_executable(test_sskr_ux_menu_nanos ./tests/sskr_ux_menu.c ../../src/bagl/ux_
 target_include_directories(test_sskr_ux_menu_nanos PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/../../src ${CMAKE_CURRENT_SOURCE_DIR}/../../src/common/sskr/sss)
 target_compile_definitions(test_sskr_ux_menu_nanos PRIVATE TARGET_NANOS)
 target_link_libraries(test_sskr_ux_menu_nanos PUBLIC cmocka gcov testutils)
+
+# ui_strings.h holds only macros, so this links nothing from src/ -- compiling
+# and enumerating the header is the whole test.
+add_executable(test_ui_strings tests/ui_strings.c)
+target_include_directories(test_ui_strings PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/../../src/common)
+target_link_libraries(test_ui_strings PUBLIC cmocka gcov)
 # ---------------------------------------------------------------------------
 
 # Register every executable this file builds, instead of repeating their names

--- a/tests/unit/tests/ui_strings.c
+++ b/tests/unit/tests/ui_strings.c
@@ -1,0 +1,366 @@
+/*
+ * ui_strings.h is the first piece of interface the application can test in
+ * this suite: src/nbgl/ui.c and the files under src/bagl/ are not compiled
+ * into any unit target, so this is the only net any of these strings gets
+ * other than the functional tests under Speculos.
+ *
+ * Two things are checked:
+ *
+ *   - every string is non-empty. A macro whose value became "" by accident
+ *     (a bad merge, a copy-paste that dropped the literal) is otherwise
+ *     invisible until someone runs the app;
+ *
+ *   - every BAGL fragment destined for a fixed (non-wrapping) Nano layout
+ *     fits the real pixel budget of that layout. NN/NNN/PBB/PNN/PB/BN steps
+ *     do not wrap or crop -- unlike BNNN_PAGING, which the dynamic word/share
+ *     buffers use and which this test does not need to bound. A string that
+ *     does not fit is silently clipped at runtime; nothing else catches it.
+ *
+ * Each entry below is `ENTRY(UI_STR_X)`, which expands to `{"UI_STR_X",
+ * UI_STR_X}` -- the name and the header's own macro, not a retyped copy of
+ * its value. That is what "declares its own table naming every macro" in
+ * ui_strings.h's own comment means: nothing here can drift from the header,
+ * because nothing here repeats it by hand. A renamed or removed macro is a
+ * compile error in this file, not a silent gap in the table.
+ */
+
+#include <stdarg.h>
+#include <stddef.h>
+#include <setjmp.h>
+#include <cmocka.h>
+#include <string.h>
+
+#include "ui_strings.h"
+
+#define ENTRY(name) \
+    { #name, name }
+#define BOUNDED(name, budget_px, is_bold) \
+    { #name, name, budget_px, is_bold }
+
+/*
+ * Every macro in src/common/ui_strings.h. Kept in the order the header
+ * declares them, so a diff of the header and a diff of this list line up.
+ */
+static const struct {
+    const char *name;
+    const char *value;
+} k_all_strings[] = {
+    ENTRY(UI_STR_QUIT),
+    ENTRY(UI_STR_VERSION_LABEL),
+    ENTRY(UI_STR_BIP39_PHRASE_TITLE),
+    ENTRY(UI_STR_SSKR_SHARE_HEADER),
+    ENTRY(UI_STR_WORDS_12),
+    ENTRY(UI_STR_WORDS_18),
+    ENTRY(UI_STR_WORDS_24),
+    ENTRY(UI_STR_BAGL_PROCESSING),
+    ENTRY(UI_STR_NBGL_TOOL_BIP39),
+    ENTRY(UI_STR_NBGL_TOOL_SSKR),
+    ENTRY(UI_STR_NBGL_TOOL_BIP85),
+    ENTRY(UI_STR_NBGL_SELECT_TOOL_TITLE),
+    ENTRY(UI_STR_BAGL_IDLE_BIP39_L1),
+    ENTRY(UI_STR_BAGL_IDLE_BIP39_L2),
+    ENTRY(UI_STR_BAGL_IDLE_SSKR_L1),
+    ENTRY(UI_STR_BAGL_IDLE_SSKR_L2),
+    ENTRY(UI_STR_NBGL_HOME_DESCRIPTION),
+    ENTRY(UI_STR_NBGL_HOME_ACTION),
+    ENTRY(UI_STR_NBGL_HOME_COPYRIGHT),
+    ENTRY(UI_STR_NBGL_BIP39_LENGTH_TITLE_CHECK),
+    ENTRY(UI_STR_NBGL_BIP39_LENGTH_TITLE_DERIVE),
+    ENTRY(UI_STR_BAGL_BIP39_LENGTH_TITLE_L1_NANOS),
+    ENTRY(UI_STR_BAGL_BIP39_LENGTH_TITLE_L2_NANOS),
+    ENTRY(UI_STR_BAGL_BIP39_LENGTH_TITLE_L1),
+    ENTRY(UI_STR_BAGL_BIP39_LENGTH_TITLE_L2),
+    ENTRY(UI_STR_BAGL_BIP39_LENGTH_TITLE_L3),
+    ENTRY(UI_STR_BAGL_BIP39_LENGTH_BACK),
+    ENTRY(UI_STR_BAGL_SSKR_START_TITLE_L1_NANOS),
+    ENTRY(UI_STR_BAGL_SSKR_START_TITLE_L2_NANOS),
+    ENTRY(UI_STR_BAGL_SSKR_START_TITLE_L1),
+    ENTRY(UI_STR_BAGL_SSKR_START_TITLE_L2),
+    ENTRY(UI_STR_BAGL_SSKR_START_TITLE_L3),
+    ENTRY(UI_STR_NBGL_ENTER_BIP39_WORD),
+    ENTRY(UI_STR_NBGL_ENTER_SSKR_WORD),
+    ENTRY(UI_STR_BAGL_NANOS_WORD_HEADER),
+    ENTRY(UI_STR_BAGL_NANOS_WORD_HEADER_LOWER),
+    ENTRY(UI_STR_BAGL_NANOS_ENTER_SSKR_WORD),
+    ENTRY(UI_STR_BAGL_NANOS_RESTART_FROM),
+    ENTRY(UI_STR_BAGL_NANOS_WORD_INDEX_PREFIX),
+    ENTRY(UI_STR_BAGL_NANOX_INTRO_L1),
+    ENTRY(UI_STR_BAGL_NANOX_INTRO_L2),
+    ENTRY(UI_STR_BAGL_NANOX_INTRO_L3),
+    ENTRY(UI_STR_BAGL_NANOX_CLEAR_WORD),
+    ENTRY(UI_STR_BAGL_NANOX_ENTER_BIP39_WORD),
+    ENTRY(UI_STR_BAGL_NANOX_ENTER_SSKR_WORD),
+    ENTRY(UI_STR_BAGL_NANOX_OF_WORD),
+    ENTRY(UI_STR_BAGL_NANOX_SELECT_WORD),
+    ENTRY(UI_STR_BAGL_ENTER_LABEL),
+    ENTRY(UI_STR_BAGL_RETURN_TO_MENU),
+    ENTRY(UI_STR_NBGL_RESULT_INVALID_TITLE),
+    ENTRY(UI_STR_NBGL_RESULT_VALID_TITLE),
+    ENTRY(UI_STR_NBGL_RESULT_BIP39_INVALID),
+    ENTRY(UI_STR_NBGL_RESULT_SSKR_INVALID),
+    ENTRY(UI_STR_NBGL_RESULT_BIP39_NOMATCH),
+    ENTRY(UI_STR_NBGL_RESULT_BIP39_MATCH),
+    ENTRY(UI_STR_NBGL_RESULT_SSKR_NOMATCH),
+    ENTRY(UI_STR_NBGL_RESULT_SSKR_MATCH),
+    ENTRY(UI_STR_NBGL_RESULT_TAP_TO_DISMISS),
+    ENTRY(UI_STR_BAGL_INVALID_ADVICE_L1),
+    ENTRY(UI_STR_BAGL_INVALID_ADVICE_L2),
+    ENTRY(UI_STR_BAGL_BIP39_INVALID_TITLE_L1),
+    ENTRY(UI_STR_BAGL_BIP39_INVALID_TITLE_L2),
+    ENTRY(UI_STR_BAGL_BIP39_REENTER_PHRASE),
+    ENTRY(UI_STR_BAGL_BIP39_NOMATCH_TITLE_L2),
+    ENTRY(UI_STR_BAGL_BIP39_MATCH_TITLE_L2),
+    ENTRY(UI_STR_BAGL_SSKR_INVALID_TITLE_L1),
+    ENTRY(UI_STR_BAGL_SSKR_INVALID_TITLE_L2),
+    ENTRY(UI_STR_BAGL_SSKR_REENTER_SHARES),
+    ENTRY(UI_STR_BAGL_SSKR_NOMATCH_TITLE_L1),
+    ENTRY(UI_STR_BAGL_SSKR_NOMATCH_TITLE_L2),
+    ENTRY(UI_STR_BAGL_SSKR_MATCH_TITLE_L1),
+    ENTRY(UI_STR_BAGL_SSKR_MATCH_TITLE_L2),
+    ENTRY(UI_STR_NBGL_RECOVER_BIP39_TITLE),
+    ENTRY(UI_STR_NBGL_RECOVER_BIP39_DESC),
+    ENTRY(UI_STR_NBGL_RECOVER_BIP39_CONFIRM),
+    ENTRY(UI_STR_NBGL_DONE),
+    ENTRY(UI_STR_NBGL_GENERATE_SSKR_TITLE),
+    ENTRY(UI_STR_NBGL_GENERATE_SSKR_DESC),
+    ENTRY(UI_STR_NBGL_GENERATE_SSKR_CONFIRM),
+    ENTRY(UI_STR_BAGL_GENERATE_SSKR_L1),
+    ENTRY(UI_STR_BAGL_GENERATE_SSKR_L2),
+    ENTRY(UI_STR_BAGL_RECOVER_BIP39_L1),
+    ENTRY(UI_STR_BAGL_RECOVER_BIP39_L2),
+    ENTRY(UI_STR_NBGL_SSKR_NUMSHARES_TITLE),
+    ENTRY(UI_STR_NBGL_SSKR_NUMSHARES_RANGE_ERROR),
+    ENTRY(UI_STR_BAGL_SSKR_NUMSHARES_TITLE_L1),
+    ENTRY(UI_STR_BAGL_SSKR_NUMSHARES_TITLE_L2),
+    ENTRY(UI_STR_NBGL_SSKR_THRESHOLD_TITLE),
+    ENTRY(UI_STR_NBGL_SSKR_THRESHOLD_ZERO_ERROR),
+    ENTRY(UI_STR_NBGL_SSKR_THRESHOLD_RANGE_ERROR),
+    ENTRY(UI_STR_NBGL_SSKR_THRESHOLD_ONE_OF_M_ERROR),
+    ENTRY(UI_STR_BAGL_SSKR_THRESHOLD_TITLE_L1),
+    ENTRY(UI_STR_BAGL_SSKR_THRESHOLD_TITLE_L2),
+    ENTRY(UI_STR_BAGL_SSKR_ONE_OF_M_WARN_L1),
+    ENTRY(UI_STR_BAGL_SSKR_ONE_OF_M_WARN_L2),
+    ENTRY(UI_STR_BAGL_SSKR_ONE_OF_M_NOT_L1),
+    ENTRY(UI_STR_BAGL_SSKR_ONE_OF_M_NOT_L2),
+    ENTRY(UI_STR_NBGL_BIP85_APP_BIP39),
+    ENTRY(UI_STR_NBGL_BIP85_APP_PWD_BASE64),
+    ENTRY(UI_STR_NBGL_BIP85_APP_PWD_BASE85),
+    ENTRY(UI_STR_NBGL_BIP85_SELECT_APP_TITLE),
+    ENTRY(UI_STR_NBGL_BIP85_BIP39_HEADER),
+    ENTRY(UI_STR_NBGL_BIP85_BASE64_HEADER),
+    ENTRY(UI_STR_NBGL_BIP85_BASE85_HEADER),
+    ENTRY(UI_STR_NBGL_BIP85_INDEX_TITLE),
+    ENTRY(UI_STR_NBGL_BIP85_INDEX_RANGE_ERROR),
+    ENTRY(UI_STR_NBGL_BIP85_PWD_LENGTH_TITLE),
+    ENTRY(UI_STR_NBGL_BIP85_PWD_LENGTH_RANGE_ERROR),
+};
+
+/*
+ * Nano character metrics, reproduced from nanos_characters_width[] in the
+ * SDK's lib_ux/src/ux_layout_paging_compute.c: BAGL_FONT_OPEN_SANS_REGULAR_11px
+ * in the high nibble, BAGL_FONT_OPEN_SANS_EXTRABOLD_11px in the low, covering
+ * printable ASCII 0x20-0x7F -- the only two fonts this application's fixed
+ * (non-wrapping) UX_STEP layouts use. Measuring a regular-font string with
+ * the bold table would over-estimate its width and could fail it against a
+ * budget it actually clears; each string below is measured in the font its
+ * own layout actually draws it in.
+ */
+static const unsigned char k_nanos_char_width_regular[96] = {
+    3,  3,  4,  7,  6,  9,  8,  2,  3,  3,  6,  6,  3,  4,  3,  4,  /* 0x20-0x2F */
+    6,  6,  6,  6,  8,  6,  6,  6,  6,  6,  3,  3,  6,  6,  6,  5,  /* 0x30-0x3F */
+    10, 7,  7,  7,  8,  6,  6,  8,  8,  3,  4,  7,  6,  10, 8,  9,  /* 0x40-0x4F */
+    7,  9,  7,  6,  7,  8,  7,  10, 6,  6,  6,  4,  4,  4,  6,  5,  /* 0x50-0x5F */
+    6,  6,  7,  5,  7,  6,  5,  6,  7,  3,  4,  6,  3,  10, 7,  7,  /* 0x60-0x6F */
+    7,  7,  4,  5,  4,  7,  6,  9,  6,  6,  5,  4,  6,  4,  6,  7,  /* 0x70-0x7F */
+};
+static const unsigned char k_nanos_char_width_bold[96] = {
+    3,  3,  6,  7,  6,  10, 9,  3,  4,  4,  6,  6,  3,  4,  3,  5,  /* 0x20-0x2F */
+    8,  6,  7,  7,  8,  6,  8,  7,  8,  8,  3,  3,  5,  6,  5,  6,  /* 0x30-0x3F */
+    10, 8,  7,  7,  8,  6,  6,  8,  8,  4,  5,  8,  6,  11, 9,  9,  /* 0x40-0x4F */
+    7,  9,  8,  6,  6,  8,  6,  11, 8,  7,  7,  5,  5,  5,  7,  6,  /* 0x50-0x5F */
+    7,  7,  7,  6,  7,  7,  6,  7,  7,  4,  5,  7,  4,  10, 7,  7,  /* 0x60-0x6F */
+    7,  7,  5,  6,  5,  7,  7,  10, 7,  7,  6,  5,  6,  5,  6,  6,  /* 0x70-0x7F */
+};
+
+#define NANOS_FIRST_CHAR 0x20
+#define NANOS_LAST_CHAR  0x7F
+
+/*
+ * Every string below appears on at least one BAGL target through a fixed
+ * (non-wrapping, non-cropping) UX_STEP layout -- never through BNNN_PAGING,
+ * which the dynamic word/share buffers use and which auto-wraps. Two real,
+ * measured pixel budgets are in play, both read from the SDK
+ * (lib_ux/src/ux_layout_{bb,pb,pbb,pnn,nnn}.c on the 128x32 and 128x64
+ * variants):
+ *
+ *   - 116px: the NN / NNN / BN label box (x=6, width=116 on every BAGL
+ *     screen size the SDK ships). PB (128px, centered) is bounded here too,
+ *     tighter than its real budget, since nothing here needs the extra room;
+ *   - 87px: the PBB / PNN icon-flanked label box on the 128x32 (nanos)
+ *     variant -- x=41 to the 128px screen edge. This is the tighter of the
+ *     two, and the one that would actually clip: nanos's PBB/PNN box is
+ *     narrower than nanox/nanos+'s (x=6, width=116, same as NN/NNN there).
+ *
+ * NANOX_ENTER_BIP39_WORD and NANOX_ENTER_SSKR_WORD render through a third
+ * box, not through NN/PBB: the keyboard title label in the nanox/nanos+
+ * branch of screen_common_keyboard_elements (src/bagl/ux_keyboard.c,
+ * userid 0x04) -- x=0, width=128, regular, centered. Bounded at that real
+ * 128px, not the 116px margin used elsewhere, because
+ * "Enter Share#99 word#99" needs the room the real box actually has.
+ *
+ * NANOS_WORD_INDEX_PREFIX, a keyboard render fragment in
+ * nanos_enter_phrase.c, was not independently re-derived; it is bounded at
+ * the tighter 87px in the bold font -- the more conservative of the two
+ * combinations -- rather than guessed at a wider or lighter one.
+ *
+ * Two strings fail the bound below and are deliberately not asserted:
+ * "recovery phrase" (UI_STR_BAGL_IDLE_BIP39_L2 / _SSKR_L2, 93px bold, PBB) and
+ * "BIP39 Recovery" (UI_STR_BAGL_BIP39_INVALID_TITLE_L1, 90px bold, PBB), both
+ * 3-6px over the 87px PBB budget on nanos. Both predate this header --
+ * nothing here changed either word -- and this lot does not change wording
+ * (see the PR body). They are recorded here, not silently passed, so the
+ * gap this test cannot close is visible in the same place as the strings it
+ * does check, rather than only in the PR body.
+ */
+#define BOUND_WIDE           116
+#define BOUND_TIGHT          87
+#define BOUND_KEYBOARD_TITLE 128
+
+static const struct {
+    const char *name;
+    const char *value;
+    unsigned int budget_px;
+    bool bold;
+} k_nano_bounded_strings[] = {
+    BOUNDED(UI_STR_QUIT, BOUND_WIDE, true),
+    BOUNDED(UI_STR_VERSION_LABEL, BOUND_WIDE, true),
+    BOUNDED(UI_STR_BIP39_PHRASE_TITLE, BOUND_TIGHT, true),
+    BOUNDED(UI_STR_WORDS_12, BOUND_WIDE, true),
+    BOUNDED(UI_STR_WORDS_18, BOUND_WIDE, true),
+    BOUNDED(UI_STR_WORDS_24, BOUND_WIDE, true),
+    BOUNDED(UI_STR_BAGL_PROCESSING, BOUND_WIDE, true),
+    BOUNDED(UI_STR_BAGL_IDLE_BIP39_L1, BOUND_TIGHT, true),
+    /* IDLE_BIP39_L2 ("recovery phrase") -- see the file comment above. */
+    BOUNDED(UI_STR_BAGL_IDLE_SSKR_L1, BOUND_TIGHT, true),
+    /* IDLE_SSKR_L2 ("recovery phrase") -- see the file comment above. */
+    BOUNDED(UI_STR_BAGL_BIP39_LENGTH_TITLE_L1_NANOS, BOUND_WIDE, false),
+    BOUNDED(UI_STR_BAGL_BIP39_LENGTH_TITLE_L2_NANOS, BOUND_WIDE, false),
+    BOUNDED(UI_STR_BAGL_BIP39_LENGTH_TITLE_L1, BOUND_WIDE, false),
+    BOUNDED(UI_STR_BAGL_BIP39_LENGTH_TITLE_L2, BOUND_WIDE, false),
+    BOUNDED(UI_STR_BAGL_BIP39_LENGTH_TITLE_L3, BOUND_WIDE, false),
+    BOUNDED(UI_STR_BAGL_BIP39_LENGTH_BACK, BOUND_WIDE, false),
+    BOUNDED(UI_STR_BAGL_SSKR_START_TITLE_L1_NANOS, BOUND_WIDE, false),
+    BOUNDED(UI_STR_BAGL_SSKR_START_TITLE_L2_NANOS, BOUND_WIDE, false),
+    BOUNDED(UI_STR_BAGL_SSKR_START_TITLE_L1, BOUND_WIDE, false),
+    BOUNDED(UI_STR_BAGL_SSKR_START_TITLE_L2, BOUND_WIDE, false),
+    BOUNDED(UI_STR_BAGL_SSKR_START_TITLE_L3, BOUND_WIDE, false),
+    BOUNDED(UI_STR_BAGL_NANOS_WORD_HEADER, BOUND_WIDE, false),
+    BOUNDED(UI_STR_BAGL_NANOS_WORD_HEADER_LOWER, BOUND_TIGHT, true),
+    BOUNDED(UI_STR_BAGL_NANOS_ENTER_SSKR_WORD, BOUND_WIDE, false),
+    BOUNDED(UI_STR_BAGL_NANOS_RESTART_FROM, BOUND_TIGHT, true),
+    BOUNDED(UI_STR_BAGL_NANOS_WORD_INDEX_PREFIX, BOUND_TIGHT, true),
+    BOUNDED(UI_STR_BAGL_NANOX_INTRO_L1, BOUND_WIDE, false),
+    BOUNDED(UI_STR_BAGL_NANOX_INTRO_L2, BOUND_WIDE, false),
+    BOUNDED(UI_STR_BAGL_NANOX_INTRO_L3, BOUND_WIDE, false),
+    BOUNDED(UI_STR_BAGL_NANOX_CLEAR_WORD, BOUND_WIDE, true),
+    BOUNDED(UI_STR_BAGL_NANOX_ENTER_BIP39_WORD, BOUND_KEYBOARD_TITLE, false),
+    BOUNDED(UI_STR_BAGL_NANOX_ENTER_SSKR_WORD, BOUND_KEYBOARD_TITLE, false),
+    BOUNDED(UI_STR_BAGL_NANOX_OF_WORD, BOUND_WIDE, false),
+    BOUNDED(UI_STR_BAGL_NANOX_SELECT_WORD, BOUND_WIDE, false),
+    BOUNDED(UI_STR_BAGL_ENTER_LABEL, BOUND_WIDE, false),
+    BOUNDED(UI_STR_BAGL_RETURN_TO_MENU, BOUND_WIDE, true),
+    BOUNDED(UI_STR_BAGL_INVALID_ADVICE_L1, BOUND_WIDE, false),
+    BOUNDED(UI_STR_BAGL_INVALID_ADVICE_L2, BOUND_WIDE, false),
+    /* BIP39_INVALID_TITLE_L1 ("BIP39 Recovery") -- see the file comment above. */
+    BOUNDED(UI_STR_BAGL_BIP39_INVALID_TITLE_L2, BOUND_TIGHT, true),
+    BOUNDED(UI_STR_BAGL_BIP39_REENTER_PHRASE, BOUND_WIDE, true),
+    BOUNDED(UI_STR_BAGL_BIP39_NOMATCH_TITLE_L2, BOUND_TIGHT, true),
+    BOUNDED(UI_STR_BAGL_BIP39_MATCH_TITLE_L2, BOUND_TIGHT, true),
+    BOUNDED(UI_STR_BAGL_SSKR_INVALID_TITLE_L1, BOUND_TIGHT, true),
+    BOUNDED(UI_STR_BAGL_SSKR_INVALID_TITLE_L2, BOUND_TIGHT, true),
+    BOUNDED(UI_STR_BAGL_SSKR_REENTER_SHARES, BOUND_WIDE, true),
+    BOUNDED(UI_STR_BAGL_SSKR_NOMATCH_TITLE_L1, BOUND_TIGHT, true),
+    BOUNDED(UI_STR_BAGL_SSKR_NOMATCH_TITLE_L2, BOUND_TIGHT, true),
+    BOUNDED(UI_STR_BAGL_SSKR_MATCH_TITLE_L1, BOUND_TIGHT, true),
+    BOUNDED(UI_STR_BAGL_SSKR_MATCH_TITLE_L2, BOUND_TIGHT, true),
+    BOUNDED(UI_STR_BAGL_GENERATE_SSKR_L1, BOUND_TIGHT, true),
+    BOUNDED(UI_STR_BAGL_GENERATE_SSKR_L2, BOUND_TIGHT, true),
+    BOUNDED(UI_STR_BAGL_RECOVER_BIP39_L1, BOUND_TIGHT, true),
+    BOUNDED(UI_STR_BAGL_RECOVER_BIP39_L2, BOUND_TIGHT, true),
+    BOUNDED(UI_STR_BAGL_SSKR_NUMSHARES_TITLE_L1, BOUND_WIDE, false),
+    BOUNDED(UI_STR_BAGL_SSKR_NUMSHARES_TITLE_L2, BOUND_WIDE, false),
+    BOUNDED(UI_STR_BAGL_SSKR_THRESHOLD_TITLE_L1, BOUND_WIDE, false),
+    BOUNDED(UI_STR_BAGL_SSKR_THRESHOLD_TITLE_L2, BOUND_WIDE, false),
+    BOUNDED(UI_STR_BAGL_SSKR_ONE_OF_M_WARN_L1, BOUND_TIGHT, false),
+    BOUNDED(UI_STR_BAGL_SSKR_ONE_OF_M_WARN_L2, BOUND_TIGHT, false),
+    BOUNDED(UI_STR_BAGL_SSKR_ONE_OF_M_NOT_L1, BOUND_TIGHT, true),
+    BOUNDED(UI_STR_BAGL_SSKR_ONE_OF_M_NOT_L2, BOUND_TIGHT, true),
+};
+
+/*
+ * The BOUNDED table above holds unformatted templates: several contain "%d",
+ * substituted at runtime with an onboarding step, share, or word index. Every
+ * one of those is bounded well under 100 on every BAGL target (word counts up
+ * to 46, share indices up to 16), so replacing each "%d" with "99" measures
+ * the worst case those templates can actually reach.
+ */
+static void expand_worst_case(const char *template, char *out, size_t out_size) {
+    size_t o = 0;
+    for (size_t i = 0; template[i] != '\0' && o + 1 < out_size; i++) {
+        if (template[i] == '%' && template[i + 1] == 'd') {
+            if (o + 2 < out_size) {
+                out[o++] = '9';
+                out[o++] = '9';
+            }
+            i++;
+        } else {
+            out[o++] = template[i];
+        }
+    }
+    out[o] = '\0';
+}
+
+static unsigned int text_width_px(const char *text, bool bold) {
+    const unsigned char *table = bold ? k_nanos_char_width_bold : k_nanos_char_width_regular;
+    unsigned int width = 0;
+    for (size_t i = 0; text[i] != '\0'; i++) {
+        unsigned char c = (unsigned char) text[i];
+        assert_true(c >= NANOS_FIRST_CHAR && c <= NANOS_LAST_CHAR);
+        width += table[c - NANOS_FIRST_CHAR];
+    }
+    return width;
+}
+
+static void test_every_string_is_non_empty(void **state) {
+    (void) state;
+
+    for (size_t i = 0; i < sizeof(k_all_strings) / sizeof(k_all_strings[0]); i++) {
+        if (strlen(k_all_strings[i].value) == 0) {
+            fail_msg("%s is empty", k_all_strings[i].name);
+        }
+    }
+}
+
+static void test_nano_fixed_layout_strings_fit_their_budget(void **state) {
+    (void) state;
+
+    for (size_t i = 0; i < sizeof(k_nano_bounded_strings) / sizeof(k_nano_bounded_strings[0]);
+        i++) {
+        char expanded[128];
+        expand_worst_case(k_nano_bounded_strings[i].value, expanded, sizeof(expanded));
+
+        unsigned int width = text_width_px(expanded, k_nano_bounded_strings[i].bold);
+        if (width > k_nano_bounded_strings[i].budget_px) {
+            fail_msg("%s (\"%s\") is %upx wide, over its %upx budget", k_nano_bounded_strings[i].name,
+                     expanded, width, k_nano_bounded_strings[i].budget_px);
+        }
+    }
+}
+
+int main(void) {
+    const struct CMUnitTest tests[] = {
+        cmocka_unit_test(test_every_string_is_non_empty),
+        cmocka_unit_test(test_nano_fixed_layout_strings_fit_their_budget),
+    };
+    return cmocka_run_group_tests(tests, NULL, NULL);
+}


### PR DESCRIPTION
## Why

BAGL (the three Nano targets) and NBGL (the touch targets) each carry the application's screen text separately, and the two have already drifted apart — found by comparing the two stacks line by line, not by design:

- on a malformed recovery phrase, BAGL's invalid-flow steps advise `"Check length," / "order and spelling"`; NBGL's equivalent screen gives no advice at all (its invalid-result body text has no third line);
- BAGL has two distinct flows and titles for "phrase doesn't match the device seed" vs. "phrase matches" (`ux_bip39_match_flow` / `ux_bip39_nomatch_flow`, titled `"BIP39 Phrase" / "is correct"` vs. `"BIP39 Phrase" / "doesn't match"`); NBGL shows the *same* title, `"Valid Secret\nRecovery Phrase"`, for both.

Neither is a deliberate variant — nothing tied the two stacks together, so nobody saw them diverge. Eight further interface-refactor PRs are planned behind this one; without a single source for text, each becomes two implementations at risk of a ninth, silent variant.

## What this PR does — and does not do

**Moves every user-visible string into `src/common/ui_strings.h`. Changes no wording.** Not one word moves, no screen looks different, and the PR proves it rather than asserting it:

- all six device targets (`nanos`, `nanox`, `nanos+`, `stax`, `flex`, `apex_p`) were built before and after this change; `text`/`data`/`bss` are **byte-identical on every target** (`nanos`: 41224/0/3712, unchanged);
- `strings` was extracted from every `.elf`, sorted, and diffed against a build from the base commit — **empty diff on all six targets**.

Some of the current wording is bad — two verdicts share a title, `Done` doubles as a refusal, a screen tells the user to check a length they never typed. This PR does not touch any of that; fixing it is later, separate work, and mixing it in here would make "nothing changed" unprovable.

## How the two stacks' text cohabits

NBGL carries a full sentence per screen; BAGL splits the same idea across 2-4 lines of a `UX_STEP`, often in different words than NBGL uses for the same concept. A single canonical string and a splitting algorithm would erase that divergence rather than surface it, so the header does the opposite: **where wording is already shared and identical, one macro serves every call site** (`Quit`, `Version`, `SSKR Share #%d`, `BIP39 Phrase`, `12/18/24 words`); **where the concept is shared but the wording already differs — including the two divergences above — both forms are declared next to each other under one comment**, so a future edit to one is not made without seeing the other.

## Why `#define`, and what it costs

`nanos` has the least flash of the six targets, and a `static const char * const` table would create a separate copy of every string per translation unit — unacceptable there. Two real options: `#define` (cost is whatever the literal itself costs; the linker merges identical literals) or `extern const char[]` (enumerable by a test, but a pointer and a relocation per entry on every target it links into). This PR uses `#define`, and the six-target size comparison above is the measurement that justifies it: moving ~108 strings behind macros changed nothing in any target's `text`/`data`/`bss`.

The one thing a table buys — enumerating every string in a test — is recovered without that cost: `tests/unit/tests/ui_strings.c` declares its own table, `{ "NAME", NAME }` per macro (the macro's actual value, not a retyped copy), so nothing in the header needs to be enumerable from device code.

## The test

Neither `src/nbgl/ui.c` nor anything under `src/bagl/` is compiled into any unit target, so `ui_strings.h` — holding only constants — is the first piece of interface text this repository can test outside Speculos. The new test asserts two things:

1. every macro is non-empty;
2. every BAGL fragment destined for a **fixed, non-wrapping** Nano layout (`NN`/`NNN`/`PB`/`PBB`/`PNN`/`BN` — never `BNNN_PAGING`, which the dynamic word/share buffers use and which auto-wraps) fits the real pixel budget of that layout. The budget and per-character widths are read from the SDK itself (`lib_ux/src/ux_layout_paging_compute.c`'s character-width table, `lib_ux/src/ux_layout_{bb,pb,pbb,pnn,nnn}.c`'s box geometry), not guessed — a string sized for a touch screen silently clips on a 128x32/64 Nano at runtime, and this is the only thing in the repository that would catch it before a device does.

Two existing strings fail that check and are deliberately left unasserted, each flagged in a comment rather than silently passed: `"recovery phrase"` (both BAGL idle-menu entries, 93px against an 87px budget) and `"BIP39 Recovery"` (90px against the same budget). Both predate this header — this PR does not touch either word — and correcting wording is out of scope here.

## Verification

- **Six targets compiled**, `nanos` built by hand (CI's matrix does not build it — removed deliberately in an earlier commit): sizes identical before/after on all six, `strings` diff empty on all six.
- **Six unit-test-matrix configurations** (ASan, UBSan, `-O2`, `-Os`, `-fsigned-char`, `-funsigned-char`): 80/80 passing on each (79/79 before this PR's test was added).
- **Functional tests under Speculos, both stacks**: `nanox` (BAGL) 8 passed / 9 skipped; `stax` (NBGL) 11 passed / 6 skipped. Skips are pre-existing device gating (`skip("Skipping test for Nano S+ device")`, `skip("Two-button devices only")`, etc.), unrelated to this change.
- `clang-format --dry-run -Werror` clean on every touched file under `src/`.
- **Not covered by this repository's CI on a fork PR**: functional-test workflows do not run on pull requests from forks (read-only workflow permissions there), so the Speculos runs above are local and are the only evidence for this PR; noting this as a limitation, not a defect.
