### PR TITLE
fix: name the values each entry screen accepts, and return a refusal to the field

### DIFF
--- a/src/common/ui_strings.h
+++ b/src/common/ui_strings.h
@@ -298,12 +298,33 @@
 /*
  * SSKR share count / threshold selection
  */
+/*
+ * The 16 spelled out in these two is SSS_MAX_SHARE_COUNT on every target that
+ * links NBGL. It stays a literal here -- nothing composed at runtime, since
+ * nothing about it varies -- and src/nbgl/ui.c static-asserts that the bound
+ * it applies is still that number, so the two cannot drift apart in silence.
+ */
 #define UI_STR_NBGL_SSKR_NUMSHARES_TITLE       "Enter number of SSKR shares\nto generate (1 - 16)"
 #define UI_STR_NBGL_SSKR_NUMSHARES_RANGE_ERROR "Number of SSKR shares must be between 1 and 16"
 #define UI_STR_BAGL_SSKR_NUMSHARES_TITLE_L1    "Select number"
 #define UI_STR_BAGL_SSKR_NUMSHARES_TITLE_L2    "of shares"
 
-#define UI_STR_NBGL_SSKR_THRESHOLD_TITLE      "Enter threshold value"
+/*
+ * Neither bound of the threshold keypad is a constant, so the title is a
+ * format composed at display time rather than a literal. The upper `%d` is
+ * the share count the user entered on the previous screen. The lower one is
+ * 2 as soon as there is more than one share: a threshold of 1 over several
+ * shares is the 1-of-m case refused below, so a title reading `(1 - N)` there
+ * would promise a value the next screen rejects. Both are the same calls the
+ * validator makes, so the screen cannot announce a range the code does not
+ * accept.
+ *
+ * Each `%d` here stands for a value of at most two digits, and `%d` is itself
+ * two characters wide, so the composed title is never longer than this format
+ * literal. src/nbgl/ui.c sizes its title buffer on that, and static-asserts
+ * the two-digit half of it against the constants themselves.
+ */
+#define UI_STR_NBGL_SSKR_THRESHOLD_TITLE      "Enter threshold value (%d - %d)"
 #define UI_STR_NBGL_SSKR_THRESHOLD_ZERO_ERROR "Threshold value cannot be 0"
 #define UI_STR_NBGL_SSKR_THRESHOLD_RANGE_ERROR \
     "Threshold value cannot be greater than number of shares"
@@ -327,8 +348,27 @@
 #define UI_STR_NBGL_BIP85_BASE64_HEADER "Base64 Password (Index #%d)"
 #define UI_STR_NBGL_BIP85_BASE85_HEADER "Base85 Password (Index #%d)"
 
-#define UI_STR_NBGL_BIP85_INDEX_TITLE       "Enter index"
+/*
+ * The bound in the title is the keypad's own digit cap
+ * (BIP85_INDEX_MAX_NUMBER_LENGTH, seven digits), which is what the person
+ * typing can actually reach -- the same number, and for the same reason, as
+ * the error message beside it. See the comment on bip85_index_validate() in
+ * src/nbgl/ui.c for why the 31-bit derivation bound it also checks is a
+ * different number on purpose.
+ */
+#define UI_STR_NBGL_BIP85_INDEX_TITLE       "Enter index (0 - 9,999,999)"
 #define UI_STR_NBGL_BIP85_INDEX_RANGE_ERROR "BIP85 index must be between 0 and 9,999,999"
 
-#define UI_STR_NBGL_BIP85_PWD_LENGTH_TITLE       "Enter password length"
+/*
+ * Both bounds depend on which password application was chosen, so the title
+ * is composed at display time from the same two values the validator applies,
+ * exactly as the error message beside it already was. Same two-digit argument
+ * for the buffer sizing as UI_STR_NBGL_SSKR_THRESHOLD_TITLE above.
+ *
+ * The line break is placed rather than left to the layout: without it the
+ * keypad title wraps inside the range itself, and all three touch devices
+ * drew "(20 - " on one line and "86)" on the next. A bound split across a
+ * line break is the one thing this title exists not to do.
+ */
+#define UI_STR_NBGL_BIP85_PWD_LENGTH_TITLE       "Enter password length\n(%d - %d)"
 #define UI_STR_NBGL_BIP85_PWD_LENGTH_RANGE_ERROR "BIP85 password length must be between %d and %d"

--- a/src/nbgl/ui.c
+++ b/src/nbgl/ui.c
@@ -90,6 +90,7 @@ static void display_sskr_select_numshares_page(void);
 static void display_sskr_select_threshold_page(void);
 static void display_bip85_select_app_page(void);
 static void display_bip85_select_index_page(void);
+static void display_bip85_select_password_length_page(void);
 
 /*
  * Utils
@@ -699,8 +700,11 @@ static void sskr_sharenum_validate(const uint8_t* sharenumentry,
     if (sskr_sharenum_get() > 0 && sskr_sharenum_get() <= SSS_MAX_SHARE_COUNT) {
         display_sskr_select_threshold_page();
     } else {
+        // Back to this keypad, not to the "Generate SSKR Phrase?" offer that
+        // opens the flow: the only thing wrong is the number that was just
+        // typed, and it is the only thing worth asking for again.
         nbgl_useCaseStatus(UI_STR_NBGL_SSKR_NUMSHARES_RANGE_ERROR, false,
-                           display_select_generate_sskr_page);
+                           display_sskr_select_numshares_page);
     }
 }
 
@@ -795,12 +799,20 @@ static void sskr_threshold_validate(const uint8_t* thresholdentry,
 
     PRINTF("Threshold value entered is '%d'\n", sskr_threshold_get());
 
+    // All three send the user back to this same keypad rather than to the
+    // "Generate SSKR Phrase?" offer at the head of the flow. The share count
+    // entered on the previous screen is valid, was accepted, and is not what
+    // is being corrected -- returning to the offer threw it away and made it
+    // be typed again before the threshold could be fixed. Nothing on this path
+    // resets it: reset_globals() and sskr_shares_reset() are reached only from
+    // display_home_page(), review_done() and the check flow, none of which any
+    // of these three branches goes through.
     if (sskr_threshold_get() < 1) {
         nbgl_useCaseStatus(UI_STR_NBGL_SSKR_THRESHOLD_ZERO_ERROR, false,
-                           display_select_generate_sskr_page);
+                           display_sskr_select_threshold_page);
     } else if (sskr_threshold_get() > sskr_sharenum_get()) {
         nbgl_useCaseStatus(UI_STR_NBGL_SSKR_THRESHOLD_RANGE_ERROR, false,
-                           display_select_generate_sskr_page);
+                           display_sskr_select_threshold_page);
     } else if (sskr_threshold_get() < sskr_threshold_min()) {
         // Below the floor is 1-of-m, and only that: the branch above has
         // already taken everything under 1, and sskr_threshold_min() is 1
@@ -808,7 +820,7 @@ static void sskr_threshold_validate(const uint8_t* thresholdentry,
         // rather than against `== 1 && sharenum > 1` so that the value the
         // title announces and the value this rejects are the same call.
         nbgl_useCaseStatus(UI_STR_NBGL_SSKR_THRESHOLD_ONE_OF_M_ERROR, false,
-                           display_select_generate_sskr_page);
+                           display_sskr_select_threshold_page);
     } else {
         display_sskr_shares();
     }
@@ -913,8 +925,14 @@ static void bip85_index_validate(const uint8_t* indexentry, uint8_t length) {
                 break;
         }
     } else {
+        // Back to the index keypad. The screen this used to return to,
+        // display_bip39_select_phrase_length_page(), is neither the field at
+        // fault nor even on the password branches of this flow. As the comment
+        // above says, this branch is unreachable from the keypad; the callback
+        // is corrected so that the guard, if it ever does fire, lands where
+        // the other five now do.
         nbgl_useCaseStatus(UI_STR_NBGL_BIP85_INDEX_RANGE_ERROR, false,
-                           display_bip39_select_phrase_length_page);
+                           display_bip85_select_index_page);
     }
 }
 
@@ -995,8 +1013,11 @@ static void bip85_password_length_validate(const uint8_t* lengthentry,
         snprintf(message, sizeof(message),
                  UI_STR_NBGL_BIP85_PWD_LENGTH_RANGE_ERROR, password_length_min,
                  password_length_max);
+        // Back to this keypad rather than to the application menu: the chosen
+        // application is what decides the bounds, it was not the mistake, and
+        // re-choosing it was the price of correcting a length.
         nbgl_useCaseStatus((const char*)message, false,
-                           display_bip85_select_app_page);
+                           display_bip85_select_password_length_page);
     }
 }
 

--- a/src/nbgl/ui.c
+++ b/src/nbgl/ui.c
@@ -31,6 +31,7 @@
 #include <nbgl_use_case.h>
 
 #include "../common/bip39/common_bip39.h"
+#include "../common/bip85/common_bip85.h"
 #include "../common/sskr/common_sskr.h"
 #include "../common/ui_strings.h"
 #include "../ui.h"
@@ -47,6 +48,36 @@ static nbgl_layout_t* layout = 0;
 
 static char headerText[HEADER_SIZE] = {0};
 static char reviewText[(SSKR_SHARES_MAX_LENGTH / 16) + 1] = {0};
+
+/*
+ * Two of the four keypads name a bound that is only known at display time --
+ * the threshold's maximum is the share count just entered, the password
+ * length's pair depends on which application was chosen -- so their titles are
+ * composed rather than declared.
+ *
+ * This buffer cannot live on the stack of the function that fills it.
+ * nbgl_layoutAddKeypadContent() stores the pointer it is handed
+ * (`textArea->text = title`, lib_nbgl/src/nbgl_layout_keypad.c) and the title
+ * area is redrawn while the keypad is up, so the text has to outlive the call.
+ *
+ * The size is taken from the formats themselves rather than counted by hand:
+ * every `%d` below stands for a value of at most two digits, and `%d` is
+ * itself two characters wide, so a composed title is never longer than its own
+ * format literal. The two-digit half of that premise is not assumed: the
+ * _Static_asserts further down check it against the constants that supply the
+ * values, and tests/unit/tests/ui_strings.c checks that each format still
+ * takes exactly the arguments its call site passes.
+ *
+ * One buffer, not two: the SSKR generation flow and the BIP85 password flow
+ * are reached from different branches of the tool menu and neither keypad is
+ * on screen while the other is.
+ */
+#define KEYPAD_TITLE_SIZE                               \
+    (sizeof(UI_STR_NBGL_SSKR_THRESHOLD_TITLE) >         \
+             sizeof(UI_STR_NBGL_BIP85_PWD_LENGTH_TITLE) \
+         ? sizeof(UI_STR_NBGL_SSKR_THRESHOLD_TITLE)     \
+         : sizeof(UI_STR_NBGL_BIP85_PWD_LENGTH_TITLE))
+static char keypadTitle[KEYPAD_TITLE_SIZE] = {0};
 
 unsigned int tool_type;
 
@@ -72,6 +103,11 @@ static void reset_globals() {
     memzero(buttonTexts, sizeof(buttonTexts[0]) * NB_MAX_SUGGESTION_BUTTONS);
     memzero(headerText, sizeof(headerText));
     memzero(reviewText, sizeof(reviewText));
+    // No secret in it -- a share count and a length range, never a word or a
+    // share. Cleared anyway because headerText, one line up, carries the same
+    // class of thing ("SSKR share 2 of 3") and is cleared: leaving one of the
+    // two behind would make the rule here look like a judgement call.
+    memzero(keypadTitle, sizeof(keypadTitle));
 }
 
 static void on_quit(void) { os_sched_exit(-1); }
@@ -623,6 +659,31 @@ enum __attribute__((packed)) sskr_gen {
     SSKR_GEN_BACK_BUTTON_TOKEN = FIRST_USER_TOKEN
 };
 
+// UI_STR_NBGL_SSKR_NUMSHARES_TITLE and its error message both spell out 16 as
+// the number of shares this screen accepts. The bound the validator below
+// applies is SSS_MAX_SHARE_COUNT, which is 16 on every target that links this
+// file -- it is 10 only under TARGET_NANOS, which is BAGL and never compiles
+// it. Asserting the two agree is what stops a label from promising a share
+// count the Shamir layer would refuse.
+_Static_assert(SSS_MAX_SHARE_COUNT == 16,
+               "the SSKR share-count screen spells its upper bound out in "
+               "UI_STR_NBGL_SSKR_NUMSHARES_TITLE and its error message; "
+               "both have to be changed with SSS_MAX_SHARE_COUNT");
+
+// The threshold title composes SSS_MAX_SHARE_COUNT into a "%d" whose width the
+// keypad title buffer is sized on. Two digits is what that sizing assumes.
+_Static_assert(SSS_MAX_SHARE_COUNT <= 99,
+               "the composed threshold title assumes a two-digit share count");
+
+// The smallest threshold this screen accepts, and the one its title announces.
+// A threshold of 1 over more than one share means any single share rebuilds
+// the secret; sskr_threshold_validate() refuses that, so the floor is 2 as
+// soon as there is more than one share. Read by the title and by the check,
+// which is what stops the screen promising a value the check would reject.
+static uint8_t sskr_threshold_min(void) {
+    return sskr_sharenum_get() > 1 ? 2 : 1;
+}
+
 static void sskr_sharenum_validate(const uint8_t* sharenumentry,
                                    uint8_t length) {
     // Code to validate the entered shares number
@@ -635,7 +696,7 @@ static void sskr_sharenum_validate(const uint8_t* sharenumentry,
 
     PRINTF("Number of shares entered is '%d'\n", sskr_sharenum_get());
 
-    if (sskr_sharenum_get() > 0 && sskr_sharenum_get() <= 16) {
+    if (sskr_sharenum_get() > 0 && sskr_sharenum_get() <= SSS_MAX_SHARE_COUNT) {
         display_sskr_select_threshold_page();
     } else {
         nbgl_useCaseStatus(UI_STR_NBGL_SSKR_NUMSHARES_RANGE_ERROR, false,
@@ -740,7 +801,12 @@ static void sskr_threshold_validate(const uint8_t* thresholdentry,
     } else if (sskr_threshold_get() > sskr_sharenum_get()) {
         nbgl_useCaseStatus(UI_STR_NBGL_SSKR_THRESHOLD_RANGE_ERROR, false,
                            display_select_generate_sskr_page);
-    } else if (sskr_threshold_get() == 1 && sskr_sharenum_get() > 1) {
+    } else if (sskr_threshold_get() < sskr_threshold_min()) {
+        // Below the floor is 1-of-m, and only that: the branch above has
+        // already taken everything under 1, and sskr_threshold_min() is 1
+        // whenever a threshold of 1 is legitimate. Written against the floor
+        // rather than against `== 1 && sharenum > 1` so that the value the
+        // title announces and the value this rejects are the same call.
         nbgl_useCaseStatus(UI_STR_NBGL_SSKR_THRESHOLD_ONE_OF_M_ERROR, false,
                            display_select_generate_sskr_page);
     } else {
@@ -749,10 +815,26 @@ static void sskr_threshold_validate(const uint8_t* thresholdentry,
 }
 
 void display_sskr_select_threshold_page() {
+    // Neither bound is a constant, so the title is composed here from the two
+    // calls sskr_threshold_validate() makes above. The upper bound is the
+    // share count entered on the previous screen; the lower one is 2 as soon
+    // as there is more than one share, because a threshold of 1 over several
+    // shares is 1-of-m and is refused -- announcing (1 - N) there would have
+    // promised a value the next screen rejects.
+    //
+    // snprintf()'s return value is not read: the buffer is sized on the
+    // format itself and the _Static_asserts above bound every argument to two
+    // digits, so there is nothing for a check to find. (It would find it if
+    // there were: on the three SDKs that compile this file snprintf() returns
+    // the length it would have needed. The nanos SDK returns 0 from every exit
+    // and documents it, but never compiles this file.)
+    snprintf(keypadTitle, sizeof(keypadTitle), UI_STR_NBGL_SSKR_THRESHOLD_TITLE,
+             sskr_threshold_min(), sskr_sharenum_get());
+
     // Draw the keypad
-    nbgl_useCaseKeypad(
-        UI_STR_NBGL_SSKR_THRESHOLD_TITLE, 1, SSKR_MAX_NUMBER_LENGTH, false,
-        false, sskr_threshold_validate, display_sskr_select_numshares_page);
+    nbgl_useCaseKeypad(keypadTitle, 1, SSKR_MAX_NUMBER_LENGTH, false, false,
+                       sskr_threshold_validate,
+                       display_sskr_select_numshares_page);
 }
 
 enum __attribute__((packed)) select_bip85_app {
@@ -843,6 +925,41 @@ void display_bip85_select_index_page() {
                        bip85_index_validate, display_bip85_select_app_page);
 }
 
+// The password lengths this screen accepts, per application. Same values as
+// bip85_pwd_base64_len_valid() and bip85_pwd_base85_len_valid()
+// (src/common/bip85/seed_bip85.c), which guard the derivation itself; these
+// are the screen's own copy, named here so that the title announcing them, the
+// branch applying them and the error message quoting them all read one pair of
+// numbers rather than three sets of literals.
+#define BIP85_PWD_BASE64_LENGTH_MIN 20
+#define BIP85_PWD_BASE64_LENGTH_MAX (BASE64_ENCODE_LENGTH - 2)
+#define BIP85_PWD_BASE85_LENGTH_MIN 10
+#define BIP85_PWD_BASE85_LENGTH_MAX BASE85_ENCODE_LENGTH
+
+// Same two-digit assumption the keypad title buffer is sized on. All four,
+// not just the maxima: the title composes the minimum through a "%d" of the
+// same width, and a three-digit minimum would truncate the title silently
+// while leaving an assertion on the maxima alone perfectly happy.
+_Static_assert(BIP85_PWD_BASE64_LENGTH_MIN <= 99 &&
+                   BIP85_PWD_BASE64_LENGTH_MAX <= 99 &&
+                   BIP85_PWD_BASE85_LENGTH_MIN <= 99 &&
+                   BIP85_PWD_BASE85_LENGTH_MAX <= 99,
+               "the composed password-length title assumes two-digit bounds");
+
+static void bip85_password_length_bounds(uint8_t* min, uint8_t* max) {
+    // Base85 is the else rather than a third case because this screen is only
+    // ever reached from the two password buttons or from its own refusal --
+    // bip85_type_get() is BIP85_APP_PWD_BASE64 or BIP85_APP_PWD_BASE85 here,
+    // never BIP85_APP_BIP39, which has no length to choose and no keypad.
+    if (bip85_type_get() == BIP85_APP_PWD_BASE64) {
+        *min = BIP85_PWD_BASE64_LENGTH_MIN;
+        *max = BIP85_PWD_BASE64_LENGTH_MAX;
+    } else {
+        *min = BIP85_PWD_BASE85_LENGTH_MIN;
+        *max = BIP85_PWD_BASE85_LENGTH_MAX;
+    }
+}
+
 static void bip85_password_length_validate(const uint8_t* lengthentry,
                                            uint8_t length) {
     // Code to validate BIP85 index
@@ -854,11 +971,22 @@ static void bip85_password_length_validate(const uint8_t* lengthentry,
     }
     PRINTF("BIP85 password length entered is '%d'\n", bip85_length_get());
 
-    uint8_t password_length_min =
-        bip85_type_get() == BIP85_APP_PWD_BASE64 ? 20 : 10;
-    uint8_t password_length_max =
-        bip85_type_get() == BIP85_APP_PWD_BASE64 ? 86 : 80;
-    char message[50] = {0};
+    uint8_t password_length_min;
+    uint8_t password_length_max;
+    bip85_password_length_bounds(&password_length_min, &password_length_max);
+
+    // static for the same reason keypadTitle is, and it is the same mistake:
+    // nbgl_useCaseStatus() keeps the pointer rather than the text
+    // (`info.centeredInfo.text1 = message`, lib_nbgl/src/nbgl_use_case.c),
+    // nbgl_layoutAddCenteredInfo() stores it in the text area, and the status
+    // page stays up for three seconds after this function has returned. The
+    // first draw is synchronous and reads a live frame; any redraw after that
+    // -- nbgl_screenRedraw() walks the whole object tree, and the UX layer
+    // calls it on a system redisplay -- would read a stack frame the event
+    // loop has since reused. This is the only status message in the file that
+    // is composed rather than a literal, so it is the only one that had the
+    // problem.
+    static char message[50] = {0};
 
     if ((bip85_length_get() >= password_length_min) &&
         (bip85_length_get() <= password_length_max)) {
@@ -873,8 +1001,18 @@ static void bip85_password_length_validate(const uint8_t* lengthentry,
 }
 
 void display_bip85_select_password_length_page() {
+    // Both bounds depend on the application chosen on the previous screen, so
+    // the title is composed here from the same helper the validator above
+    // reads. Return value unused, as on the threshold title.
+    uint8_t password_length_min;
+    uint8_t password_length_max;
+    bip85_password_length_bounds(&password_length_min, &password_length_max);
+    snprintf(keypadTitle, sizeof(keypadTitle),
+             UI_STR_NBGL_BIP85_PWD_LENGTH_TITLE, password_length_min,
+             password_length_max);
+
     // Draw the keypad
-    nbgl_useCaseKeypad(UI_STR_NBGL_BIP85_PWD_LENGTH_TITLE, 1, 2, false, false,
+    nbgl_useCaseKeypad(keypadTitle, 1, 2, false, false,
                        bip85_password_length_validate,
                        display_bip85_select_app_page);
 }

--- a/tests/functional/test_bip85_pwd_base64.py
+++ b/tests/functional/test_bip85_pwd_base64.py
@@ -32,6 +32,13 @@ def all_eink_bip85_pwd_base64(backend, device):
     # is 10 to 80; the two are not interchangeable, which is why the title is
     # composed per application rather than declared once.
     backend.wait_for_text_on_screen(r"\(20 - 86\)", 1)
+    # A length outside that range comes back to this keypad, not to the
+    # application menu: the application chosen is what decides the bounds and
+    # was never the mistake.
+    keypad.write("5")
+    keypad.enter()
+    backend.wait_for_text_on_screen("BIP85 password", 5)
+    backend.wait_for_text_on_screen("Enter password length", 10)
     keypad.write("2")
     keypad.write("1")
     keypad.enter()

--- a/tests/functional/test_bip85_pwd_base64.py
+++ b/tests/functional/test_bip85_pwd_base64.py
@@ -27,10 +27,16 @@ def all_eink_bip85_pwd_base64(backend, device):
     backend.wait_for_text_on_screen("Which BIP85", 5)
     genericbuttons.choose(2)
     backend.wait_for_text_on_screen("Enter password length", 5)
+    # The keypad names the range this application accepts, on its own line --
+    # escaped because wait_for_text_on_screen() matches with re.match(). Base85
+    # is 10 to 80; the two are not interchangeable, which is why the title is
+    # composed per application rather than declared once.
+    backend.wait_for_text_on_screen(r"\(20 - 86\)", 1)
     keypad.write("2")
     keypad.write("1")
     keypad.enter()
     backend.wait_for_text_on_screen("Enter index", 5)
+    backend.wait_for_text_on_screen(r"Enter index \(0 - 9,999,999\)", 1)
     keypad.write("0")
     keypad.enter()
     backend.wait_for_text_on_screen("Base64 Password", 5)

--- a/tests/functional/test_bip85_pwd_base85.py
+++ b/tests/functional/test_bip85_pwd_base85.py
@@ -27,6 +27,10 @@ def all_eink_bip85_pwd_base85(backend, device):
     backend.wait_for_text_on_screen("Which BIP85", 5)
     genericbuttons.choose(3)
     backend.wait_for_text_on_screen("Enter password length", 5)
+    # Base85 accepts 10 to 80, where Base64 accepts 20 to 86. Asserting the
+    # range here and in test_bip85_pwd_base64.py is what keeps the composed
+    # title honest per application rather than merely present.
+    backend.wait_for_text_on_screen(r"\(10 - 80\)", 1)
     keypad.write("1")
     keypad.write("2")
     keypad.enter()

--- a/tests/functional/test_sskr_unsupported_values.py
+++ b/tests/functional/test_sskr_unsupported_values.py
@@ -8,6 +8,17 @@ from ragger.firmware.touch.layouts import CenteredFooter, LetterOnlyKeyboard, Su
 from keypad import Keypad
 from genericlayout import GenericLayout
 
+# The threshold keypad names the values it accepts. Its upper bound is the
+# share count entered on the screen before it, so this string is also the
+# evidence that the count survived a refusal. Its lower bound is 2, not 1:
+# a threshold of 1 over three shares is the 1-of-m case the app refuses, and
+# a title reading (1 - 3) would be promising it.
+#
+# Escaped, because wait_for_text_on_screen() passes its argument to re.match():
+# unescaped parentheses are a group, and "(2 - 3)" would match a screen reading
+# "Enter threshold value 2 - 3", which is not what the device draws.
+THRESHOLD_TITLE_3_SHARES = r"Enter threshold value \(2 - 3\)"
+
 @fixture(scope='session')
 def set_seed():
     # Seed taken from https://github.com/BlockchainCommons/crypto-commons/blob/master/Docs/sskr-test-vector.md#128-bit-seed
@@ -39,70 +50,57 @@ def all_eink_unsupported_values(backend, device):
     backend.wait_for_text_on_screen("Generate SSKR", 5)
     choice.confirm()
 
-    # Test invalid sharenum values
+    # An out-of-range share count is refused and asked for again, on the keypad
+    # that asked for it. Each refusal is waited for on its own: the status page
+    # does not carry the keypad title, so reaching the title afterwards is a
+    # screen change and not the screen we were already on.
     backend.wait_for_text_on_screen("Enter number of SSKR shares", 5)
+    # The range on its own line, matched whole. This title carries a
+    # hand-placed line break for the same reason the password one does, and a
+    # layout that wrapped inside the range would draw "to generate (1 - " and
+    # "16)" as two events, so this assertion is what keeps the break where it
+    # was put. The other three ranges are matched whole for the same reason.
+    backend.wait_for_text_on_screen(r"to generate \(1 - 16\)", 1)
     keypad.write("0")
     keypad.enter()
-    # Test cannot catch transient (3s) status page fast enough but
-    # if unsupported values are entered and app does not crash it
-    # will display status and then return to "Generate SSKR" screen
-#    backend.wait_for_text_on_screen("between", 3)
-    backend.wait_for_text_on_screen("Generate SSKR", 5)
-    choice.confirm()
-    backend.wait_for_text_on_screen("Enter number of SSKR shares", 5)
+    backend.wait_for_text_on_screen("Number of SSKR", 5)
+    backend.wait_for_text_on_screen("Enter number of SSKR shares", 10)
     keypad.write("17")
     keypad.enter()
-    # Test cannot catch transient (3s) status page fast enough but
-    # if unsupported values are entered and app does not crash it
-    # will display status and then return to "Generate SSKR" screen
-#    backend.wait_for_text_on_screen("between", 3)
-    backend.wait_for_text_on_screen("Generate SSKR", 5)
-    choice.confirm()
+    backend.wait_for_text_on_screen("Number of SSKR", 5)
+    backend.wait_for_text_on_screen("Enter number of SSKR shares", 10)
 
-    # Test invalid threshold values
-    backend.wait_for_text_on_screen("Enter number of SSKR shares", 5)
+    # From here the share count is entered exactly once, and the rest of the
+    # test never types it again. Everything below depends on it still being 3.
     keypad.write("3")
     keypad.enter()
-    backend.wait_for_text_on_screen("Enter threshold value", 5)
+    backend.wait_for_text_on_screen(THRESHOLD_TITLE_3_SHARES, 5)
+
+    # Each of the three threshold refusals comes back to the threshold keypad,
+    # still announcing (1 - 3).
     keypad.write("0")
     keypad.enter()
-    # Test cannot catch transient (3s) status page fast enough but
-    # if unsupported values are entered and app does not crash it
-    # will display status and then return to "Generate SSKR" screen
-#    backend.wait_for_text_on_screen("cannot", 3)
-    backend.wait_for_text_on_screen("Generate SSKR", 5)
-    choice.confirm()
-    backend.wait_for_text_on_screen("Enter number of SSKR shares", 5)
-    keypad.write("3")
-    keypad.enter()
-    backend.wait_for_text_on_screen("Enter threshold value", 5)
+    backend.wait_for_text_on_screen("Threshold value", 5)
+    backend.wait_for_text_on_screen(THRESHOLD_TITLE_3_SHARES, 10)
+
     keypad.write("4")
     keypad.enter()
-    # Test cannot catch transient (3s) status page fast enough but
-    # if unsupported values are entered and app does not crash it
-    # will display status and then return to "Generate SSKR" screen
-#    backend.wait_for_text_on_screen("cannot", 3)
-    backend.wait_for_text_on_screen("Generate SSKR", 5)
-    choice.confirm()
-    backend.wait_for_text_on_screen("Enter number of SSKR shares", 5)
-    keypad.write("3")
-    keypad.enter()
-    backend.wait_for_text_on_screen("Enter threshold value", 5)
+    backend.wait_for_text_on_screen("Threshold value", 5)
+    backend.wait_for_text_on_screen(THRESHOLD_TITLE_3_SHARES, 10)
+
     keypad.write("1")
     keypad.enter()
-    # Test cannot catch transient (3s) status page fast enough but
-    # if unsupported values are entered and app does not crash it
-    # will display status and then return to "Generate SSKR" screen
-#    backend.wait_for_text_on_screen("not supported", 3)
-    backend.wait_for_text_on_screen("Generate SSKR", 5)
-    choice.confirm()
-    backend.wait_for_text_on_screen("Enter number of SSKR shares", 5)
-    keypad.write("1")
+    backend.wait_for_text_on_screen("1-of-m shares", 5)
+    backend.wait_for_text_on_screen(THRESHOLD_TITLE_3_SHARES, 10)
+
+    # And a threshold this one does accept generates a 2-of-3 straight away.
+    # This is what the three refusals above cost before: each of them returned
+    # to the "Generate SSKR Phrase?" offer, so reaching this point meant typing
+    # the share count three more times. The share label naming 3 is the proof
+    # that the count entered once is the count that was used.
+    keypad.write("2")
     keypad.enter()
-    backend.wait_for_text_on_screen("Enter threshold value", 5)
-    keypad.write("1")
-    keypad.enter()
-    backend.wait_for_text_on_screen("SSKR share", 5)
+    backend.wait_for_text_on_screen("SSKR share 1 of 3", 5)
     backend.wait_for_text_on_screen("tuna next keep gyro", 1)
     review.exit()
     backend.wait_for_text_on_screen("Seed Tool", 5)

--- a/tests/unit/tests/ui_strings.c
+++ b/tests/unit/tests/ui_strings.c
@@ -33,10 +33,12 @@
 #include <stddef.h>
 #include <setjmp.h>
 #include <cmocka.h>
+#include <stdbool.h>
 #include <string.h>
 #include <stdio.h>
 
 #include "ui_strings.h"
+#include "constants.h"
 #include "sss-constants.h"
 
 #define ENTRY(name) \
@@ -416,11 +418,144 @@ static void test_sskr_share_label_fits_the_nano_title_line(void **state) {
     }
 }
 
+/*
+ * Four of the entry screens name, in their own title, the range of values
+ * they accept. A title that announces a bound the code does not apply is
+ * worse than a title with no bound at all: it is read as a promise.
+ *
+ * Two of the four carry the bound as a literal, because nothing about it
+ * varies -- and a literal is exactly what drifts. Both are checked here
+ * against the constant that actually decides the bound:
+ *
+ *   - the SSKR share count against SSS_MAX_SHARE_COUNT, which is what
+ *     sskr_sharenum_validate() compares against and what the Shamir layer
+ *     refuses to exceed;
+ *   - the BIP85 index against the keypad's own digit cap,
+ *     BIP85_INDEX_MAX_NUMBER_LENGTH. Raising that cap to eight digits without
+ *     touching the strings would leave two screens announcing a ceiling a
+ *     million short of the one the keypad accepts.
+ *
+ * The number is looked for as digits, with any thousands separators dropped
+ * first, so that "9,999,999" and "9999999" are the same claim.
+ *
+ * It is matched as a whole run of digits, not as a substring. A substring
+ * search passes on exactly the half of the problem that matters: lower the
+ * keypad cap to six digits and "999999" is still found inside the title's
+ * "9999999", so a title promising ten times what the keypad accepts would go
+ * through. Comparing whole runs fails in both directions.
+ */
+static void strip_commas(const char *in, char *out, size_t out_size) {
+    size_t o = 0;
+    for (size_t i = 0; in[i] != '\0' && o + 1 < out_size; i++) {
+        if (in[i] != ',') {
+            out[o++] = in[i];
+        }
+    }
+    out[o] = '\0';
+}
+
+static bool has_digit_run(const char *text, const char *bound) {
+    size_t bound_len = strlen(bound);
+    for (size_t i = 0; text[i] != '\0';) {
+        if (text[i] < '0' || text[i] > '9') {
+            i++;
+            continue;
+        }
+        size_t start = i;
+        while (text[i] >= '0' && text[i] <= '9') {
+            i++;
+        }
+        size_t run_len = i - start;
+        if (run_len == bound_len && strncmp(text + start, bound, bound_len) == 0) {
+            return true;
+        }
+    }
+    return false;
+}
+
+static void assert_announces(const char *name, const char *value, const char *bound) {
+    char plain[256];
+    strip_commas(value, plain, sizeof(plain));
+    if (!has_digit_run(plain, bound)) {
+        fail_msg("%s (\"%s\") does not name %s, the bound the code applies", name, value, bound);
+    }
+}
+
+static void test_announced_bounds_are_the_applied_ones(void **state) {
+    (void) state;
+
+    char bound[32];
+
+    snprintf(bound, sizeof(bound), "%d", SSS_MAX_SHARE_COUNT);
+    assert_announces("UI_STR_NBGL_SSKR_NUMSHARES_TITLE", UI_STR_NBGL_SSKR_NUMSHARES_TITLE, bound);
+    assert_announces("UI_STR_NBGL_SSKR_NUMSHARES_RANGE_ERROR",
+                     UI_STR_NBGL_SSKR_NUMSHARES_RANGE_ERROR, bound);
+
+    /* the largest value BIP85_INDEX_MAX_NUMBER_LENGTH digits can spell */
+    unsigned long index_max = 1;
+    for (int i = 0; i < BIP85_INDEX_MAX_NUMBER_LENGTH; i++) {
+        index_max *= 10;
+    }
+    snprintf(bound, sizeof(bound), "%lu", index_max - 1);
+    assert_announces("UI_STR_NBGL_BIP85_INDEX_TITLE", UI_STR_NBGL_BIP85_INDEX_TITLE, bound);
+    assert_announces("UI_STR_NBGL_BIP85_INDEX_RANGE_ERROR", UI_STR_NBGL_BIP85_INDEX_RANGE_ERROR,
+                     bound);
+}
+
+/*
+ * The other two carry their bounds as "%d", filled in at display time -- the
+ * threshold's maximum is the share count just entered, the password length's
+ * pair depends on the chosen application. Nothing here can check the values,
+ * which only exist at runtime; what it can check is that each format still
+ * takes exactly the arguments its call site passes.
+ *
+ * Both failure modes are real and neither is loud. A title reworded without
+ * its "%d" drops the bound the screen was changed to show, and nothing warns.
+ * A title that gains one reads an argument that was never pushed.
+ */
+static size_t count_conversions(const char *format) {
+    size_t n = 0;
+    for (size_t i = 0; format[i] != '\0'; i++) {
+        if (format[i] == '%' && format[i + 1] == 'd') {
+            n++;
+            i++;
+        }
+    }
+    return n;
+}
+
+static void test_composed_titles_take_the_arguments_passed_to_them(void **state) {
+    (void) state;
+
+    static const struct {
+        const char *name;
+        const char *value;
+        size_t expected;
+    } k_composed[] = {
+        /* display_sskr_select_threshold_page(): the floor, then the share count */
+        {"UI_STR_NBGL_SSKR_THRESHOLD_TITLE", UI_STR_NBGL_SSKR_THRESHOLD_TITLE, 2},
+        /* display_bip85_select_password_length_page(): minimum, maximum */
+        {"UI_STR_NBGL_BIP85_PWD_LENGTH_TITLE", UI_STR_NBGL_BIP85_PWD_LENGTH_TITLE, 2},
+        /* bip85_password_length_validate(): the same pair */
+        {"UI_STR_NBGL_BIP85_PWD_LENGTH_RANGE_ERROR", UI_STR_NBGL_BIP85_PWD_LENGTH_RANGE_ERROR, 2},
+    };
+
+    for (size_t i = 0; i < sizeof(k_composed) / sizeof(k_composed[0]); i++) {
+        size_t found = count_conversions(k_composed[i].value);
+        if (found != k_composed[i].expected) {
+            fail_msg("%s (\"%s\") takes %zu \"%%d\", but its call site passes %zu",
+                     k_composed[i].name, k_composed[i].value, found, k_composed[i].expected);
+        }
+    }
+}
+
 int main(void) {
     const struct CMUnitTest tests[] = {
         cmocka_unit_test(test_every_string_is_non_empty),
         cmocka_unit_test(test_nano_fixed_layout_strings_fit_their_budget),
         cmocka_unit_test(test_sskr_share_label_fits_the_nano_title_line),
+        cmocka_unit_test(test_announced_bounds_are_the_applied_ones),
+        cmocka_unit_test(test_composed_titles_take_the_arguments_passed_to_them),
     };
     return cmocka_run_group_tests(tests, NULL, NULL);
 }


### PR DESCRIPTION
## What the user had to redo, and no longer does

Enter 3 shares, then a threshold of 4. The threshold is refused — correctly — and the application returns to **"Generate SSKR Phrase?"**, the first screen of the flow. The share count that was just accepted is thrown away along with the value that was not, and has to be typed again before the threshold can be corrected.

That was true of all four SSKR refusals. The test in this repository encoded it: `test_sskr_unsupported_values.py` asserted `wait_for_text_on_screen("Generate SSKR")` after each of six refusals, and re-entered the share count every time.

The same sequence now — 3 shares, threshold 4, then threshold 2 — produces a 2-of-3 without the share count being typed a second time.

## Where each refusal went, and where it goes

All six are in `src/nbgl/ui.c`; the second argument of `nbgl_useCaseStatus()` is the return callback.

| Refusal | Returned to | Returns to |
|---|---|---|
| share count out of range | `display_select_generate_sskr_page` | `display_sskr_select_numshares_page` |
| threshold < 1 | `display_select_generate_sskr_page` | `display_sskr_select_threshold_page` |
| threshold > share count | `display_select_generate_sskr_page` | `display_sskr_select_threshold_page` |
| threshold 1-of-m | `display_select_generate_sskr_page` | `display_sskr_select_threshold_page` |
| BIP85 index out of range | `display_bip39_select_phrase_length_page` | `display_bip85_select_index_page` |
| BIP85 password length | `display_bip85_select_app_page` | `display_bip85_select_password_length_page` |

The index one was returning to a screen that is neither the field at fault nor on the branch of the flow that reaches it.

**Nothing on these paths preserves state the code assumed reset.** The threshold screen reads the share count through `sskr_sharenum_get()`, whose only writer is its own validator, and that screen is reachable only from the validator's success branch or from its own refusals — so the count it displays and compares against has always been through validation. `reset_globals()` and `sskr_shares_reset()` are reached from `display_home_page()`, `review_done()` and the check flow, none of which any of the six branches goes through.

**Reaching the erase path does get longer**, and that is worth stating rather than leaving as a side effect. After a refusal, `Cancel` on the offer screen was one tap from `display_home_page()` and so from `reset_globals()`; it is now two back arrows and a `Cancel`. The phrase the user has just entered word by word is in RAM throughout. Nothing bypasses the erase — none of the three old targets called `reset_globals()` either — but the distance to it changed.

## What the screens now announce

Four entry screens; one already named its range, three did not.

| Screen | Title | Where the bound comes from |
|---|---|---|
| share count | `Enter number of SSKR shares\nto generate (1 - 16)` — unchanged | `SSS_MAX_SHARE_COUNT`, now also what the validator compares against, with a `_Static_assert` tying the literal to it |
| threshold | `Enter threshold value (%d - %d)` | `sskr_threshold_min()` and `sskr_sharenum_get()` — the calls the validator makes |
| BIP85 index | `Enter index (0 - 9,999,999)` | the keypad's own digit cap, the number the error message already gave |
| BIP85 password length | `Enter password length\n(%d - %d)` | one accessor, read by the title, the validator and the error message |

**The threshold's floor is not 1.** A threshold of 1 over more than one share means any single share rebuilds the secret, and this screen has always refused it. A title reading `(1 - 3)` would promise a value the next screen rejects, so the floor is announced as well as applied: three shares offer `(2 - 3)`, one share still offers `(1 - 1)`. The check is written against `sskr_threshold_min()` rather than an open-coded `== 1 && sharenum > 1`, so the announced floor and the applied floor cannot say different things.

The share-count validator compared against a literal `16` where the title said `(1 - 16)`; it now compares against `SSS_MAX_SHARE_COUNT`, and a `_Static_assert` fails the build if that constant stops being the number the two strings spell out. The password bounds were two ternaries inside the validator, invisible to the title; they are four named constants and one accessor.

The two composed titles share one static buffer. `nbgl_layoutAddKeypadContent()` keeps the pointer it is given (`textArea->text = title`, `lib_nbgl/src/nbgl_layout_keypad.c`) and redraws that area while the keypad is up, so a stack buffer would dangle. Its size is derived from the format literals rather than counted: every `%d` stands for a value of at most two digits and is itself two characters wide, so a composed title is never longer than its own format. Every one of those values is `_Static_assert`ed, minima included — a three-digit minimum would truncate a title in silence while an assertion on the maxima alone stayed happy.

The error message built beside them was on the stack, and had exactly the problem the title buffer exists to avoid: `nbgl_useCaseStatus()` stores the pointer, `nbgl_layoutAddCenteredInfo()` puts it in the text area, and the status page outlives the function by three seconds. It is `static` now. It is the only status message in the file that is composed rather than a literal.

The line break in the password title is placed rather than left to the layout: without it, all three touch devices wrapped inside the range and drew `(20 - ` on one line and `86)` on the next.

## Unenterable, or only cheaper?

**Cheaper and announced in advance — not unenterable.** A numeric keypad accepts any one- or two-digit number; bounding what can be entered means replacing the widget. The 1-of-m refusal would survive that anyway, since 1-of-1 is legitimate. The three threshold status screens still exist. What changed is that the range is visible before the keypad is used, and being refused no longer costs the field before it.

## BAGL is unaffected, and why

The three Nano targets are **byte-identical before and after** — same `sha256` on `nanos`, `nanox` and `nanos+` against this PR's base. Only `src/nbgl/` and `src/common/ui_strings.h` are touched, and every string changed is an NBGL-only macro.

They were never affected on the two SSKR screens. The Nano share count and threshold are chosen from `UX_STEP_MENULIST`s whose entries come from `sskr_descriptor_label()` (`src/bagl/ux_sskr_menu.c`), bounded by `sskr_descriptor_count()` for the count and by the already-chosen count for the threshold — so an out-of-range value is not representable and there is no status screen to return from. BIP85 has no BAGL screen at all, on any Nano.

One nuance rather than a clean sweep: BAGL does keep a 1-of-m refusal (`ux_threshold_warn_flow`, `src/bagl/ux_sskr.c`). Two of the three threshold refusals are impossible there; the third is not. It is out of scope here — this change is touch-only.

## Sizes

`arm-none-eabi-size` reports `.text` unchanged on the three touch targets, and **that number cannot move**: `_install_parameters` sits at a fixed address on these targets (`0xc0df2a00` on stax, before and after), and `.text` as reported spans to the end of that block. Adding 130 bytes of unused string literal to check left it at 76385 as well. The section end symbols are the honest figures:

| Target | `_etext` | `_ebss` |
|---|---|---|
| nanos | unchanged | unchanged |
| nanox | unchanged | unchanged |
| nanos+ | unchanged | unchanged |
| stax | +276 | +32 |
| flex | +220 | +32 |
| apex_p | +220 | +32 |

The RAM is the two static buffers. A sorted `strings` diff on the touch targets shows the changed titles, the `(%d - %d)` tail of the password format, and the new symbol names — nothing else of substance.

## Tests

**Functional, which is where this change lives** — `src/nbgl/ui.c` is in no unit target. `test_sskr_unsupported_values.py` is rewritten: it enters the share count exactly once and never again, walks the three threshold refusals, asserts after each that the screen is the threshold keypad still announcing `(2 - 3)` — which is at the same time the evidence that the count survived — and finishes by generating a 2-of-3. Each refusal is waited for on its own before its field is, so arriving at the field is a screen change rather than the screen already displayed. `test_bip85_pwd_base64.py` gained the same shape for the password length, and both password tests assert their own range, which differ (`20 - 86` against `10 - 80`).

Every announced range is matched as a whole screen event, so a layout that wrapped inside one would fail the test rather than ship. Assertions carrying a range escape their parentheses: `wait_for_text_on_screen()` hands its argument to `re.match()`, where an unescaped `(2 - 3)` is a group and would match a screen reading `Enter threshold value 2 - 3` instead.

**Unit** — `tests/unit/tests/ui_strings.c` gains two cases, both run in their failing state. That the two literal bounds name the constant that decides them, matched as whole runs of digits rather than substrings: a substring search passes on exactly the half that matters, since lowering the keypad cap to six digits still finds `999999` inside the title's `9999999`, so a title promising ten times what the keypad accepts would go through. And that each composed format still takes exactly the arguments its call site passes, since a title reworded without its `%d` would silently drop the bound it was changed to show.

Verification run: six unit configurations 80/80 each; six targets built without warnings; Speculos on `stax` 12 passed / 6 skipped, `flex` 12/6, `apex_p` 12/6, `nanox` 9/9, `nanos+` 9/9; `clang-format --dry-run -Werror` clean.

## What no test holds

- **The BIP85 index refusal.** Unreachable from its keypad, which caps entry at seven digits, so the largest value that can arrive is 9,999,999 and the 31-bit bound it guards cannot be crossed from the screen. Corrected as a guard, not as a lived path; no functional test can drive it.
- **The dangling-pointer fix.** Speculos has no system UX takeover, so it never produces the redraw that would have read the dead stack frame. The chain is established by reading the SDK — pointer stored, object tree walked on redraw — not by reproducing it.
- **The Nano S.** No emulator covers it. It is in the build matrix and is byte-identical here, which is the whole of what can be said.
- **Functional CI.** This repository's workflows do not run the functional suite on pull requests from a fork — the workflow token is read-only there. The runs above were made locally under Speculos.
