### PR TITLE
Name the four things this application can do, in its menu

### DIFF
--- a/src/bagl/nanos_enter_phrase.c
+++ b/src/bagl/nanos_enter_phrase.c
@@ -71,9 +71,7 @@ const bagl_element_t screen_onboarding_restore_word_select_elements[] = {
 
 void screen_onboarding_restore_word_display_auto_complete(void);
 
-extern const ux_flow_step_t* const ux_bip39_match_flow;
 extern const ux_flow_step_t* const ux_sskr_match_flow;
-extern const ux_flow_step_t* const ux_bip39_nomatch_flow;
 extern const ux_flow_step_t* const ux_sskr_nomatch_flow;
 extern const ux_flow_step_t* const ux_bip39_invalid_flow;
 extern const ux_flow_step_t* const ux_sskr_invalid_flow;
@@ -397,13 +395,33 @@ void compare_recovery_phrase_and_display_result(void) {
         // invalid rather than as a seed mismatch
         ux_flow_init(0, &ux_sskr_invalid_flow, NULL);
     } else if (match) {
-        (G_bolos_ux_context.tool_type == TOOL_TYPE_BIP39)
-            ? ux_flow_init(0, &ux_bip39_match_flow, NULL)
-            : ux_flow_init(0, &ux_sskr_match_flow, NULL);
+        if (G_bolos_ux_context.tool_type == TOOL_TYPE_BIP39) {
+            // Two flows behind this call, chosen on the intention: checking
+            // ends on the verdict, splitting goes on to the share count. See
+            // ux_bip39_match_display() in ux_nano.c.
+            ux_bip39_match_display();
+        } else {
+            ux_flow_init(0, &ux_sskr_match_flow, NULL);
+        }
     } else {
-        (G_bolos_ux_context.tool_type == TOOL_TYPE_BIP39)
-            ? ux_flow_init(0, &ux_bip39_nomatch_flow, NULL)
-            : ux_flow_init(0, &ux_sskr_nomatch_flow, NULL);
+        if (G_bolos_ux_context.tool_type == TOOL_TYPE_BIP39) {
+            // Erased here, as nanox_enter_phrase.c already did on this same
+            // branch and this file did not. Nothing downstream of a BIP-39
+            // mismatch reads the phrase again -- only a match leads anywhere
+            // that does -- so it has no reason to outlive the verdict, and
+            // the backup flow now puts one more screen between this point
+            // and the erasure ui_idle_init() performs on the way out.
+            //
+            // Only this branch. The SSKR one below keeps words_buffer,
+            // because that is where bolos_ux_sskr_to_seed_convert() left the
+            // reconstructed phrase and recover_bip39() displays it from the
+            // mismatch flow.
+            memzero(G_bolos_ux_context.words_buffer,
+                    G_bolos_ux_context.words_buffer_length);
+            ux_bip39_nomatch_display();
+        } else {
+            ux_flow_init(0, &ux_sskr_nomatch_flow, NULL);
+        }
     }
 }
 

--- a/src/bagl/nanox_enter_phrase.c
+++ b/src/bagl/nanox_enter_phrase.c
@@ -80,9 +80,7 @@ const bagl_element_t screen_onboarding_restore_word_select_elements[] = {
 UX_STEP_NOCB(ux_load_step, pn, {&C_icon_loader_14px, UI_STR_BAGL_PROCESSING});
 UX_FLOW(ux_load_flow, &ux_load_step);
 
-extern const ux_flow_step_t* const ux_bip39_match_flow;
 extern const ux_flow_step_t* const ux_sskr_match_flow;
-extern const ux_flow_step_t* const ux_bip39_nomatch_flow;
 extern const ux_flow_step_t* const ux_sskr_nomatch_flow;
 extern const ux_flow_step_t* const ux_bip39_invalid_flow;
 extern const ux_flow_step_t* const ux_sskr_invalid_flow;
@@ -472,11 +470,14 @@ void screen_onboarding_restore_word_validate(void) {
                 // Against VERDICT_MATCH, not "not zero": every other value,
                 // corrupted or not, is a mismatch. See common.h.
                 if (compare_recovery_phrase(&reconstructed) == VERDICT_MATCH) {
-                    ux_flow_init(0, &ux_bip39_match_flow, NULL);
+                    // Two flows behind this call, chosen on the intention:
+                    // checking ends on the verdict, splitting goes on to the
+                    // share count. See ux_bip39_match_display() in ux_nano.c.
+                    ux_bip39_match_display();
                 } else {
                     memzero(G_bolos_ux_context.words_buffer,
                             G_bolos_ux_context.words_buffer_length);
-                    ux_flow_init(0, &ux_bip39_nomatch_flow, NULL);
+                    ux_bip39_nomatch_display();
                 }
             }
         } else {

--- a/src/bagl/ui.c
+++ b/src/bagl/ui.c
@@ -84,6 +84,42 @@ UX_FLOW(ux_bip39_flow, &ux_bip39_instruction_step, &ux_bip39_menu_step);
 
 //////////////////////////////////////////////////////////////////////
 
+/*
+ * Splitting a phrase starts by explaining why the phrase is being asked for.
+ *
+ * Same reason as on the touch stack: compare_recovery_phrase()
+ * (src/common/common_seed.c) gets a seed back from the device and never the
+ * words, so the words have to come from the person -- and being asked to type
+ * twenty-four of them into a device that already holds them is the moment
+ * that needs saying. It needs saying more here than there, not less: on a
+ * Nano those words are entered one letter at a time with two buttons.
+ *
+ * nanos shows two lines, which is why the first two are a complete sentence
+ * on their own; the taller Nanos add the third.
+ */
+#if defined(TARGET_NANOS)
+UX_STEP_NOCB(ux_backup_explain_step, nn,
+             {
+                 UI_STR_BAGL_BACKUP_EXPLAIN_L1,
+                 UI_STR_BAGL_BACKUP_EXPLAIN_L2,
+             });
+#else
+UX_STEP_NOCB(ux_backup_explain_step, nnn,
+             {
+                 UI_STR_BAGL_BACKUP_EXPLAIN_L1,
+                 UI_STR_BAGL_BACKUP_EXPLAIN_L2,
+                 UI_STR_BAGL_BACKUP_EXPLAIN_L3,
+             });
+#endif
+
+// The length menu and its instruction are the same two steps the check flow
+// uses -- the question they ask is the same one, and the intention already
+// recorded is what makes the difference later.
+UX_FLOW(ux_backup_flow, &ux_backup_explain_step, &ux_bip39_instruction_step,
+        &ux_bip39_menu_step);
+
+//////////////////////////////////////////////////////////////////////
+
 void screen_onboarding_sskr_restore_init(void) {
     G_bolos_ux_context.tool_type = TOOL_TYPE_SSKR;
     screen_onboarding_restore_word_init(RESTORE_WORD_ACTION_FIRST_WORD);
@@ -110,31 +146,60 @@ UX_FLOW(ux_sskr_flow, &ux_sskr_instruction_step);
 
 //////////////////////////////////////////////////////////////////////
 
-UX_STEP_VALID(ux_idle_flow_1_step, pbb, ux_flow_init(0, ux_bip39_flow, NULL),
+/*
+ * The idle menu: one entry per intention, as on the touch stack, minus the
+ * one that has nowhere to go.
+ *
+ * Three, not four. BIP-85 has no BAGL screen on any Nano, so a fourth entry
+ * would lead nowhere; the two stacks do not have the same menu and this is
+ * where they differ.
+ *
+ * Each entry records what the user came to do before starting the flow. That
+ * is the whole reason the field exists: the first two both end up entering a
+ * BIP-39 phrase and are both TOOL_TYPE_BIP39, and without it the verdict
+ * cannot tell which of the two it is answering.
+ *
+ * The icon names the format the entry produces rather than the one it
+ * consumes, which is what keeps the last two apart: splitting arrives at SSKR
+ * shares, restoring arrives at a BIP-39 phrase.
+ */
+UX_STEP_VALID(ux_idle_flow_1_step, pbb,
+              G_bolos_ux_context.user_intent = USER_INTENT_CHECK;
+              ux_flow_init(0, ux_bip39_flow, NULL),
               {
                   &BIP39_ICON,
-                  UI_STR_BAGL_IDLE_BIP39_L1,
-                  UI_STR_BAGL_IDLE_BIP39_L2,
+                  UI_STR_BAGL_IDLE_CHECK_L1,
+                  UI_STR_BAGL_IDLE_CHECK_L2,
               });
-UX_STEP_VALID(ux_idle_flow_2_step, pbb, ux_flow_init(0, ux_sskr_flow, NULL),
+UX_STEP_VALID(ux_idle_flow_2_step, pbb,
+              G_bolos_ux_context.user_intent = USER_INTENT_BACKUP;
+              ux_flow_init(0, ux_backup_flow, NULL),
               {
                   &SSKR_ICON,
-                  UI_STR_BAGL_IDLE_SSKR_L1,
-                  UI_STR_BAGL_IDLE_SSKR_L2,
+                  UI_STR_BAGL_IDLE_BACKUP_L1,
+                  UI_STR_BAGL_IDLE_BACKUP_L2,
+              });
+UX_STEP_VALID(ux_idle_flow_3_step, pbb,
+              G_bolos_ux_context.user_intent = USER_INTENT_RECOVER;
+              ux_flow_init(0, ux_sskr_flow, NULL),
+              {
+                  &BIP39_ICON,
+                  UI_STR_BAGL_IDLE_RECOVER_L1,
+                  UI_STR_BAGL_IDLE_RECOVER_L2,
               });
 
-UX_STEP_NOCB(ux_idle_flow_3_step, bn,
+UX_STEP_NOCB(ux_idle_flow_4_step, bn,
              {
                  UI_STR_VERSION_LABEL,
                  APPVERSION,
              });
-UX_STEP_VALID(ux_idle_flow_4_step, pb, os_sched_exit(-1),
+UX_STEP_VALID(ux_idle_flow_5_step, pb, os_sched_exit(-1),
               {
                   &C_icon_dashboard_x,
                   UI_STR_QUIT,
               });
 UX_FLOW(ux_idle_flow, &ux_idle_flow_1_step, &ux_idle_flow_2_step,
-        &ux_idle_flow_3_step, &ux_idle_flow_4_step);
+        &ux_idle_flow_3_step, &ux_idle_flow_4_step, &ux_idle_flow_5_step);
 
 void ui_idle_init(void) {
     memzero(G_bolos_ux_context.words_buffer,
@@ -146,6 +211,11 @@ void ui_idle_init(void) {
     G_bolos_ux_context.words_buffer_length = 0;
     G_bolos_ux_context.sskr_words_buffer_length = 0;
     G_bolos_ux_context.sskr_share_index = 0;
+    // Back to the first entry, so that no flow started from this menu reads
+    // what the previous one left behind. Every entry writes it again on the
+    // way out, so this only matters for the value read before any entry has
+    // been picked.
+    G_bolos_ux_context.user_intent = USER_INTENT_CHECK;
 
     // reserve a display stack slot if none yet
     if (G_ux.stack_count == 0) {

--- a/src/bagl/ux_nano.c
+++ b/src/bagl/ux_nano.c
@@ -176,7 +176,20 @@ UX_STEP_NOCB(ux_bip39_nomatch_step_1, pbb,
              {&C_icon_warning, UI_STR_BIP39_PHRASE_TITLE,
               UI_STR_BAGL_BIP39_NOMATCH_TITLE_L2});
 
-UX_FLOW(ux_bip39_nomatch_flow, &ux_bip39_nomatch_step_1, &ux_return_step);
+// What the mismatch means when the phrase was on its way to being split. The
+// title above answers "is this my phrase?"; this answers "can I back it up?",
+// which is the question that was actually asked, and the two are not the same
+// answer. Its own step for the same reason ux_invalid_step_2 is one: a pbb
+// title has two short lines and no room for a sentence.
+UX_STEP_NOCB(ux_backup_nomatch_step_2, nn,
+             {
+                 UI_STR_BAGL_BACKUP_NOMATCH_L1,
+                 UI_STR_BAGL_BACKUP_NOMATCH_L2,
+             });
+
+UX_FLOW(ux_bip39_check_nomatch_flow, &ux_bip39_nomatch_step_1, &ux_return_step);
+UX_FLOW(ux_bip39_backup_nomatch_flow, &ux_bip39_nomatch_step_1,
+        &ux_backup_nomatch_step_2, &ux_return_step);
 
 UX_STEP_NOCB(ux_bip39_match_step_1, pbb,
              {&C_icon_validate_14, UI_STR_BIP39_PHRASE_TITLE,
@@ -185,8 +198,56 @@ UX_STEP_CB(ux_bip39_recover_step_1, pbb, set_sskr_descriptor_values();
            , {&SSKR_ICON, UI_STR_BAGL_GENERATE_SSKR_L1,
               UI_STR_BAGL_GENERATE_SSKR_L2});
 
-UX_FLOW(ux_bip39_match_flow, &ux_bip39_match_step_1, &ux_quit_step,
-        &ux_bip39_recover_step_1);
+// Checking ends on the verdict; that is what makes it a destination. The step
+// offering to generate shares is gone from this flow -- it was the only way
+// in before, and it is now an entry of the idle menu, where it says what it
+// is. ux_return_step takes its place so that the flow still has a way back to
+// that menu rather than only a way out of the application.
+UX_FLOW(ux_bip39_check_match_flow, &ux_bip39_match_step_1, &ux_quit_step,
+        &ux_return_step);
+
+// Splitting passes through it: verdict, a way out, the press that starts the
+// generation, and a way back to the menu.
+//
+// The first three steps are what this file already had. The fourth is new,
+// and it is the same step the check flow above gained: without it the only
+// exit from a successful backup verdict is ux_quit_step, which erases but
+// closes the application, so someone who changed their mind had to leave
+// rather than go back. That was true before this change too; it is worth
+// less defending than fixing.
+UX_FLOW(ux_bip39_backup_match_flow, &ux_bip39_match_step_1, &ux_quit_step,
+        &ux_bip39_recover_step_1, &ux_return_step);
+
+/*
+ * The same guarantee the touch stack gets from its tables, stated where a
+ * Nano build will see it.
+ *
+ * src/nbgl/ui.c is not compiled into any Nano target, so its static
+ * assertions say nothing here: a fifth intention added for the touch menu
+ * breaks that build and leaves this one silent, and the two functions below
+ * would send the new value down the check flow through their `else` -- the
+ * safe answer, arrived at by accident.
+ */
+_Static_assert(USER_INTENT_NB == 4,
+               "the two functions below choose a flow on the intention, and "
+               "everything they do not name takes the check flow; a new "
+               "intention needs a decision here, not an else branch");
+
+void ux_bip39_match_display(void) {
+    if (G_bolos_ux_context.user_intent == USER_INTENT_BACKUP) {
+        ux_flow_init(0, ux_bip39_backup_match_flow, NULL);
+    } else {
+        ux_flow_init(0, ux_bip39_check_match_flow, NULL);
+    }
+}
+
+void ux_bip39_nomatch_display(void) {
+    if (G_bolos_ux_context.user_intent == USER_INTENT_BACKUP) {
+        ux_flow_init(0, ux_bip39_backup_nomatch_flow, NULL);
+    } else {
+        ux_flow_init(0, ux_bip39_check_nomatch_flow, NULL);
+    }
+}
 
 UX_STEP_NOCB(ux_sskr_invalid_step_1, pbb,
              {&C_icon_crossmark, UI_STR_BAGL_SSKR_INVALID_TITLE_L1,

--- a/src/bagl/ux_nano.h
+++ b/src/bagl/ux_nano.h
@@ -20,6 +20,8 @@
 #include <ux.h>
 #include "ui.h"
 #include "../common/common.h"
+// user_intent_e, stored in the context below and shared with the touch stack
+#include "constants.h"
 
 #if defined(HAVE_BAGL)
 
@@ -72,6 +74,14 @@ typedef struct bolos_ux_context {
 
     // Type of tool we are using (BIP39 or SSKR)
     unsigned int tool_type;
+
+    // Which entry of the idle menu the user picked. Not the same thing as the
+    // tool: checking a phrase and splitting one into shares both enter a
+    // BIP-39 phrase, so both are TOOL_TYPE_BIP39, and only this tells the
+    // verdict flow which of the two it is ending. Written by the idle menu
+    // and by ui_idle_init(), read by ux_bip39_match_display() and
+    // ux_bip39_nomatch_display() in src/bagl/ux_nano.c.
+    user_intent_e user_intent;
 
     // State of the dynamic display
     unsigned int current_state;
@@ -140,6 +150,14 @@ void screen_common_keyboard_init(unsigned int stack_slot,
 
 void set_sskr_descriptor_values(void);
 void recover_bip39(void);
+
+// The BIP-39 verdict, in whichever form the intention calls for. Two flows
+// per outcome, and the choice between them lives next to the flows in
+// src/bagl/ux_nano.c rather than at the call sites: nanos_enter_phrase.c and
+// nanox_enter_phrase.c both reach the verdict, by different routes, and a
+// copy of this decision in each is a third thing to keep in step.
+void ux_bip39_match_display(void);
+void ux_bip39_nomatch_display(void);
 
 #include "common/bip39/common_bip39.h"
 #include "common/sskr/common_sskr.h"

--- a/src/common/ui_strings.h
+++ b/src/common/ui_strings.h
@@ -129,14 +129,48 @@
 #define UI_STR_NBGL_MENU_TITLE "What do you want\nto do?"
 
 /*
- * BAGL: the equivalent two entries on the Nano idle menu
- * (src/bagl/ui.c). BAGL's idle menu has no third entry for BIP85 -- that
- * flow has no BAGL screens at all, on any Nano.
+ * BAGL: the same intentions on the Nano idle menu (src/bagl/ui.c).
+ *
+ * Three, not four, and this is the one place the two stacks genuinely differ
+ * rather than merely word things differently: BIP-85 has no BAGL screen at
+ * all, on any Nano, so there is nothing for a fourth entry to lead to. The
+ * three that are here are the same three intentions, in the same order.
+ *
+ * They read shorter than the touch labels, and not by preference. A pbb step
+ * draws its two lines in an icon-flanked box that is 87px wide on the 128x32
+ * Nano S, and that box does not wrap -- it clips, silently.
+ * tests/unit/tests/ui_strings.c measures all six of these against it.
+ *
+ * The two entries these replace ended on "recovery phrase", which is 93px and
+ * had therefore always been over that budget -- one of the two strings that
+ * test recorded as failing rather than asserting, and so one of the two it
+ * could say nothing about. Rewriting these lines was the occasion to stop
+ * shipping it.
+ *
+ * The last two say, word for word, what the touch buttons say: "Generate" +
+ * "backup shares" is 53px + 82px, "Recover" + "from backup" is 47px + 72px,
+ * and both pairs clear the budget. Only the first entry has to differ --
+ * "Check recovery" alone is 88px -- and what it does with the room is worth
+ * more than the consistency it loses: "Check phrase" / "on this Ledger" says
+ * what the phrase is checked against, which is the one thing the touch
+ * button has no room to say.
  */
-#define UI_STR_BAGL_IDLE_BIP39_L1 "Check BIP39"
-#define UI_STR_BAGL_IDLE_BIP39_L2 "recovery phrase"
-#define UI_STR_BAGL_IDLE_SSKR_L1  "Check SSKR"
-#define UI_STR_BAGL_IDLE_SSKR_L2  "recovery phrase"
+#define UI_STR_BAGL_IDLE_CHECK_L1   "Check phrase"
+#define UI_STR_BAGL_IDLE_CHECK_L2   "on this Ledger"
+#define UI_STR_BAGL_IDLE_BACKUP_L1  "Generate"
+#define UI_STR_BAGL_IDLE_BACKUP_L2  "backup shares"
+#define UI_STR_BAGL_IDLE_RECOVER_L1 "Recover"
+#define UI_STR_BAGL_IDLE_RECOVER_L2 "from backup"
+
+/*
+ * The Nano form of the screen that says why the phrase is asked for. Same
+ * reason as UI_STR_NBGL_BACKUP_EXPLAIN_DESC further down, cut for a step that
+ * does not wrap: the first two lines are a complete sentence and are all a
+ * nanos nn step shows, and the taller Nanos get the third.
+ */
+#define UI_STR_BAGL_BACKUP_EXPLAIN_L1 "This Ledger cannot"
+#define UI_STR_BAGL_BACKUP_EXPLAIN_L2 "show you its phrase."
+#define UI_STR_BAGL_BACKUP_EXPLAIN_L3 "Enter it to split it."
 
 /* NBGL home screen description and action (src/nbgl/ui.c). */
 #define UI_STR_NBGL_HOME_DESCRIPTION \
@@ -290,6 +324,16 @@
 #define UI_STR_BAGL_BIP39_REENTER_PHRASE   "Re-enter phrase"
 #define UI_STR_BAGL_BIP39_NOMATCH_TITLE_L2 "doesn't match"
 #define UI_STR_BAGL_BIP39_MATCH_TITLE_L2   "is correct"
+
+/*
+ * What the mismatch adds when the phrase was being backed up rather than
+ * checked -- the Nano's two lines of what UI_STR_NBGL_RESULT_BACKUP_NOMATCH
+ * says in one sentence on the touch screens. It follows the "doesn't match"
+ * title as its own step, the way the invalid advice above already does,
+ * because a pbb title has no room for it.
+ */
+#define UI_STR_BAGL_BACKUP_NOMATCH_L1 "It would not restore"
+#define UI_STR_BAGL_BACKUP_NOMATCH_L2 "this Ledger"
 
 #define UI_STR_BAGL_SSKR_INVALID_TITLE_L1 "SSKR Recovery"
 #define UI_STR_BAGL_SSKR_INVALID_TITLE_L2 "phrase invalid"

--- a/src/common/ui_strings.h
+++ b/src/common/ui_strings.h
@@ -78,11 +78,55 @@
  * Home / tool selection
  */
 
-/* NBGL: three buttons on the "select a tool" screen (src/nbgl/ui.c). */
-#define UI_STR_NBGL_TOOL_BIP39        "BIP39 Check"
-#define UI_STR_NBGL_TOOL_SSKR         "SSKR Check"
-#define UI_STR_NBGL_TOOL_BIP85        "BIP85 Generate"
-#define UI_STR_NBGL_SELECT_TOOL_TITLE "Select the tool\nyou wish to use"
+/*
+ * NBGL: the four buttons of the menu (src/nbgl/ui.c), one per intention.
+ *
+ * They used to name formats -- "BIP39 Check", "SSKR Check", "BIP85 Generate"
+ * -- and generating a backup was not among them: it was only offered after a
+ * check had succeeded, so someone who came to back up a phrase found nothing
+ * that matched what they came for. These name what the user wants instead,
+ * and the two things worth the most in a backup tool are the two that gained
+ * an entry.
+ *
+ * "backup" rather than "SSKR" on the two middle entries: someone who does not
+ * know what SSKR is has to be able to find the function. The term itself
+ * stays inside the flow, and above all on the paper the user copies down --
+ * see UI_STR_NBGL_SSKR_SHARE_HEADER below.
+ *
+ * The Recover entry says "from backup" and not "from backup shares", which is
+ * both shorter and, on reflection, the better half to drop. Measured first:
+ * the longer form is 268px in a 268px button on apex_p -- not clipped, but
+ * with no margin at all, which is the state just before clipping and
+ * indistinguishable from it on a screenshot. And "shares" is the format's
+ * word while "backup" is the word of someone holding the paper, which is who
+ * this entry is for.
+ */
+#define UI_STR_NBGL_MENU_CHECK   "Check recovery phrase"
+#define UI_STR_NBGL_MENU_BACKUP  "Generate backup shares"
+#define UI_STR_NBGL_MENU_RECOVER "Recover from backup"
+#define UI_STR_NBGL_MENU_DERIVE  "Derive with BIP85"
+/*
+ * The break is placed rather than left to the layout. The text area this is
+ * drawn in breaks on characters because generic_screen_set_top_title()
+ * (src/nbgl/layout_generic_screen.c) leaves `wrapping` clear, as every title
+ * in that file does; without the break Stax drew "What do you want to d" and
+ * "o?". Setting the field would wrap on words instead -- the break is kept
+ * because these two halves are chosen rather than discovered.
+ *
+ * Nothing under it, though two of the four entries would be the better for a
+ * line of their own -- "Check recovery phrase" does not say what it is
+ * checked against, and "Derive with BIP85" says nothing to someone who does
+ * not already know. There is no room on any of the three screens. Between the
+ * back button and the fourth entry Flex has 96px, of which a single title
+ * line takes 44; a subtitle wrapped to two lines was measured under Speculos
+ * drawing its second line *under the first button*, which does not clip it,
+ * it deletes it. One line would fit, and one line is 26 characters on apex_p.
+ *
+ * The list component that carries a subtitle per entry does not fit either:
+ * nbgl_layoutAddTouchableBar() makes an entry 94px on apex_p with a one-line
+ * subtitle, and four of them come to 376px against 340px of usable height.
+ */
+#define UI_STR_NBGL_MENU_TITLE "What do you want\nto do?"
 
 /*
  * BAGL: the equivalent two entries on the Nano idle menu
@@ -97,17 +141,19 @@
 /* NBGL home screen description and action (src/nbgl/ui.c). */
 #define UI_STR_NBGL_HOME_DESCRIPTION \
     "This Ledger application\nprovides some useful seed\nmanagement utilities."
-#define UI_STR_NBGL_HOME_ACTION    "Select Tool"
+#define UI_STR_NBGL_HOME_ACTION    "Select an action"
 #define UI_STR_NBGL_HOME_COPYRIGHT "(c) 2018-2026 Ledger"
 
 /*
  * BIP39 phrase length selection
  *
- * display_bip39_select_phrase_length_page() (src/nbgl/ui.c) serves two
- * different callers, distinguished by tool_type: checking an existing phrase
- * and generating a new one. BAGL has one screen for the same choice
- * (src/bagl/ui.c), worded for the Check flow only, and split 2 lines on
- * nanos, 3 lines on nanox/nanos+.
+ * display_bip39_select_phrase_length_page() (src/nbgl/ui.c) serves three of
+ * the four intentions, and only two titles: checking a phrase and backing one
+ * up ask the same question -- how long is the phrase you are about to type --
+ * so they read the same title, while deriving asks how long a phrase to
+ * produce, which is a different question. BAGL has one screen for the same
+ * choice (src/bagl/ui.c), worded for the Check flow only, and split 2 lines
+ * on nanos, 3 lines on nanox/nanos+.
  */
 #define UI_STR_NBGL_BIP39_LENGTH_TITLE_CHECK    "How long is your\nBIP39 Recovery\nPhrase?"
 #define UI_STR_NBGL_BIP39_LENGTH_TITLE_DERIVE   "Length of BIP39\nphrase to\ngenerate?"
@@ -203,6 +249,30 @@
 #define UI_STR_NBGL_RESULT_TAP_TO_DISMISS "Tap to dismiss"
 
 /*
+ * The same three outcomes, read on the way to generating a backup.
+ *
+ * The verdict is a destination when the user came to check a phrase and a
+ * step on the way when they came to back one up, and a failure does not mean
+ * the same thing in the two. "Doesn't match the one present on this Ledger
+ * device" is a complete answer to "is this my phrase?"; it is only half of
+ * one to "can I back this up?", where what matters is that the shares about
+ * to be written down would restore something this device cannot.
+ *
+ * The invalid outcome is not repeated here: a phrase that is not well formed
+ * is not well formed for either purpose, and UI_STR_NBGL_RESULT_BIP39_INVALID
+ * above says so in both flows, advice line included.
+ *
+ * The footer changes with it. A screen that continues cannot be labelled "Tap
+ * to dismiss" -- and only the match continues, so the failures above keep the
+ * dismissal.
+ */
+#define UI_STR_NBGL_RESULT_BACKUP_NOMATCH \
+    "You would be backing up\na phrase this Ledger\ncannot recover."
+#define UI_STR_NBGL_RESULT_BACKUP_MATCH \
+    "This is the recovery phrase\non this Ledger device.\nIt can be split into shares."
+#define UI_STR_NBGL_RESULT_TAP_TO_CONTINUE "Tap to continue"
+
+/*
  * Invalid-phrase advice. BAGL (src/bagl/ux_nano.c) splits it over two lines,
  * shared by the BIP39 and SSKR invalid flows; NBGL (src/nbgl/ui.c) now
  * carries the same advice as a third, gray line under the invalid result's
@@ -230,8 +300,14 @@
 #define UI_STR_BAGL_SSKR_MATCH_TITLE_L2   "is correct"
 
 /*
- * Recover BIP39 from SSKR / Generate SSKR from BIP39 -- the two choice
- * screens offered right after a successful verdict.
+ * Recover BIP39 from SSKR -- the screen between a successful verdict on a set
+ * of shares and the phrase they rebuild.
+ *
+ * It is the only thing standing in front of a revealed recovery phrase, so it
+ * stays even though the user chose "Recover from backup shares" from the menu
+ * and has already said what they want. The screen that used to sit opposite
+ * it, "Generate SSKR Phrase?", does not: nothing secret is on screen there,
+ * and it now duplicates a menu entry.
  *
  * NBGL asks with a title + description + two buttons (src/nbgl/ui.c); BAGL
  * folds the same choice into the verdict flow's own steps
@@ -250,10 +326,36 @@
  */
 #define UI_STR_NBGL_CANCEL "Cancel"
 
-#define UI_STR_NBGL_GENERATE_SSKR_TITLE "Generate SSKR Phrase?"
-#define UI_STR_NBGL_GENERATE_SSKR_DESC \
-    "Choose if you wish to\ngenerate SSKR shares from\nyour valid BIP39 phrase."
-#define UI_STR_NBGL_GENERATE_SSKR_CONFIRM "Generate SSKR"
+/*
+ * Backing up: why the phrase is asked for before anything is split.
+ *
+ * This screen exists because the question it answers had no answer on screen
+ * at all. Someone who picks "Generate backup shares" is immediately asked to
+ * type twenty-four words into a device that already holds them, and nothing
+ * said why.
+ *
+ * The reason is verifiable rather than reassuring: compare_recovery_phrase()
+ * (src/common/common_seed.c) derives a seed from what is typed and compares
+ * it with one derived from the device. What the device gives back is a seed,
+ * never the words -- so the words have to come from the person, and the
+ * shares are built from those words.
+ *
+ * The confirmation button names the next screen rather than the SDK's generic
+ * wording, as the two other choice screens in this application already do.
+ *
+ * No line breaks in the body, unlike the keypad titles further down. Those
+ * are drawn in a text area that breaks on characters, so a break has to be
+ * placed by hand or a range gets cut in half; nbgl_useCaseChoice() wraps this
+ * one on word boundaries on its own, and hand-placed breaks only fought with
+ * it -- Stax drew "This Ledger cannot read back" and then "the" alone on the
+ * next line, because the break was put after a word that no longer fitted.
+ */
+#define UI_STR_NBGL_BACKUP_EXPLAIN_TITLE "Enter your recovery phrase"
+#define UI_STR_NBGL_BACKUP_EXPLAIN_DESC                                  \
+    "This Ledger cannot read back the recovery phrase it holds. Enter "  \
+    "it, and it will be checked against this device before it is split " \
+    "into SSKR shares."
+#define UI_STR_NBGL_BACKUP_EXPLAIN_CONFIRM "Enter recovery phrase"
 
 /*
  * nbgl_useCaseGenericReview()'s reject parameter is named rejectText in

--- a/src/constants.h
+++ b/src/constants.h
@@ -30,8 +30,43 @@ enum __attribute__((packed)) {
     BIP39_MNEMONIC_SIZE_24 = 24,
 };
 
-// Type of tool we are using (BIP39, SSKR or BIP85)
+/*
+ * What the user typed, and therefore which buffer holds it -- not what the
+ * user came to do. The menu has four entries and this has three values,
+ * because two of those entries, checking a recovery phrase and backing one
+ * up, both enter a BIP-39 phrase and are the same thing to everything that
+ * reads this. user_intent below is what tells them apart.
+ *
+ * Adding a value here is not a display change, and the compiler will not stop
+ * it. compare_recovery_phrase() (src/common/common_seed.c) dispatches on this
+ * to choose which buffer to derive the seed from; a fourth value falls
+ * through both of its branches, hands 64 zero bytes to the comparison, and
+ * reports every phrase as not matching the device -- with nothing on screen
+ * to say the derivation never ran.
+ */
 enum __attribute__((packed)) { TOOL_TYPE_BIP39, TOOL_TYPE_SSKR, TOOL_TYPE_BIP85 };
+
+/*
+ * What the user came to do -- one value per entry of the menu.
+ *
+ * This exists because the same screens serve several of them. Entering a
+ * BIP-39 phrase is a destination when checking one and a step on the way when
+ * backing one up, so the verdict screen does not say the same thing in the
+ * two, and does not go to the same place afterwards. Before this, the flow
+ * was inferred from the tool, which could not tell those two apart.
+ *
+ * USER_INTENT_NB is the size of the enumeration, not a value. Tables in
+ * src/nbgl/ui.c are sized on it and static-assert against it, so a fifth
+ * intention is a compile error at the table that has to gain a row rather
+ * than a row silently left empty.
+ */
+typedef enum __attribute__((packed)) user_intent_e {
+    USER_INTENT_CHECK = 0,
+    USER_INTENT_BACKUP,
+    USER_INTENT_RECOVER,
+    USER_INTENT_DERIVE,
+    USER_INTENT_NB
+} user_intent_e;
 
 // State of the dynamic display
 enum __attribute__((packed)) { STATIC_SCREEN, DYNAMIC_SCREEN };

--- a/src/nbgl/layout_generic_screen.c
+++ b/src/nbgl/layout_generic_screen.c
@@ -62,6 +62,42 @@ nbgl_text_area_t* generic_screen_set_title(nbgl_obj_t* align_to) {
     return textArea;
 }
 
+/*
+ * A title for a screen that has no icon to hang it from.
+ *
+ * generic_screen_set_title() above aligns BOTTOM_MIDDLE to the icon it is
+ * given; with no icon there is nothing to align to, and BOTTOM_MIDDLE against
+ * a NULL alignTo is the bottom of the screen -- under the buttons. This one
+ * hangs from the top instead, clear of the back button, whose height the SDK
+ * names (BACK_BUTTON_HEADER_HEIGHT: 88 on Stax, 96 on Flex, 60 on Apex).
+ *
+ * `wrapping` is left unset here, as generic_screen_set_title() above also
+ * leaves it. That is a decision and not an oversight, and it is why every
+ * title in this file carries a hand-placed "\n": with the field clear the
+ * text area breaks on characters, so a title that overflows is cut mid-word;
+ * setting it would break on words instead. Placed breaks are kept because
+ * these titles are short and their two halves are chosen, not discovered --
+ * but a caller that reads "the area wraps on characters" should know it is
+ * reading this line, not a property of the widget.
+ */
+nbgl_text_area_t* generic_screen_set_top_title(void) {
+    nbgl_text_area_t* textArea =
+        (nbgl_text_area_t*)nbgl_objPoolGet(TEXT_AREA, 0);
+    textArea->textColor = BLACK;
+    textArea->text = "";
+    textArea->textAlignment = CENTER;
+    textArea->fontId = LARGE_MEDIUM_FONT;
+    textArea->obj.area.width = SCREEN_WIDTH - 2 * BORDER_MARGIN;
+    textArea->obj.area.height =
+        nbgl_getTextHeight(textArea->fontId, textArea->text);
+    textArea->style = NO_STYLE;
+    textArea->obj.alignment = TOP_MIDDLE;
+    textArea->obj.alignTo = NULL;
+    textArea->obj.alignmentMarginX = 0;
+    textArea->obj.alignmentMarginY = BACK_BUTTON_HEADER_HEIGHT;
+    return textArea;
+}
+
 void generic_screen_configure_buttons(nbgl_button_t** buttons,
                                       const size_t size) {
     nbgl_button_t* button;

--- a/src/nbgl/layout_generic_screen.h
+++ b/src/nbgl/layout_generic_screen.h
@@ -21,6 +21,7 @@
 
 nbgl_image_t *generic_screen_set_icon(const nbgl_icon_details_t *icon);
 nbgl_text_area_t *generic_screen_set_title(nbgl_obj_t *align_to);
+nbgl_text_area_t *generic_screen_set_top_title(void);
 void generic_screen_configure_buttons(nbgl_button_t **buttons, const size_t size);
 nbgl_button_t *generic_screen_set_back_button();
 

--- a/src/nbgl/ui.c
+++ b/src/nbgl/ui.c
@@ -81,9 +81,33 @@ static char keypadTitle[KEYPAD_TITLE_SIZE] = {0};
 
 unsigned int tool_type;
 
+/*
+ * What the user picked from the menu. tool_type says which of the three kinds
+ * of data is being entered and is what compare_recovery_phrase() dispatches
+ * on; this says what it is being entered for, which the tool cannot express:
+ * checking a phrase and backing one up are both TOOL_TYPE_BIP39.
+ *
+ * Defaulted to the first entry so that no screen reads it unset. Every path
+ * to a screen that consults it goes through select_menu_callback(), which
+ * writes it.
+ *
+ * volatile, and for one reason: the bound in display_check_result_page()
+ * disappears without it. Every write to this variable in this file is a
+ * constant between 0 and 3 and the variable is static, so the compiler proves
+ * `user_intent < USER_INTENT_NB` and folds the check away -- measured: _etext
+ * was byte-identical on all three touch targets with the bound present and
+ * with it removed. What the bound is there for is a byte that changed without
+ * anyone writing it, which is exactly the case that proof excludes. Same
+ * reason `checkpoints` is volatile in compare_recovery_phrase_finish()
+ * (src/common/common_seed.c).
+ */
+static volatile user_intent_e user_intent = USER_INTENT_CHECK;
+
 static void display_home_page(void);
+static void display_select_menu_page(void);
 static void display_check_keyboard_page(void);
 static void display_check_result_page(const bool result);
+static void display_backup_explain_page(void);
 static void display_bip39_select_phrase_length_page(void);
 static void display_generic_review(void);
 static void display_sskr_select_numshares_page(void);
@@ -114,85 +138,122 @@ static void reset_globals() {
 static void on_quit(void) { os_sched_exit(-1); }
 
 /*
- * Select tool type, BIP39 or SSKR
+ * The menu: one entry per intention
  */
-enum __attribute__((packed)) select_tool {
-    SELECT_TOOL_ICON_INDEX = 0,
-    SELECT_TOOL_TEXT_INDEX,
-    SELECT_TOOL_BIP39_INDEX,
-    SELECT_TOOL_SSKR_INDEX,
-    SELECT_TOOL_BIP85_INDEX,
-    SELECT_TOOL_BACK_BUTTON_INDEX,
-    SELECT_TOOL_NB_CHILDREN
+enum __attribute__((packed)) select_menu {
+    SELECT_MENU_TEXT_INDEX = 0,
+    /*
+     * generic_screen_configure_buttons() stacks its buttons upwards from the
+     * bottom of the screen, so the first button child is the *last* line the
+     * user reads. These four are declared in that order -- bottom entry
+     * first -- and named for the intention they carry rather than for where
+     * they sit, which is how the reading order stays Check, Generate,
+     * Recover, Derive from the top without any of the code below depending
+     * on knowing that.
+     */
+    SELECT_MENU_DERIVE_INDEX,
+    SELECT_MENU_RECOVER_INDEX,
+    SELECT_MENU_BACKUP_INDEX,
+    SELECT_MENU_CHECK_INDEX,
+    SELECT_MENU_BACK_BUTTON_INDEX,
+    SELECT_MENU_NB_CHILDREN
 };
 
-static const char* toolType[] = {UI_STR_NBGL_TOOL_BIP39, UI_STR_NBGL_TOOL_SSKR,
-                                 UI_STR_NBGL_TOOL_BIP85};
-static void select_tool_callback(nbgl_obj_t* obj, nbgl_touchType_t eventType) {
+// One button per intention. Asserted against the enumeration rather than
+// counted by hand, because this number is what nbgl_objPoolGetArray() below
+// writes into consecutive children: a value smaller than the run of button
+// indices leaves an unallocated child, a larger one runs into the back
+// button.
+#define SELECT_MENU_NB_BUTTONS 4
+_Static_assert(SELECT_MENU_BACK_BUTTON_INDEX - SELECT_MENU_DERIVE_INDEX ==
+                   SELECT_MENU_NB_BUTTONS,
+               "the menu allocates SELECT_MENU_NB_BUTTONS buttons into the "
+               "children between SELECT_MENU_DERIVE_INDEX and the back "
+               "button; adding an entry means changing both");
+_Static_assert(USER_INTENT_NB == SELECT_MENU_NB_BUTTONS,
+               "the menu shows one entry per intention");
+
+static void select_menu_callback(nbgl_obj_t* obj, nbgl_touchType_t eventType) {
     nbgl_obj_t** screenChildren = nbgl_screenGetElements(0);
     if (eventType != TOUCHED) {
         return;
     }
     io_seproxyhal_play_tune(TUNE_TAP_CASUAL);
     nbgl_layoutRelease(layout);
-    if (obj == screenChildren[SELECT_TOOL_BIP39_INDEX]) {
+    // Each entry sets both: the intention, and the kind of data the screens
+    // it leads to will be handed. Checking a phrase and backing one up are
+    // the same tool and different intentions, which is the whole reason the
+    // two are separate variables.
+    if (obj == screenChildren[SELECT_MENU_CHECK_INDEX]) {
+        user_intent = USER_INTENT_CHECK;
         tool_type = TOOL_TYPE_BIP39;
         display_bip39_select_phrase_length_page();
-    } else if (obj == screenChildren[SELECT_TOOL_SSKR_INDEX]) {
+    } else if (obj == screenChildren[SELECT_MENU_BACKUP_INDEX]) {
+        user_intent = USER_INTENT_BACKUP;
+        tool_type = TOOL_TYPE_BIP39;
+        display_backup_explain_page();
+    } else if (obj == screenChildren[SELECT_MENU_RECOVER_INDEX]) {
+        user_intent = USER_INTENT_RECOVER;
         tool_type = TOOL_TYPE_SSKR;
         display_check_keyboard_page();
-    } else if (obj == screenChildren[SELECT_TOOL_BIP85_INDEX]) {
+    } else if (obj == screenChildren[SELECT_MENU_DERIVE_INDEX]) {
+        user_intent = USER_INTENT_DERIVE;
         tool_type = TOOL_TYPE_BIP85;
         display_bip85_select_app_page();
-    } else if (obj == screenChildren[SELECT_TOOL_BACK_BUTTON_INDEX]) {
+    } else if (obj == screenChildren[SELECT_MENU_BACK_BUTTON_INDEX]) {
         display_home_page();
         return;
     }
 }
 
-static void display_select_tool_page(void) {
+static void display_select_menu_page(void) {
     nbgl_obj_t** screenChildren;
 
     // From top to bottom:
-    // <return back arrow> + <icon> + <text> + <3 buttons>
-    nbgl_screenSet(&screenChildren, SELECT_TOOL_NB_CHILDREN, NULL,
-                   (nbgl_touchCallback_t)&select_tool_callback);
+    // <return back arrow> + <text> + <4 buttons>
+    //
+    // No icon, where the three-entry menu had the application's. Two reasons,
+    // both checked rather than preferred:
+    //
+    //   - there is no room. On apex_p a button is 56px on a 400px screen and
+    //     the stack starts BORDER_MARGIN from the bottom, so the fourth one
+    //     occupies y=136 to 192, and the icon and the title together ran from
+    //     74 to 200. The title alone, hung under the back button, ends well
+    //     above it;
+    //   - the icons this repository has name formats -- icon_bip39,
+    //     icon_sskr, icon_bip85 -- while these entries name intentions.
+    //     Generate and Recover would both have taken icon_sskr, which is
+    //     exactly what the previous menu did to its BIP85 entry: it wore the
+    //     SSKR icon, so two of three buttons were illustrated identically.
+    //
+    // No emphasised button either. The black button of an NBGL screen is its
+    // primary action, and these four are peers.
+    nbgl_screenSet(&screenChildren, SELECT_MENU_NB_CHILDREN, NULL,
+                   (nbgl_touchCallback_t)&select_menu_callback);
 
-    screenChildren[SELECT_TOOL_ICON_INDEX] =
-        (nbgl_obj_t*)generic_screen_set_icon(&ICON_APP_HOME);
-    screenChildren[SELECT_TOOL_TEXT_INDEX] =
-        (nbgl_obj_t*)generic_screen_set_title(
-            screenChildren[SELECT_TOOL_ICON_INDEX]);
-    ((nbgl_text_area_t*)screenChildren[SELECT_TOOL_TEXT_INDEX])->text =
-        UI_STR_NBGL_SELECT_TOOL_TITLE;
-    // create nb words buttons
+    screenChildren[SELECT_MENU_TEXT_INDEX] =
+        (nbgl_obj_t*)generic_screen_set_top_title();
+    ((nbgl_text_area_t*)screenChildren[SELECT_MENU_TEXT_INDEX])->text =
+        UI_STR_NBGL_MENU_TITLE;
+
     nbgl_objPoolGetArray(
-        BUTTON, ARRAYLEN(toolType), 0,
-        (nbgl_obj_t**)&screenChildren[SELECT_TOOL_BIP39_INDEX]);
+        BUTTON, SELECT_MENU_NB_BUTTONS, 0,
+        (nbgl_obj_t**)&screenChildren[SELECT_MENU_DERIVE_INDEX]);
     generic_screen_configure_buttons(
-        (nbgl_button_t**)&screenChildren[SELECT_TOOL_BIP39_INDEX],
-        ARRAYLEN(toolType));
-    ((nbgl_button_t*)screenChildren[SELECT_TOOL_BIP39_INDEX])->text =
-        toolType[0];
-    ((nbgl_button_t*)screenChildren[SELECT_TOOL_BIP39_INDEX])->icon =
-        &BIP39_ICON_SMALL;
-    ((nbgl_button_t*)screenChildren[SELECT_TOOL_SSKR_INDEX])->text =
-        toolType[1];
-    ((nbgl_button_t*)screenChildren[SELECT_TOOL_SSKR_INDEX])->icon =
-        &SSKR_ICON_SMALL;
-    ((nbgl_button_t*)screenChildren[SELECT_TOOL_SSKR_INDEX])->borderColor =
-        BLACK;
-    ((nbgl_button_t*)screenChildren[SELECT_TOOL_SSKR_INDEX])->innerColor =
-        BLACK;
-    ((nbgl_button_t*)screenChildren[SELECT_TOOL_SSKR_INDEX])->foregroundColor =
-        WHITE;
-    ((nbgl_button_t*)screenChildren[SELECT_TOOL_BIP85_INDEX])->text =
-        toolType[2];
-    ((nbgl_button_t*)screenChildren[SELECT_TOOL_BIP85_INDEX])->icon =
-        &SSKR_ICON_SMALL;
+        (nbgl_button_t**)&screenChildren[SELECT_MENU_DERIVE_INDEX],
+        SELECT_MENU_NB_BUTTONS);
+
+    ((nbgl_button_t*)screenChildren[SELECT_MENU_CHECK_INDEX])->text =
+        UI_STR_NBGL_MENU_CHECK;
+    ((nbgl_button_t*)screenChildren[SELECT_MENU_BACKUP_INDEX])->text =
+        UI_STR_NBGL_MENU_BACKUP;
+    ((nbgl_button_t*)screenChildren[SELECT_MENU_RECOVER_INDEX])->text =
+        UI_STR_NBGL_MENU_RECOVER;
+    ((nbgl_button_t*)screenChildren[SELECT_MENU_DERIVE_INDEX])->text =
+        UI_STR_NBGL_MENU_DERIVE;
 
     // create back button
-    screenChildren[SELECT_TOOL_BACK_BUTTON_INDEX] =
+    screenChildren[SELECT_MENU_BACK_BUTTON_INDEX] =
         (nbgl_obj_t*)generic_screen_set_back_button();
 
     nbgl_screenRedraw();
@@ -222,22 +283,34 @@ void display_select_recover_bip39_page(void) {
 }
 
 /*
- * Select Generate SSKR
+ * Backing up: why the phrase is asked for first
+ *
+ * The one screen this change adds to the path the user walks. "Generate
+ * backup shares" leads here, and here explains why an application running on
+ * a device that already holds the phrase is about to ask for twenty-four
+ * words -- compare_recovery_phrase() gets a seed back from the device, never
+ * the words, so the words have to come from the person.
+ *
+ * It takes the place of "Generate SSKR Phrase?", which used to sit *after*
+ * the verdict and ask whether to do the thing the user had not asked for.
+ * Declining still lands on the home page, and still through
+ * display_home_page(), which is what calls reset_globals(); nothing is entered
+ * yet at this point.
  */
-static void select_generate_sskr_choice(bool sskr_gen) {
+static void backup_explain_choice(bool proceed) {
     nbgl_layoutRelease(layout);
-    if (sskr_gen) {
-        display_sskr_select_numshares_page();
+    if (proceed) {
+        display_bip39_select_phrase_length_page();
     } else {
         display_home_page();
     }
 }
 
-void display_select_generate_sskr_page(void) {
-    nbgl_useCaseChoice(&SSKR_ICON, UI_STR_NBGL_GENERATE_SSKR_TITLE,
-                       UI_STR_NBGL_GENERATE_SSKR_DESC,
-                       UI_STR_NBGL_GENERATE_SSKR_CONFIRM, UI_STR_NBGL_CANCEL,
-                       select_generate_sskr_choice);
+static void display_backup_explain_page(void) {
+    nbgl_useCaseChoice(&SSKR_ICON, UI_STR_NBGL_BACKUP_EXPLAIN_TITLE,
+                       UI_STR_NBGL_BACKUP_EXPLAIN_DESC,
+                       UI_STR_NBGL_BACKUP_EXPLAIN_CONFIRM, UI_STR_NBGL_CANCEL,
+                       backup_explain_choice);
 }
 
 /*
@@ -274,18 +347,53 @@ static void select_bip39_phrase_length_callback(nbgl_obj_t* obj,
         bip39_mnemonic_final_size_set(BIP39_MNEMONIC_SIZE_24);
     } else if (obj ==
                screenChildren[SELECT_BIP39_PHRASE_LENGTH_BACK_BUTTON_INDEX]) {
-        if (tool_type == TOOL_TYPE_BIP85) {
-            display_bip85_select_app_page();
-        } else {
-            display_select_tool_page();
+        // Back goes to whatever asked for this screen, which is now three
+        // different things. Written on the intention rather than on the tool
+        // because Check and Backup share the tool and do not share a caller.
+        switch (user_intent) {
+            case USER_INTENT_DERIVE:
+                display_bip85_select_app_page();
+                break;
+            case USER_INTENT_BACKUP:
+                display_backup_explain_page();
+                break;
+            case USER_INTENT_CHECK:
+            case USER_INTENT_RECOVER:
+            case USER_INTENT_NB:
+                // Recover enters ByteWords and never chooses a BIP-39 length;
+                // it is grouped with Check so that this switch stays
+                // exhaustive and a new intention is a -Wswitch diagnostic
+                // rather than a silent fall onto someone else's back button.
+                display_select_menu_page();
+                break;
         }
         return;
     }
-    if (tool_type == TOOL_TYPE_BIP85) {
+    if (user_intent == USER_INTENT_DERIVE) {
         display_bip85_select_index_page();
     } else {
         display_check_keyboard_page();
     }
+}
+
+// Three intentions reach the length screen and two questions are asked on it.
+// Check and Backup both type in a phrase that already exists, so both ask how
+// long it is; Derive asks how long a phrase to produce. The ternary that used
+// to do this had two branches because it had two callers.
+static const char* bip39_length_title(void) {
+    switch (user_intent) {
+        case USER_INTENT_CHECK:
+        case USER_INTENT_BACKUP:
+            return UI_STR_NBGL_BIP39_LENGTH_TITLE_CHECK;
+        case USER_INTENT_DERIVE:
+            return UI_STR_NBGL_BIP39_LENGTH_TITLE_DERIVE;
+        case USER_INTENT_RECOVER:
+        case USER_INTENT_NB:
+            break;
+    }
+    // Recover does not come here; the question it would be asked is still the
+    // one about a phrase being typed in, not one being produced.
+    return UI_STR_NBGL_BIP39_LENGTH_TITLE_CHECK;
 }
 
 static void display_bip39_select_phrase_length_page(void) {
@@ -303,9 +411,7 @@ static void display_bip39_select_phrase_length_page(void) {
         (nbgl_obj_t*)generic_screen_set_title(
             screenChildren[SELECT_BIP39_PHRASE_LENGTH_ICON_INDEX]);
     ((nbgl_text_area_t*)screenChildren[SELECT_BIP39_PHRASE_LENGTH_TEXT_INDEX])
-        ->text = tool_type == TOOL_TYPE_BIP39
-                     ? UI_STR_NBGL_BIP39_LENGTH_TITLE_CHECK
-                     : UI_STR_NBGL_BIP39_LENGTH_TITLE_DERIVE;
+        ->text = bip39_length_title();
     // create nb words buttons
     nbgl_objPoolGetArray(BUTTON, ARRAYLEN(bip39_passphraseLength), 0,
                          (nbgl_obj_t**)&screenChildren
@@ -471,7 +577,7 @@ static void sskr_keyboard_dispatcher(const int token, uint8_t index) {
             display_check_keyboard_page();
         } else {
             sskr_shares_reset();
-            display_select_tool_page();
+            display_select_menu_page();
         }
     } else if (token >= CHECK_FIRST_SUGGESTION_TOKEN) {
         // The length only, as above: these are the ByteWords of the shares.
@@ -554,7 +660,7 @@ static void display_home_page() {
     reset_globals();
 
     nbgl_homeAction_t action = {.text = UI_STR_NBGL_HOME_ACTION,
-                                .callback = PIC(display_select_tool_page)};
+                                .callback = PIC(display_select_menu_page)};
 
     nbgl_useCaseHomeAndSettings(APPNAME, &ICON_APP_HOME,
                                 UI_STR_NBGL_HOME_DESCRIPTION, INIT_HOME_PAGE,
@@ -586,31 +692,87 @@ static void display_home_page() {
  */
 static void check_result_callback(int token __attribute__((unused)),
                                   uint8_t index __attribute__((unused))) {
-    if (tool_type == TOOL_TYPE_BIP39 && bip39_mnemonic_check(&seed_match) &&
-        seed_match) {
-        display_select_generate_sskr_page();
-    } else if (tool_type == TOOL_TYPE_SSKR && sskr_shares_check(&seed_match)) {
-        display_select_recover_bip39_page();
-    } else {
-        reset_globals();
-        display_home_page();
+    // Where the verdict leads, per intention. Only the two flows that have
+    // somewhere to go re-run the check; the others fall through to the home
+    // page below. Written as a switch with no default so that a fifth
+    // intention has to say here what it does after a verdict, rather than
+    // inheriting "go home" from a branch nobody wrote for it.
+    switch (user_intent) {
+        case USER_INTENT_BACKUP:
+            if (bip39_mnemonic_check(&seed_match) && seed_match) {
+                display_sskr_select_numshares_page();
+                return;
+            }
+            break;
+        case USER_INTENT_RECOVER:
+            if (sskr_shares_check(&seed_match)) {
+                display_select_recover_bip39_page();
+                return;
+            }
+            break;
+        case USER_INTENT_CHECK:
+        case USER_INTENT_DERIVE:
+        case USER_INTENT_NB:
+            // Check ends here -- that is what makes it a destination. Derive
+            // never reaches this screen at all.
+            break;
     }
+    reset_globals();
+    display_home_page();
 }
 
+// The three answers this screen gives. An index into the tables below, and
+// nothing else: what used to sit here was 1 + tool_type * 2 + seed_match into
+// a five-element row, an arithmetic on an enumeration value that a fourth
+// tool type would have walked off the end of, guarded by a test naming the
+// two values that were safe.
+enum __attribute__((packed)) verdict_outcome {
+    OUTCOME_INVALID = 0,
+    OUTCOME_NOMATCH,
+    OUTCOME_MATCH,
+    OUTCOME_NB
+};
+
+/*
+ * What the verdict says, per intention and per outcome.
+ *
+ * Two intentions enter a BIP-39 phrase and read different things here: the
+ * check flow ends on this screen, the backup flow passes through it, and
+ * "doesn't match the one present on this Ledger device" is a complete answer
+ * only to the first. The row is the wording, the column is the answer.
+ *
+ * USER_INTENT_DERIVE has no row. The BIP85 flow goes to
+ * display_generic_review() and never asks for a verdict, so there is nothing
+ * true to put there; leaving it NULL means that a path which did arrive here
+ * with it would draw a title over an empty body -- visibly wrong on screen --
+ * instead of borrowing a sentence about a phrase it never compared.
+ */
+_Static_assert(USER_INTENT_NB == 4,
+               "verdict_body[] has one row per intention and the backup row "
+               "does not say what the check row says on the same tool; a new "
+               "intention needs a decision here, not a default row");
+static const char* const verdict_body[USER_INTENT_NB][OUTCOME_NB] = {
+    [USER_INTENT_CHECK] = {UI_STR_NBGL_RESULT_BIP39_INVALID,
+                           UI_STR_NBGL_RESULT_BIP39_NOMATCH,
+                           UI_STR_NBGL_RESULT_BIP39_MATCH},
+    [USER_INTENT_BACKUP] = {UI_STR_NBGL_RESULT_BIP39_INVALID,
+                            UI_STR_NBGL_RESULT_BACKUP_NOMATCH,
+                            UI_STR_NBGL_RESULT_BACKUP_MATCH},
+    [USER_INTENT_RECOVER] = {UI_STR_NBGL_RESULT_SSKR_INVALID,
+                             UI_STR_NBGL_RESULT_SSKR_NOMATCH,
+                             UI_STR_NBGL_RESULT_SSKR_MATCH},
+};
+
 static void display_check_result_page(const bool result) {
-    static const char* possible_results[2][5] = {
-        {NULL, UI_STR_NBGL_RESULT_BIP39_INVALID, "",
-         UI_STR_NBGL_RESULT_SSKR_INVALID, ""},
-        {NULL, UI_STR_NBGL_RESULT_BIP39_NOMATCH, UI_STR_NBGL_RESULT_BIP39_MATCH,
-         UI_STR_NBGL_RESULT_SSKR_NOMATCH, UI_STR_NBGL_RESULT_SSKR_MATCH}};
     // Three distinct outcomes -- invalid, doesn't match, matches -- each with
     // its own title and icon, matching what the BAGL flows
-    // (ux_bip39_invalid_flow / ux_bip39_nomatch_flow / ux_bip39_match_flow
-    // and their SSKR equivalents) already give the user.
-    static const char* const titles[3] = {UI_STR_NBGL_RESULT_INVALID_TITLE,
-                                          UI_STR_NBGL_RESULT_NOMATCH_TITLE,
-                                          UI_STR_NBGL_RESULT_VALID_TITLE};
-    static const nbgl_icon_details_t* icons[3] = {
+    // (ux_bip39_invalid_flow / ux_bip39_check_nomatch_flow /
+    // ux_bip39_check_match_flow and their SSKR equivalents) already give the
+    // user.
+    static const char* const titles[OUTCOME_NB] = {
+        UI_STR_NBGL_RESULT_INVALID_TITLE, UI_STR_NBGL_RESULT_NOMATCH_TITLE,
+        UI_STR_NBGL_RESULT_VALID_TITLE};
+    static const nbgl_icon_details_t* const icons[OUTCOME_NB] = {
         &DENIED_CIRCLE_ICON, &IMPORTANT_CIRCLE_ICON, &CHECK_CIRCLE_ICON};
 
     // result is false only when the phrase itself is not well formed, in
@@ -618,22 +780,29 @@ static void display_check_result_page(const bool result) {
     // 0, 1 or 2, indexing the invalid / nomatch / match outcome respectively.
     const uint8_t outcome = (uint8_t)(result + seed_match);
 
-    // The text index is 1 + tool_type * 2 + seed_match into a five-element row.
-    // TOOL_TYPE_BIP39 and TOOL_TYPE_SSKR give 1..4; TOOL_TYPE_BIP85, the third
-    // value of that enumeration (constants.h), would give 5 or 6 and read past
-    // the row. No path reaches this screen with the BIP85 tool selected -- that
-    // flow goes to display_generic_review() and never asks for a verdict -- so
-    // this is a bound on an index the screens cannot currently produce, not a
-    // fix for one they can.
-    const uint8_t text_index =
-        (tool_type == TOOL_TYPE_BIP39 || tool_type == TOOL_TYPE_SSKR)
-            ? (uint8_t)(1 + (tool_type * 2) + seed_match)
-            : 1;
+    // The row index, bounded at run time and not only at compile time.
+    //
+    // The static assertion on verdict_body[] says a new intention has to be
+    // given a row. It says nothing about a byte that is not an intention at
+    // all: user_intent is a packed enum, one byte of static RAM, and this is
+    // the only array in this file indexed by it. USER_INTENT_NB is itself out
+    // of range and is a case label in three switches, so it is a value the
+    // code already handles rather than one nothing can hold.
+    //
+    // The arithmetic this table replaced carried such a bound -- it clamped
+    // to 1 for any tool_type outside the two it named -- and dropping it in
+    // exchange for compile-time assertions would be a step back in a file
+    // whose verdict is deliberately hardened against a single fault
+    // (compare_recovery_phrase_finish(), src/common/common_seed.c). Out of
+    // range reads as a check, which is the flow that ends here and shows the
+    // least.
+    const user_intent_e wording =
+        (user_intent < USER_INTENT_NB) ? user_intent : USER_INTENT_CHECK;
 
     nbgl_pageInfoDescription_t info = {
         .centeredInfo.icon = icons[outcome],
         .centeredInfo.text1 = titles[outcome],
-        .centeredInfo.text2 = possible_results[result][text_index],
+        .centeredInfo.text2 = verdict_body[wording][outcome],
         // Advice only on the invalid outcome; NULL elsewhere.
         // LARGE_CASE_GRAY_INFO is required for this to render as its own gray
         // line -- see the comment on UI_STR_NBGL_RESULT_INVALID_ADVICE in
@@ -641,7 +810,13 @@ static void display_check_result_page(const bool result) {
         .centeredInfo.text3 = result ? NULL : UI_STR_NBGL_RESULT_INVALID_ADVICE,
         .centeredInfo.style = LARGE_CASE_GRAY_INFO,
         .centeredInfo.offsetY = -16,
-        .footerText = UI_STR_NBGL_RESULT_TAP_TO_DISMISS,
+        // Only one of the six screens this draws continues rather than ends:
+        // a phrase that matched, in the backup flow. A failure in that flow
+        // is still a full stop, and still says so.
+        .footerText =
+            (user_intent == USER_INTENT_BACKUP && outcome == OUTCOME_MATCH)
+                ? UI_STR_NBGL_RESULT_TAP_TO_CONTINUE
+                : UI_STR_NBGL_RESULT_TAP_TO_DISMISS,
         .footerToken = CHECK_RESULT_TOKEN,
         .bottomButtonStyle = NO_BUTTON_STYLE,
         .tapActionText = NULL,
@@ -700,19 +875,24 @@ static void sskr_sharenum_validate(const uint8_t* sharenumentry,
     if (sskr_sharenum_get() > 0 && sskr_sharenum_get() <= SSS_MAX_SHARE_COUNT) {
         display_sskr_select_threshold_page();
     } else {
-        // Back to this keypad, not to the "Generate SSKR Phrase?" offer that
-        // opens the flow: the only thing wrong is the number that was just
-        // typed, and it is the only thing worth asking for again.
+        // Back to this keypad, not to the head of the flow: the only thing
+        // wrong is the number that was just typed, and it is the only thing
+        // worth asking for again.
         nbgl_useCaseStatus(UI_STR_NBGL_SSKR_NUMSHARES_RANGE_ERROR, false,
                            display_sskr_select_numshares_page);
     }
 }
 
 void display_sskr_select_numshares_page() {
-    // Draw the keypad
-    nbgl_useCaseKeypad(
-        UI_STR_NBGL_SSKR_NUMSHARES_TITLE, 1, SSKR_MAX_NUMBER_LENGTH, false,
-        false, sskr_sharenum_validate, display_select_generate_sskr_page);
+    // The back arrow leaves for the home page rather than for the screen
+    // before, which is the verdict on a phrase that has just been typed and
+    // cannot be usefully drawn again. Leaving is also the only thing worth
+    // doing at that point, and display_home_page() calls reset_globals(): the
+    // phrase in RAM is erased in one gesture, where the "Generate SSKR
+    // Phrase?" offer this used to return to took two.
+    nbgl_useCaseKeypad(UI_STR_NBGL_SSKR_NUMSHARES_TITLE, 1,
+                       SSKR_MAX_NUMBER_LENGTH, false, false,
+                       sskr_sharenum_validate, display_home_page);
 }
 
 static void review_done(void) {
@@ -800,13 +980,13 @@ static void sskr_threshold_validate(const uint8_t* thresholdentry,
     PRINTF("Threshold value entered is '%d'\n", sskr_threshold_get());
 
     // All three send the user back to this same keypad rather than to the
-    // "Generate SSKR Phrase?" offer at the head of the flow. The share count
-    // entered on the previous screen is valid, was accepted, and is not what
-    // is being corrected -- returning to the offer threw it away and made it
-    // be typed again before the threshold could be fixed. Nothing on this path
-    // resets it: reset_globals() and sskr_shares_reset() are reached only from
-    // display_home_page(), review_done() and the check flow, none of which any
-    // of these three branches goes through.
+    // head of the flow. The share count entered on the previous screen is
+    // valid, was accepted, and is not what is being corrected -- returning to
+    // the head threw it away and made it be typed again before the threshold
+    // could be fixed. Nothing on this path resets it: reset_globals() and
+    // sskr_shares_reset() are reached only from display_home_page(),
+    // review_done() and the check flow, none of which any of these three
+    // branches goes through.
     if (sskr_threshold_get() < 1) {
         nbgl_useCaseStatus(UI_STR_NBGL_SSKR_THRESHOLD_ZERO_ERROR, false,
                            display_sskr_select_threshold_page);
@@ -1058,7 +1238,7 @@ static void select_bip85_app_callback(nbgl_obj_t* obj,
         bip85_type_set(BIP85_APP_PWD_BASE85);
         display_bip85_select_password_length_page();
     } else if (obj == screenChildren[SELECT_BIP85_APP_BACK_BUTTON_INDEX]) {
-        display_select_tool_page();
+        display_select_menu_page();
         return;
     } else {
         display_home_page();

--- a/tests/functional/genericlayout.py
+++ b/tests/functional/genericlayout.py
@@ -3,33 +3,66 @@ from ledgered.devices import DeviceType
 from ragger.firmware.touch.positions import POSITIONS, Position, STAX_X_CENTER, FLEX_X_CENTER, APEX_P_X_CENTER
 from ragger.firmware.touch.element import Element
 
+# Positions are counted from the *bottom* of the screen, because that is the
+# order generic_screen_configure_buttons() (src/nbgl/layout_generic_screen.c)
+# lays the buttons out in: child i sits (BUTTON_DIAMETER + 8) * i above the
+# bottom margin, so child 0 is the lowest one on screen and the last one read.
+#
+# The fourth entry is new with the four-intention menu. Its coordinate is the
+# same arithmetic the three above already follow -- one button pitch higher --
+# and it was checked against what Speculos actually draws rather than assumed:
+# the buttons report y=153/217/281/345 on apex_p, 218/314/410/506 on flex.
 GENERIC_LAYOUT_POSITIONS = {
     "GenericLayout": {
         DeviceType.STAX: {
-            # Up to 3 choices in a list
+            # Up to 4 choices in a list, lowest first
             1: Position(STAX_X_CENTER, 620),
             2: Position(STAX_X_CENTER, 520),
-            3: Position(STAX_X_CENTER, 420)
+            3: Position(STAX_X_CENTER, 420),
+            4: Position(STAX_X_CENTER, 340)
         },
         DeviceType.FLEX: {
-            # Up to 3 choices in a list
+            # Up to 4 choices in a list, lowest first
             1: Position(FLEX_X_CENTER, 540),
             2: Position(FLEX_X_CENTER, 430),
-            3: Position(FLEX_X_CENTER, 320)
+            3: Position(FLEX_X_CENTER, 320),
+            4: Position(FLEX_X_CENTER, 236)
         },
         DeviceType.APEX_P: {
-            # Up to 3 choices in a list
+            # Up to 4 choices in a list, lowest first
             1: Position(APEX_P_X_CENTER, 350),
             2: Position(APEX_P_X_CENTER, 290),
-            3: Position(APEX_P_X_CENTER, 230)
+            3: Position(APEX_P_X_CENTER, 230),
+            4: Position(APEX_P_X_CENTER, 164)
         }
     }
 }
 
 POSITIONS.update(GENERIC_LAYOUT_POSITIONS)
 
+# The four entries of the menu, in the order they are read from the top, and
+# the position each one occupies counting from the bottom.
+#
+# Written out rather than computed, and named rather than numbered. The screen
+# and the layout disagree about which end of the list comes first, so a bare
+# choose(2) on this screen is a claim about the layout that nothing in the
+# test would check; MENU_BACKUP at least names the entry it means.
+#
+# Naming it does not verify it. A caller waits for the label to be somewhere
+# on screen and then touches a coordinate, so a table shifted by one row would
+# satisfy the wait, touch the wrong entry, and fail several screens later with
+# an unrelated message. What holds the mapping is
+# test_menu_positions.py::test_each_entry_opens_what_it_names, which touches
+# each constant and asserts the screen it arrives on.
+MENU_CHECK = 4
+MENU_BACKUP = 3
+MENU_RECOVER = 2
+MENU_DERIVE = 1
+
+
 class GenericLayout(Element):
 
     def choose(self, index: int):
-        assert 1 <= index <= 3, "Choice index must be in [1, 3]"
+        """Touch the index-th button counting up from the bottom of the list."""
+        assert 1 <= index <= 4, "Choice index must be in [1, 4]"
         self.client.finger_touch(*self.positions[index])

--- a/tests/functional/nano.py
+++ b/tests/functional/nano.py
@@ -127,7 +127,7 @@ def select_in_menu(navigator, label, timeout=30):
     `screen_change_before_first_instruction` has to be off, as it is at every
     call site in this repository: the entry the caller is after is often
     already displayed when this is called -- the home screen opens on
-    "Check BIP39" -- and waiting for a screen change that nobody is going to
+    "Check phrase" -- and waiting for a screen change that nobody is going to
     cause times out.
     """
     navigator.navigate_until_text(NavInsID.RIGHT_CLICK, [NavInsID.BOTH_CLICK],
@@ -140,10 +140,11 @@ def choose_in_flow(backend, label, timeout_clicks=None):
 
     select_in_menu() above is Ragger's navigate_until_text(), which is right
     for a menu list: those loop, so a click always changes the screen. The
-    verdict flows do not loop -- ux_bip39_match_flow and its neighbours in
-    src/bagl/ux_nano.c are three fixed steps -- so a right click on the last
-    one changes nothing, and navigate_until_text() cannot tell that from a
-    screen that has stopped responding. It reports the second as the first.
+    verdict flows do not loop -- ux_bip39_check_match_flow and its neighbours
+    in src/bagl/ux_nano.c are two or three fixed steps -- so a right click on
+    the last one changes nothing, and navigate_until_text() cannot tell that
+    from a screen that has stopped responding. It reports the second as the
+    first.
 
     _click() returns whether anything moved, which is what makes the
     difference visible here.

--- a/tests/functional/test_backup_from_menu.py
+++ b/tests/functional/test_backup_from_menu.py
@@ -1,0 +1,163 @@
+"""
+Generating a backup, asked for at the menu.
+
+This is the path the four-intention menu adds, and no test in this directory
+could reach it before, because it did not exist: share generation was offered
+only by check_result_callback() (src/nbgl/ui.c), and only when the tool was
+BIP39, the phrase was well formed, and it matched the device. Someone who came
+to back up a phrase had to check it first, succeed, and then accept an offer
+they had not asked for -- and nothing in the menu said any of that was there.
+
+Three claims, and the second and third are what make the first mean something.
+
+  * the flow is reachable from the menu and gets as far as the share count;
+  * a phrase that is well formed but is *not* this device's stops at the
+    verdict and never reaches the share count -- the entry point is new, the
+    guard in front of the shares is not, and this is what says so;
+  * checking a phrase no longer leads there at all. That was the only door
+    before; it is now a destination, and the offer that used to sit behind it
+    is gone.
+
+The second and third also pin the wording apart. The same screen, reached
+from two different entries with the same correct phrase, says two different
+things -- "matches the one present on this Ledger device" when the question
+was whether it matches, "This is the recovery phrase on this Ledger device.
+It can be split into shares." when the question was whether it can be backed
+up -- and the footer follows: one screen ends, the other continues. Asserting
+only one of the two would pass on a build that had lost the distinction.
+
+Text is matched with re.match against each rendered line on its own (ragger's
+SpeculosBackend), so every string below is a prefix of one drawn line, not a
+fragment of a sentence spanning two. Where a line was chosen it was read off
+Speculos rather than guessed: the three touch devices wrap these bodies at
+exactly the same words.
+"""
+
+from pytest import fixture
+from pytest import mark
+from pytest import skip
+from ledgered.devices import DeviceType
+from ragger.conftest import configuration
+from ragger.firmware.touch.use_cases import UseCaseHomeExt, UseCaseChoice
+from ragger.firmware.touch.layouts import CenteredFooter, LetterOnlyKeyboard, Suggestions
+from genericlayout import GenericLayout, MENU_BACKUP, MENU_CHECK
+
+# https://github.com/BlockchainCommons/crypto-commons/blob/master/Docs/sskr-test-vector.md#128-bit-seed
+DEVICE_PHRASE = "fly mule excess resource treat plunge nose soda reflect adult ramp planet"
+
+# Valid, correct checksum, and not the device's -- the same phrase
+# test_bip39_seed_match.py uses for the mismatch case.
+OTHER_PHRASE = "girl mad pet galaxy egg matter matrix prison refuse sense ordinary nose"
+
+
+@fixture(scope='session')
+def set_seed():
+    configuration.OPTIONAL.CUSTOM_SEED = DEVICE_PHRASE
+
+
+def _touch_only(device):
+    if device.type not in (DeviceType.STAX, DeviceType.FLEX, DeviceType.APEX_P):
+        skip("The four-intention menu is the touch stack's; the Nano menu is "
+             "covered by the two-button tests")
+
+
+def _enter(backend, device, phrase):
+    keyboard = LetterOnlyKeyboard(backend, device)
+    suggestion = Suggestions(backend, device)
+    for word in phrase.split():
+        keyboard.write(word[:4])
+        suggestion.choose(1)
+
+
+def _walk_to_verdict(backend, device, entry, phrase):
+    """Menu -> the chosen entry -> a 12-word phrase -> the verdict screen."""
+    home_page = UseCaseHomeExt(backend, device)
+    genericbuttons = GenericLayout(backend, device)
+    choice = UseCaseChoice(backend, device)
+
+    backend.wait_for_text_on_screen("Seed Tool", 10)
+    home_page.action()
+    backend.wait_for_text_on_screen("Check recovery phrase", 5)
+    backend.wait_for_text_on_screen("Generate backup shares", 1)
+    genericbuttons.choose(entry)
+
+    if entry == MENU_BACKUP:
+        # The screen this change adds. Its first body line is the reason the
+        # phrase is being asked for at all, which is the whole point of the
+        # screen; asserting the title alone would pass on an empty one.
+        backend.wait_for_text_on_screen("Enter your recovery", 5)
+        backend.wait_for_text_on_screen("This Ledger cannot read back", 1)
+        choice.confirm()
+
+    backend.wait_for_text_on_screen("12 words", 5)
+    genericbuttons.choose(1)
+    backend.wait_for_text_on_screen("Enter word", 5)
+    _enter(backend, device, phrase)
+
+
+@mark.use_on_backend("speculos")
+def test_backup_reaches_the_share_count_from_the_menu(device, backend, set_seed):
+    _touch_only(device)
+    check_result = CenteredFooter(backend, device)
+
+    _walk_to_verdict(backend, device, MENU_BACKUP, DEVICE_PHRASE)
+
+    # A verdict that continues, and says so. "Tap to continue" is not
+    # decoration: the same screen in the check flow reads "Tap to dismiss",
+    # and test_checking_a_phrase_does_not_lead_to_shares() below asserts that.
+    backend.wait_for_text_on_screen("Valid Secret", 5)
+    backend.wait_for_text_on_screen("This is the recovery phrase", 1)
+    backend.wait_for_text_on_screen("It can be split into shares.", 1)
+    backend.wait_for_text_on_screen("Tap to continue", 1)
+    check_result.tap()
+
+    # Reached without a single screen having offered anything: the user asked
+    # for this at the menu five screens ago.
+    backend.wait_for_text_on_screen("Enter number of SSKR shares", 5)
+
+
+@mark.use_on_backend("speculos")
+def test_backup_stops_on_a_phrase_this_device_cannot_recover(device, backend, set_seed):
+    _touch_only(device)
+    check_result = CenteredFooter(backend, device)
+
+    _walk_to_verdict(backend, device, MENU_BACKUP, OTHER_PHRASE)
+
+    # Well formed, so it got past the checksum, and not this device's, so the
+    # comparison refused it. The sentence is the backup flow's own: "doesn't
+    # match the one present on this Ledger device" answers a question this
+    # user did not ask.
+    backend.wait_for_text_on_screen("Mismatched Secret", 5)
+    backend.wait_for_text_on_screen("You would be backing up", 1)
+    backend.wait_for_text_on_screen("a phrase this Ledger", 1)
+    backend.wait_for_text_on_screen("cannot recover.", 1)
+    # A failure ends the flow, so it is dismissed and not continued.
+    backend.wait_for_text_on_screen("Tap to dismiss", 1)
+    check_result.tap()
+
+    # And it ends at the home page rather than at the share count. This is the
+    # assertion that makes the new entry point safe to have: arriving here is
+    # only possible if check_result_callback() took neither of the two
+    # branches that lead to a share, and reaching "Seed Tool" is what proves
+    # the keypad was not drawn instead.
+    backend.wait_for_text_on_screen("Seed Tool", 5)
+
+
+@mark.use_on_backend("speculos")
+def test_checking_a_phrase_does_not_lead_to_shares(device, backend, set_seed):
+    _touch_only(device)
+    check_result = CenteredFooter(backend, device)
+
+    _walk_to_verdict(backend, device, MENU_CHECK, DEVICE_PHRASE)
+
+    # Same phrase, same device, same screen as the first test -- and a
+    # different answer, because a different question was asked.
+    backend.wait_for_text_on_screen("Valid Secret", 5)
+    backend.wait_for_text_on_screen("The BIP39 Recovery Phrase", 1)
+    backend.wait_for_text_on_screen("matches the one present", 1)
+    backend.wait_for_text_on_screen("Tap to dismiss", 1)
+    check_result.tap()
+
+    # Home, not the "Generate SSKR Phrase?" offer this used to open. Backing
+    # up is still one tap away, from the menu, where it says what it is.
+    backend.wait_for_text_on_screen("Seed Tool", 5)

--- a/tests/functional/test_backup_from_menu_two_button.py
+++ b/tests/functional/test_backup_from_menu_two_button.py
@@ -1,0 +1,118 @@
+"""
+The same three claims as test_backup_from_menu.py, on the two-button devices.
+
+The Nano menu gained the same intentions the touch menu did, minus BIP-85,
+which has no BAGL screen on any Nano. Everything the touch file says about
+why applies here; what differs is the shape, and the shape is what has to be
+tested separately:
+
+  * there is no verdict "footer" to read. A BAGL flow is a list of steps, so
+    what says the verdict continues rather than ends is whether any step of
+    it generates anything: ux_bip39_backup_match_flow ends on the step that
+    does, ux_bip39_check_match_flow ends on a way back to the menu;
+  * a mismatch in the backup flow gets an extra step rather than a longer
+    sentence: a pbb title has two short lines and no room for one.
+
+nano.choose_in_flow() walks a flow to the step showing a label and raises if
+no step does. That is what the two negative assertions below use: they are not
+"the label was not on the first screen", they are "the label is on no step of
+this flow", which is the claim.
+"""
+
+from pytest import fixture
+from pytest import mark
+from pytest import raises
+from pytest import skip
+from ledgered.devices import DeviceType
+from ragger.conftest import configuration
+import nano
+
+# https://github.com/BlockchainCommons/crypto-commons/blob/master/Docs/sskr-test-vector.md#128-bit-seed
+DEVICE_PHRASE = "fly mule excess resource treat plunge nose soda reflect adult ramp planet"
+
+# Valid, correct checksum, and not the device's -- the same phrase
+# test_bip39_seed_match.py uses for the mismatch case.
+OTHER_PHRASE = "girl mad pet galaxy egg matter matrix prison refuse sense ordinary nose"
+
+
+@fixture(scope='session')
+def set_seed():
+    configuration.OPTIONAL.CUSTOM_SEED = DEVICE_PHRASE
+
+
+def _two_button_only(device):
+    if device.type == DeviceType.NANOS:
+        skip("Nano S is not emulated by the current Speculos")
+    if device.type not in (DeviceType.NANOX, DeviceType.NANOSP):
+        skip("Two-button devices only; the touch path is covered elsewhere")
+
+
+@mark.use_on_backend("speculos")
+def test_backup_explains_why_the_phrase_is_asked_for(device, backend, navigator, set_seed):
+    _two_button_only(device)
+
+    # The step this change adds to the Nano flow, between the menu and the
+    # length list. Its first two lines are a whole sentence because a nanos nn
+    # step shows only two -- and this device shows three, so the third is
+    # there as well.
+    nano.select_in_menu(navigator, "Generate")
+    nano.wait_for_lines(backend, "This Ledger cannot", "show you its phrase.")
+
+    nano.select_in_menu(navigator, "12 words")
+    nano.enter_phrase(backend, DEVICE_PHRASE)
+    nano.wait_for_lines(backend, "BIP39 Phrase", "is correct")
+
+    # And the verdict carries on rather than stopping: the generation step is
+    # on this flow. test_sskr_generate_two_button.py takes it from here and
+    # checks what comes out of it.
+    nano.choose_in_flow(backend, "Generate")
+    nano.wait_for_lines(backend, "Select number", "of shares")
+
+
+@mark.use_on_backend("speculos")
+def test_backup_stops_on_a_phrase_this_device_cannot_recover(device, backend, navigator, set_seed):
+    _two_button_only(device)
+
+    nano.select_in_menu(navigator, "Generate")
+    nano.select_in_menu(navigator, "12 words")
+    nano.enter_phrase(backend, OTHER_PHRASE)
+
+    # The verdict title is the one the check flow already gave. What the
+    # backup flow adds is the step after it, which answers the question that
+    # was actually asked: not "is this my phrase" but "can I back it up".
+    nano.wait_for_lines(backend, "BIP39 Phrase", "doesn't match")
+    nano.choose_in_flow(backend, "It would not restore")
+    nano.wait_for_lines(backend, "It would not restore", "this Ledger")
+
+
+@mark.use_on_backend("speculos")
+def test_a_mismatch_never_reaches_the_generation_step(device, backend, navigator, set_seed):
+    _two_button_only(device)
+
+    nano.select_in_menu(navigator, "Generate")
+    nano.select_in_menu(navigator, "12 words")
+    nano.enter_phrase(backend, OTHER_PHRASE)
+    nano.wait_for_lines(backend, "BIP39 Phrase", "doesn't match")
+
+    # No step of this flow generates anything. The entry point into the backup
+    # flow is new; the requirement that the phrase be the device's before a
+    # single share exists is not, and this is what says so on this stack.
+    with raises(AssertionError):
+        nano.choose_in_flow(backend, "Generate")
+
+
+@mark.use_on_backend("speculos")
+def test_checking_a_phrase_does_not_lead_to_shares(device, backend, navigator, set_seed):
+    _two_button_only(device)
+
+    nano.select_in_menu(navigator, "Check phrase")
+    nano.select_in_menu(navigator, "12 words")
+    nano.enter_phrase(backend, DEVICE_PHRASE)
+    nano.wait_for_lines(backend, "BIP39 Phrase", "is correct")
+
+    # The same phrase, the same verdict, and no offer behind it any more. The
+    # generation step used to be the third step of this flow and was the only
+    # way to reach it; it is an entry of the idle menu now, where it says what
+    # it is.
+    with raises(AssertionError):
+        nano.choose_in_flow(backend, "Generate")

--- a/tests/functional/test_bip39_12word.py
+++ b/tests/functional/test_bip39_12word.py
@@ -7,7 +7,7 @@ from ragger.conftest import configuration
 from ragger.firmware.touch.use_cases import UseCaseHomeExt, UseCaseViewDetails, UseCaseChoice
 from ragger.firmware.touch.layouts import CenteredFooter, LetterOnlyKeyboard, Suggestions, ChoiceList
 from keypad import Keypad
-from genericlayout import GenericLayout
+from genericlayout import GenericLayout, MENU_BACKUP
 
 @fixture(scope='session')
 def set_seed():
@@ -292,8 +292,14 @@ def all_eink_bip39_12word(backend, device):
 
     backend.wait_for_text_on_screen("Seed Tool", 10)
     home_page.action()
-    backend.wait_for_text_on_screen("BIP39 Check", 5)
-    genericbuttons.choose(1)
+    # Splitting a phrase into shares is now something the user asks for at
+    # the menu, so this test asks for it there. It used to get here by
+    # checking the phrase and accepting an offer that arrived afterwards,
+    # which was the only way in and is the thing this change removes.
+    backend.wait_for_text_on_screen("Generate backup shares", 5)
+    genericbuttons.choose(MENU_BACKUP)
+    backend.wait_for_text_on_screen("Enter your recovery", 5)
+    choice.confirm()
     backend.wait_for_text_on_screen("12 words", 5)
     genericbuttons.choose(1)
     backend.wait_for_text_on_screen("Enter word", 5)
@@ -303,8 +309,6 @@ def all_eink_bip39_12word(backend, device):
     backend.wait_for_text_on_screen("Valid Secret", 5)
     backend.wait_for_text_on_screen("Recovery Phrase", 1)
     check_result.tap()
-    backend.wait_for_text_on_screen("Generate SSKR", 5)
-    choice.confirm()
     backend.wait_for_text_on_screen("Enter number of SSKR shares", 5)
     keypad.write("3")
     keypad.enter()

--- a/tests/functional/test_bip39_18word.py
+++ b/tests/functional/test_bip39_18word.py
@@ -7,7 +7,7 @@ from ragger.conftest import configuration
 from ragger.firmware.touch.use_cases import UseCaseHomeExt, UseCaseViewDetails, UseCaseChoice
 from ragger.firmware.touch.layouts import CenteredFooter, LetterOnlyKeyboard, Suggestions, ChoiceList
 from keypad import Keypad
-from genericlayout import GenericLayout
+from genericlayout import GenericLayout, MENU_BACKUP
 
 @fixture(scope='session')
 def set_seed():
@@ -394,8 +394,14 @@ def all_eink_bip39_18word(backend, device):
 
     backend.wait_for_text_on_screen("Seed Tool", 10)
     home_page.action()
-    backend.wait_for_text_on_screen("BIP39 Check", 5)
-    genericbuttons.choose(1)
+    # Splitting a phrase into shares is now something the user asks for at
+    # the menu, so this test asks for it there. It used to get here by
+    # checking the phrase and accepting an offer that arrived afterwards,
+    # which was the only way in and is the thing this change removes.
+    backend.wait_for_text_on_screen("Generate backup shares", 5)
+    genericbuttons.choose(MENU_BACKUP)
+    backend.wait_for_text_on_screen("Enter your recovery", 5)
+    choice.confirm()
     backend.wait_for_text_on_screen("18 words", 5)
     genericbuttons.choose(2)
     backend.wait_for_text_on_screen("Enter word", 5)
@@ -405,8 +411,6 @@ def all_eink_bip39_18word(backend, device):
     backend.wait_for_text_on_screen("Valid Secret", 10)
     backend.wait_for_text_on_screen("Recovery Phrase", 1)
     check_result.tap()
-    backend.wait_for_text_on_screen("Generate SSKR", 5)
-    choice.confirm()
     backend.wait_for_text_on_screen("Enter number of SSKR shares", 5)
     keypad.write("3")
     keypad.enter()

--- a/tests/functional/test_bip39_24word.py
+++ b/tests/functional/test_bip39_24word.py
@@ -7,7 +7,7 @@ from ragger.conftest import configuration
 from ragger.firmware.touch.use_cases import UseCaseHomeExt, UseCaseViewDetails, UseCaseChoice
 from ragger.firmware.touch.layouts import CenteredFooter, LetterOnlyKeyboard, Suggestions, ChoiceList
 from keypad import Keypad
-from genericlayout import GenericLayout
+from genericlayout import GenericLayout, MENU_BACKUP
 
 @fixture(scope='session')
 def set_seed():
@@ -475,8 +475,14 @@ def all_eink_bip39_24word(backend, device):
 
     backend.wait_for_text_on_screen("Seed Tool", 10)
     home_page.action()
-    backend.wait_for_text_on_screen("BIP39 Check", 5)
-    genericbuttons.choose(1)
+    # Splitting a phrase into shares is now something the user asks for at
+    # the menu, so this test asks for it there. It used to get here by
+    # checking the phrase and accepting an offer that arrived afterwards,
+    # which was the only way in and is the thing this change removes.
+    backend.wait_for_text_on_screen("Generate backup shares", 5)
+    genericbuttons.choose(MENU_BACKUP)
+    backend.wait_for_text_on_screen("Enter your recovery", 5)
+    choice.confirm()
     backend.wait_for_text_on_screen("24 words", 5)
     genericbuttons.choose(3)
     backend.wait_for_text_on_screen("Enter word", 5)
@@ -486,8 +492,6 @@ def all_eink_bip39_24word(backend, device):
     backend.wait_for_text_on_screen("Valid Secret", 10)
     backend.wait_for_text_on_screen("Recovery Phrase", 1)
     check_result.tap()
-    backend.wait_for_text_on_screen("Generate SSKR", 5)
-    choice.confirm()
     backend.wait_for_text_on_screen("Enter number of SSKR shares", 5)
     keypad.write("3")
     keypad.enter()

--- a/tests/functional/test_bip39_seed_match.py
+++ b/tests/functional/test_bip39_seed_match.py
@@ -41,7 +41,7 @@ from ledgered.devices import DeviceType
 from ragger.conftest import configuration
 from ragger.firmware.touch.use_cases import UseCaseHomeExt
 from ragger.firmware.touch.layouts import LetterOnlyKeyboard, Suggestions
-from genericlayout import GenericLayout
+from genericlayout import GenericLayout, MENU_CHECK
 import nano
 
 # Same seed as the other functional tests.
@@ -78,8 +78,8 @@ def _touch_check(backend, device, phrase, title, verdict):
 
     backend.wait_for_text_on_screen("Seed Tool", 10)
     home_page.action()
-    backend.wait_for_text_on_screen("BIP39 Check", 5)
-    genericbuttons.choose(1)
+    backend.wait_for_text_on_screen("Check recovery phrase", 5)
+    genericbuttons.choose(MENU_CHECK)
     backend.wait_for_text_on_screen("12 words", 5)
     genericbuttons.choose(1)
     backend.wait_for_text_on_screen("Enter word", 5)

--- a/tests/functional/test_bip39_seed_match.py
+++ b/tests/functional/test_bip39_seed_match.py
@@ -64,7 +64,7 @@ def set_seed():
 
 
 def _two_button_check(backend, navigator, phrase, first_line, second_line):
-    nano.select_in_menu(navigator, "Check BIP39")
+    nano.select_in_menu(navigator, "Check phrase")
     nano.select_in_menu(navigator, "12 words")
     nano.enter_phrase(backend, phrase)
     nano.wait_for_lines(backend, first_line, second_line)

--- a/tests/functional/test_bip85_bip39.py
+++ b/tests/functional/test_bip85_bip39.py
@@ -6,7 +6,7 @@ from ragger.conftest import configuration
 from ragger.firmware.touch.use_cases import UseCaseHomeExt, UseCaseViewDetails
 from ragger.firmware.touch.layouts import ChoiceList
 from keypad import Keypad
-from genericlayout import GenericLayout
+from genericlayout import GenericLayout, MENU_DERIVE
 
 @fixture(scope='session')
 def set_seed():
@@ -22,8 +22,8 @@ def all_eink_bip85_bip39(backend, device):
 
     backend.wait_for_text_on_screen("Seed Tool", 10)
     home_page.action()
-    backend.wait_for_text_on_screen("BIP85 Generate", 5)
-    genericbuttons.choose(3)
+    backend.wait_for_text_on_screen("Derive with BIP85", 5)
+    genericbuttons.choose(MENU_DERIVE)
     backend.wait_for_text_on_screen("Which BIP85", 5)
     genericbuttons.choose(1)
     backend.wait_for_text_on_screen("Length of BIP39", 5)

--- a/tests/functional/test_bip85_pwd_base64.py
+++ b/tests/functional/test_bip85_pwd_base64.py
@@ -6,7 +6,7 @@ from ragger.conftest import configuration
 from ragger.firmware.touch.use_cases import UseCaseHomeExt, UseCaseViewDetails
 from ragger.firmware.touch.layouts import ChoiceList
 from keypad import Keypad
-from genericlayout import GenericLayout
+from genericlayout import GenericLayout, MENU_DERIVE
 
 @fixture(scope='session')
 def set_seed():
@@ -22,8 +22,8 @@ def all_eink_bip85_pwd_base64(backend, device):
 
     backend.wait_for_text_on_screen("Seed Tool", 10)
     home_page.action()
-    backend.wait_for_text_on_screen("BIP85 Generate", 5)
-    genericbuttons.choose(3)
+    backend.wait_for_text_on_screen("Derive with BIP85", 5)
+    genericbuttons.choose(MENU_DERIVE)
     backend.wait_for_text_on_screen("Which BIP85", 5)
     genericbuttons.choose(2)
     backend.wait_for_text_on_screen("Enter password length", 5)

--- a/tests/functional/test_bip85_pwd_base85.py
+++ b/tests/functional/test_bip85_pwd_base85.py
@@ -6,7 +6,7 @@ from ragger.conftest import configuration
 from ragger.firmware.touch.use_cases import UseCaseHomeExt, UseCaseViewDetails
 from ragger.firmware.touch.layouts import ChoiceList
 from keypad import Keypad
-from genericlayout import GenericLayout
+from genericlayout import GenericLayout, MENU_DERIVE
 
 @fixture(scope='session')
 def set_seed():
@@ -22,8 +22,8 @@ def all_eink_bip85_pwd_base85(backend, device):
 
     backend.wait_for_text_on_screen("Seed Tool", 10)
     home_page.action()
-    backend.wait_for_text_on_screen("BIP85 Generate", 5)
-    genericbuttons.choose(3)
+    backend.wait_for_text_on_screen("Derive with BIP85", 5)
+    genericbuttons.choose(MENU_DERIVE)
     backend.wait_for_text_on_screen("Which BIP85", 5)
     genericbuttons.choose(3)
     backend.wait_for_text_on_screen("Enter password length", 5)

--- a/tests/functional/test_menu_positions.py
+++ b/tests/functional/test_menu_positions.py
@@ -1,0 +1,65 @@
+"""
+Each menu constant opens the entry its name claims.
+
+`genericlayout.py` maps the four entries to touch coordinates counted from the
+*bottom* of the screen, because `generic_screen_configure_buttons()`
+(src/nbgl/layout_generic_screen.c) stacks its buttons upwards: child 0 is the
+lowest one drawn and the last one read. That inversion is the kind of thing a
+suite can get wrong and stay green about.
+
+Nothing else in this directory checks the mapping. Every other test waits for
+a label to appear *somewhere* on the menu and then touches a coordinate, so a
+table shifted by one row would satisfy the wait, open the wrong entry, and
+fail several screens later with a message about something else entirely.
+
+This asserts the only thing that settles it: the screen each coordinate
+actually arrives on. The four destinations are distinguishable from each other
+by their first line, which is what makes the assertions two-directional --
+MENU_BACKUP landing on the length screen would fail, not merely fail to prove.
+"""
+
+from pytest import fixture
+from pytest import mark
+from pytest import skip
+from ledgered.devices import DeviceType
+from ragger.conftest import configuration
+from ragger.firmware.touch.use_cases import UseCaseHomeExt
+from genericlayout import GenericLayout, MENU_CHECK, MENU_BACKUP, MENU_RECOVER, MENU_DERIVE
+
+
+@fixture(scope='session')
+def set_seed():
+    configuration.OPTIONAL.CUSTOM_SEED = \
+        "fly mule excess resource treat plunge nose soda reflect adult ramp planet"
+
+
+# entry constant -> a line only the screen it opens draws
+DESTINATIONS = [
+    (MENU_CHECK, "How long is your"),
+    (MENU_BACKUP, "Enter your recovery"),
+    (MENU_RECOVER, "Enter Share 1 Word 1"),
+    (MENU_DERIVE, "Which BIP85"),
+]
+
+
+@mark.use_on_backend("speculos")
+@mark.parametrize("entry,destination", DESTINATIONS,
+                  ids=["check", "backup", "recover", "derive"])
+def test_each_entry_opens_what_it_names(device, backend, set_seed, entry, destination):
+    if device.type not in (DeviceType.STAX, DeviceType.FLEX, DeviceType.APEX_P):
+        skip("The four-entry menu is the touch stack's")
+
+    home_page = UseCaseHomeExt(backend, device)
+    genericbuttons = GenericLayout(backend, device)
+
+    backend.wait_for_text_on_screen("Seed Tool", 10)
+    home_page.action()
+    # All four labels on one screen: this is the menu, before anything is
+    # touched, and every entry below is drawn.
+    backend.wait_for_text_on_screen("Check recovery phrase", 5)
+    backend.wait_for_text_on_screen("Generate backup shares", 1)
+    backend.wait_for_text_on_screen("Recover from backup", 1)
+    backend.wait_for_text_on_screen("Derive with BIP85", 1)
+
+    genericbuttons.choose(entry)
+    backend.wait_for_text_on_screen(destination, 5)

--- a/tests/functional/test_sskr_128bit.py
+++ b/tests/functional/test_sskr_128bit.py
@@ -7,7 +7,7 @@ from ragger.conftest import configuration
 from ragger.firmware.touch.use_cases import UseCaseHomeExt, UseCaseViewDetails, UseCaseChoice
 from ragger.firmware.touch.layouts import CenteredFooter, LetterOnlyKeyboard, Suggestions, ChoiceList
 from keypad import Keypad
-from genericlayout import GenericLayout
+from genericlayout import GenericLayout, MENU_RECOVER
 
 @fixture(scope='session')
 def set_seed():
@@ -863,8 +863,8 @@ def all_eink_sskr_128bit(backend, device):
 
     backend.wait_for_text_on_screen("Seed Tool", 10)
     home_page.action()
-    backend.wait_for_text_on_screen("SSKR Check", 5)
-    genericbuttons.choose(2)
+    backend.wait_for_text_on_screen("Recover from backup", 5)
+    genericbuttons.choose(MENU_RECOVER)
     backend.wait_for_text_on_screen("Enter Share 1 Word 1", 5)
     for shard in sskr_shards:
         for word in shard.split():

--- a/tests/functional/test_sskr_256bit.py
+++ b/tests/functional/test_sskr_256bit.py
@@ -7,7 +7,7 @@ from ragger.conftest import configuration
 from ragger.firmware.touch.use_cases import UseCaseHomeExt, UseCaseViewDetails, UseCaseChoice
 from ragger.firmware.touch.layouts import CenteredFooter, LetterOnlyKeyboard, Suggestions, ChoiceList
 from keypad import Keypad
-from genericlayout import GenericLayout
+from genericlayout import GenericLayout, MENU_RECOVER
 
 @fixture(scope='session')
 def set_seed():
@@ -1237,8 +1237,8 @@ def all_eink_sskr_256bit(backend, device):
 
     backend.wait_for_text_on_screen("Seed Tool", 10)
     home_page.action()
-    backend.wait_for_text_on_screen("SSKR Check", 5)
-    genericbuttons.choose(2)
+    backend.wait_for_text_on_screen("Recover from backup", 5)
+    genericbuttons.choose(MENU_RECOVER)
     backend.wait_for_text_on_screen("Enter Share 1 Word 1", 5)
     for shard in sskr_shards:
         for word in shard.split():

--- a/tests/functional/test_sskr_duplicate_share_two_button.py
+++ b/tests/functional/test_sskr_duplicate_share_two_button.py
@@ -69,7 +69,7 @@ def test_sskr_duplicate_share_is_refused_as_invalid(device, backend, navigator,
     if device.type not in (DeviceType.NANOX, DeviceType.NANOSP):
         skip("Two-button devices only; the touch path is covered elsewhere")
 
-    nano.select_in_menu(navigator, "Check SSKR")
+    nano.select_in_menu(navigator, "Recover")
     nano.confirm(backend)
 
     for _ in range(2):

--- a/tests/functional/test_sskr_entry_two_button.py
+++ b/tests/functional/test_sskr_entry_two_button.py
@@ -53,7 +53,7 @@ def test_sskr_entry_two_button(device, backend, navigator, set_seed):
     if device.type not in (DeviceType.NANOX, DeviceType.NANOSP):
         skip("Two-button devices only; the touch path is covered elsewhere")
 
-    nano.select_in_menu(navigator, "Check SSKR")
+    nano.select_in_menu(navigator, "Recover")
     # The SSKR flow opens on an instruction screen whose callback starts the
     # entry; the BIP-39 flow reaches the keyboard through its word-count menu
     # instead, which is why the other two-button test needs no equivalent.

--- a/tests/functional/test_sskr_generate_two_button.py
+++ b/tests/functional/test_sskr_generate_two_button.py
@@ -63,14 +63,15 @@ def test_sskr_generate_two_button(device, backend, navigator, set_seed):
     if device.type not in (DeviceType.NANOX, DeviceType.NANOSP):
         skip("Two-button devices only; the touch path is covered elsewhere")
 
-    nano.select_in_menu(navigator, "Check BIP39")
+    nano.select_in_menu(navigator, "Generate")
     nano.select_in_menu(navigator, "12 words")
     nano.enter_phrase(backend, DEVICE_PHRASE)
 
     # The phrase is the device's, so the verdict is a match -- and only the
-    # match flow offers to generate shares (ux_bip39_match_flow,
-    # src/bagl/ux_nano.c). Asserting it here is what makes the rest of this
-    # test mean "generation from a verified phrase" rather than "generation".
+    # match flow carries on to the generation
+    # (ux_bip39_backup_match_flow, src/bagl/ux_nano.c). Asserting it here is
+    # what makes the rest of this test mean "generation from a verified
+    # phrase" rather than "generation".
     nano.wait_for_lines(backend, "BIP39 Phrase", "is correct")
 
     nano.choose_in_flow(backend, "Generate")

--- a/tests/functional/test_sskr_threshold_refusal_two_button.py
+++ b/tests/functional/test_sskr_threshold_refusal_two_button.py
@@ -54,7 +54,7 @@ def test_sskr_threshold_of_one_is_refused(device, backend, navigator, set_seed):
 
     # Generation is only reachable through a phrase the device agrees with,
     # so the phrase below is the one it was seeded with.
-    nano.select_in_menu(navigator, "Check BIP39")
+    nano.select_in_menu(navigator, "Generate")
     nano.select_in_menu(navigator, "12 words")
     nano.enter_phrase(backend, DEVICE_PHRASE)
     nano.wait_for_lines(backend, "BIP39 Phrase", "is correct")

--- a/tests/functional/test_sskr_unsupported_values.py
+++ b/tests/functional/test_sskr_unsupported_values.py
@@ -6,7 +6,7 @@ from ragger.conftest import configuration
 from ragger.firmware.touch.use_cases import UseCaseHomeExt, UseCaseViewDetails, UseCaseChoice
 from ragger.firmware.touch.layouts import CenteredFooter, LetterOnlyKeyboard, Suggestions, ChoiceList
 from keypad import Keypad
-from genericlayout import GenericLayout
+from genericlayout import GenericLayout, MENU_BACKUP
 
 # The threshold keypad names the values it accepts. Its upper bound is the
 # share count entered on the screen before it, so this string is also the
@@ -34,10 +34,16 @@ def all_eink_unsupported_values(backend, device):
     choice = UseCaseChoice(backend, device)
     genericbuttons = GenericLayout(backend, device)
 
+    # Reached from the menu entry, not from a verdict that happened to offer
+    # it. The verdict is still crossed on the way -- the phrase has to be the
+    # device's before it can be split -- but it is now a step of a flow the
+    # user asked for rather than the only door into it.
     backend.wait_for_text_on_screen("Seed Tool", 10)
     home_page.action()
-    backend.wait_for_text_on_screen("BIP39 Check", 5)
-    genericbuttons.choose(1)
+    backend.wait_for_text_on_screen("Generate backup shares", 5)
+    genericbuttons.choose(MENU_BACKUP)
+    backend.wait_for_text_on_screen("Enter your recovery", 5)
+    choice.confirm()
     backend.wait_for_text_on_screen("12 words", 5)
     genericbuttons.choose(1)
     backend.wait_for_text_on_screen("Enter word", 5)
@@ -47,8 +53,6 @@ def all_eink_unsupported_values(backend, device):
     backend.wait_for_text_on_screen("Valid Secret", 5)
     backend.wait_for_text_on_screen("Recovery Phrase", 1)
     check_result.tap()
-    backend.wait_for_text_on_screen("Generate SSKR", 5)
-    choice.confirm()
 
     # An out-of-range share count is refused and asked for again, on the keypad
     # that asked for it. Each refusal is waited for on its own: the status page
@@ -95,9 +99,9 @@ def all_eink_unsupported_values(backend, device):
 
     # And a threshold this one does accept generates a 2-of-3 straight away.
     # This is what the three refusals above cost before: each of them returned
-    # to the "Generate SSKR Phrase?" offer, so reaching this point meant typing
-    # the share count three more times. The share label naming 3 is the proof
-    # that the count entered once is the count that was used.
+    # to the head of the flow, so reaching this point meant typing the share
+    # count three more times. The share label naming 3 is the proof that the
+    # count entered once is the count that was used.
     keypad.write("2")
     keypad.enter()
     backend.wait_for_text_on_screen("SSKR share 1 of 3", 5)

--- a/tests/functional/test_two_button_refusals.py
+++ b/tests/functional/test_two_button_refusals.py
@@ -70,7 +70,7 @@ def _two_button_only(device):
 def test_bip39_bad_checksum_is_refused(device, backend, navigator, set_seed):
     _two_button_only(device)
 
-    nano.select_in_menu(navigator, "Check BIP39")
+    nano.select_in_menu(navigator, "Check phrase")
     nano.select_in_menu(navigator, "12 words")
     nano.enter_phrase(backend, BAD_CHECKSUM_PHRASE)
 
@@ -84,7 +84,7 @@ def test_bip39_bad_checksum_is_refused(device, backend, navigator, set_seed):
 def test_sskr_bad_crc_is_refused(device, backend, navigator, set_seed):
     _two_button_only(device)
 
-    nano.select_in_menu(navigator, "Check SSKR")
+    nano.select_in_menu(navigator, "Recover")
     nano.confirm(backend)
 
     for shard in CORRUPTED_SHARDS:

--- a/tests/unit/CMakeLists.txt
+++ b/tests/unit/CMakeLists.txt
@@ -1070,6 +1070,11 @@ target_link_libraries(test_sskr_ux_menu_nanos PUBLIC cmocka gcov testutils)
 add_executable(test_ui_strings tests/ui_strings.c)
 target_include_directories(test_ui_strings PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/../../src/common ${CMAKE_CURRENT_SOURCE_DIR}/../../src/common/sskr/sss)
 target_link_libraries(test_ui_strings PUBLIC cmocka gcov)
+# The header is read as a file as well as included as one: the test counts the
+# macros it declares and holds that count against the table that is supposed
+# to name them all. See test_the_table_names_every_macro_of_the_header().
+target_compile_definitions(test_ui_strings PRIVATE
+    UI_STRINGS_HEADER_PATH="${CMAKE_CURRENT_SOURCE_DIR}/../../src/common/ui_strings.h")
 # ---------------------------------------------------------------------------
 
 # Register every executable this file builds, instead of repeating their names

--- a/tests/unit/tests/ui_strings.c
+++ b/tests/unit/tests/ui_strings.c
@@ -36,6 +36,7 @@
 #include <stdbool.h>
 #include <string.h>
 #include <stdio.h>
+#include <ctype.h>
 
 #include "ui_strings.h"
 #include "constants.h"
@@ -63,10 +64,11 @@ static const struct {
     ENTRY(UI_STR_WORDS_18),
     ENTRY(UI_STR_WORDS_24),
     ENTRY(UI_STR_BAGL_PROCESSING),
-    ENTRY(UI_STR_NBGL_TOOL_BIP39),
-    ENTRY(UI_STR_NBGL_TOOL_SSKR),
-    ENTRY(UI_STR_NBGL_TOOL_BIP85),
-    ENTRY(UI_STR_NBGL_SELECT_TOOL_TITLE),
+    ENTRY(UI_STR_NBGL_MENU_CHECK),
+    ENTRY(UI_STR_NBGL_MENU_BACKUP),
+    ENTRY(UI_STR_NBGL_MENU_RECOVER),
+    ENTRY(UI_STR_NBGL_MENU_DERIVE),
+    ENTRY(UI_STR_NBGL_MENU_TITLE),
     ENTRY(UI_STR_BAGL_IDLE_BIP39_L1),
     ENTRY(UI_STR_BAGL_IDLE_BIP39_L2),
     ENTRY(UI_STR_BAGL_IDLE_SSKR_L1),
@@ -114,6 +116,9 @@ static const struct {
     ENTRY(UI_STR_NBGL_RESULT_SSKR_NOMATCH),
     ENTRY(UI_STR_NBGL_RESULT_SSKR_MATCH),
     ENTRY(UI_STR_NBGL_RESULT_TAP_TO_DISMISS),
+    ENTRY(UI_STR_NBGL_RESULT_BACKUP_NOMATCH),
+    ENTRY(UI_STR_NBGL_RESULT_BACKUP_MATCH),
+    ENTRY(UI_STR_NBGL_RESULT_TAP_TO_CONTINUE),
     ENTRY(UI_STR_NBGL_RESULT_INVALID_ADVICE),
     ENTRY(UI_STR_BAGL_INVALID_ADVICE_L1),
     ENTRY(UI_STR_BAGL_INVALID_ADVICE_L2),
@@ -133,9 +138,9 @@ static const struct {
     ENTRY(UI_STR_NBGL_RECOVER_BIP39_DESC),
     ENTRY(UI_STR_NBGL_RECOVER_BIP39_CONFIRM),
     ENTRY(UI_STR_NBGL_CANCEL),
-    ENTRY(UI_STR_NBGL_GENERATE_SSKR_TITLE),
-    ENTRY(UI_STR_NBGL_GENERATE_SSKR_DESC),
-    ENTRY(UI_STR_NBGL_GENERATE_SSKR_CONFIRM),
+    ENTRY(UI_STR_NBGL_BACKUP_EXPLAIN_TITLE),
+    ENTRY(UI_STR_NBGL_BACKUP_EXPLAIN_DESC),
+    ENTRY(UI_STR_NBGL_BACKUP_EXPLAIN_CONFIRM),
     ENTRY(UI_STR_NBGL_CLOSE),
     ENTRY(UI_STR_BAGL_GENERATE_SSKR_L1),
     ENTRY(UI_STR_BAGL_GENERATE_SSKR_L2),
@@ -229,11 +234,9 @@ static const unsigned char k_nanos_char_width_bold[96] = {
  * Two strings fail the bound below and are deliberately not asserted:
  * "recovery phrase" (UI_STR_BAGL_IDLE_BIP39_L2 / _SSKR_L2, 93px bold, PBB) and
  * "BIP39 Recovery" (UI_STR_BAGL_BIP39_INVALID_TITLE_L1, 90px bold, PBB), both
- * 3-6px over the 87px PBB budget on nanos. Both predate this header --
- * nothing here changed either word -- and this lot does not change wording
- * (see the PR body). They are recorded here, not silently passed, so the
- * gap this test cannot close is visible in the same place as the strings it
- * does check, rather than only in the PR body.
+ * 3-6px over the 87px PBB budget on nanos. Both predate this header, and
+ * neither is changed here. They are recorded rather than silently passed, so
+ * the gap this test cannot close is visible beside the strings it does check.
  */
 #define BOUND_WIDE           116
 #define BOUND_TIGHT          87
@@ -549,9 +552,106 @@ static void test_composed_titles_take_the_arguments_passed_to_them(void **state)
     }
 }
 
+/*
+ * The table at the top of this file names every macro of ui_strings.h -- and
+ * until now, nothing said so.
+ *
+ * A *renamed* or *removed* macro has always been caught, and loudly: ENTRY()
+ * expands to the macro itself, so the compiler refuses the file. An *added*
+ * one was the silent half. Nothing linked the header to the table, so a macro
+ * declared in the header and never listed here was checked by none of the
+ * four tests above -- not for being empty, not for fitting a Nano line -- and
+ * the suite stayed green. Six macros were added by the change that added this
+ * test, which is why it is being added now rather than being noted as a gap.
+ *
+ * Read from the header itself, at the path CMake hands over, rather than
+ * compared against a number kept up to date by hand: a hand-kept count is the
+ * same class of thing as a hand-kept list, and would drift the same way.
+ *
+ * Names, not a count. Comparing cardinalities passes on a header that gains
+ * two macros while the table lists one of them twice -- the totals agree and
+ * one macro is still checked by nothing. Each declared name is looked for in
+ * the table by name, and the table is checked for repeats, so both halves
+ * fail loudly. One "#define" line per macro, including the multi-line ones: a
+ * value continued with a backslash still has exactly one.
+ */
+#ifndef UI_STRINGS_HEADER_PATH
+#error "UI_STRINGS_HEADER_PATH must name src/common/ui_strings.h"
+#endif
+
+#define MACRO_PREFIX "#define UI_STR_"
+
+static bool table_names(const char *name) {
+    for (size_t i = 0; i < sizeof(k_all_strings) / sizeof(k_all_strings[0]); i++) {
+        if (strcmp(k_all_strings[i].name, name) == 0) {
+            return true;
+        }
+    }
+    return false;
+}
+
+static void test_the_table_names_every_macro_of_the_header(void **state) {
+    (void) state;
+
+    /* no entry names the same macro twice */
+    for (size_t i = 0; i < sizeof(k_all_strings) / sizeof(k_all_strings[0]); i++) {
+        for (size_t j = i + 1; j < sizeof(k_all_strings) / sizeof(k_all_strings[0]); j++) {
+            if (strcmp(k_all_strings[i].name, k_all_strings[j].name) == 0) {
+                fail_msg("k_all_strings[] lists %s twice", k_all_strings[i].name);
+            }
+        }
+    }
+
+    FILE *header = fopen(UI_STRINGS_HEADER_PATH, "r");
+    if (header == NULL) {
+        fail_msg("cannot open %s", UI_STRINGS_HEADER_PATH);
+    }
+
+    size_t declared = 0;
+    char line[512];
+    while (fgets(line, sizeof(line), header) != NULL) {
+        if (strncmp(line, MACRO_PREFIX, strlen(MACRO_PREFIX)) != 0) {
+            continue;
+        }
+        declared++;
+
+        /* the macro name is the token after "#define " */
+        const char *start = line + strlen("#define ");
+        size_t len = 0;
+        while (start[len] != '\0' && !isspace((unsigned char) start[len]) &&
+               start[len] != '(') {
+            len++;
+        }
+        char name[128];
+        if (len >= sizeof(name)) {
+            fail_msg("%s declares a macro name longer than this test can hold", MACRO_PREFIX);
+        }
+        memcpy(name, start, len);
+        name[len] = '\0';
+
+        if (!table_names(name)) {
+            fclose(header);
+            fail_msg("%s declares %s, k_all_strings[] does not list it; a macro "
+                     "missing from that table is checked by nothing in this file",
+                     UI_STRINGS_HEADER_PATH, name);
+        }
+    }
+    fclose(header);
+
+    /* every name in the table is a macro of the header, so equal totals now
+     * mean equal sets -- the reverse direction is a compile error anyway,
+     * since ENTRY() expands to the macro itself */
+    const size_t listed = sizeof(k_all_strings) / sizeof(k_all_strings[0]);
+    if (declared != listed) {
+        fail_msg("%s declares %zu UI_STR_ macros, k_all_strings[] lists %zu",
+                 UI_STRINGS_HEADER_PATH, declared, listed);
+    }
+}
+
 int main(void) {
     const struct CMUnitTest tests[] = {
         cmocka_unit_test(test_every_string_is_non_empty),
+        cmocka_unit_test(test_the_table_names_every_macro_of_the_header),
         cmocka_unit_test(test_nano_fixed_layout_strings_fit_their_budget),
         cmocka_unit_test(test_sskr_share_label_fits_the_nano_title_line),
         cmocka_unit_test(test_announced_bounds_are_the_applied_ones),

--- a/tests/unit/tests/ui_strings.c
+++ b/tests/unit/tests/ui_strings.c
@@ -69,10 +69,15 @@ static const struct {
     ENTRY(UI_STR_NBGL_MENU_RECOVER),
     ENTRY(UI_STR_NBGL_MENU_DERIVE),
     ENTRY(UI_STR_NBGL_MENU_TITLE),
-    ENTRY(UI_STR_BAGL_IDLE_BIP39_L1),
-    ENTRY(UI_STR_BAGL_IDLE_BIP39_L2),
-    ENTRY(UI_STR_BAGL_IDLE_SSKR_L1),
-    ENTRY(UI_STR_BAGL_IDLE_SSKR_L2),
+    ENTRY(UI_STR_BAGL_IDLE_CHECK_L1),
+    ENTRY(UI_STR_BAGL_IDLE_CHECK_L2),
+    ENTRY(UI_STR_BAGL_IDLE_BACKUP_L1),
+    ENTRY(UI_STR_BAGL_IDLE_BACKUP_L2),
+    ENTRY(UI_STR_BAGL_IDLE_RECOVER_L1),
+    ENTRY(UI_STR_BAGL_IDLE_RECOVER_L2),
+    ENTRY(UI_STR_BAGL_BACKUP_EXPLAIN_L1),
+    ENTRY(UI_STR_BAGL_BACKUP_EXPLAIN_L2),
+    ENTRY(UI_STR_BAGL_BACKUP_EXPLAIN_L3),
     ENTRY(UI_STR_NBGL_HOME_DESCRIPTION),
     ENTRY(UI_STR_NBGL_HOME_ACTION),
     ENTRY(UI_STR_NBGL_HOME_COPYRIGHT),
@@ -127,6 +132,8 @@ static const struct {
     ENTRY(UI_STR_BAGL_BIP39_REENTER_PHRASE),
     ENTRY(UI_STR_BAGL_BIP39_NOMATCH_TITLE_L2),
     ENTRY(UI_STR_BAGL_BIP39_MATCH_TITLE_L2),
+    ENTRY(UI_STR_BAGL_BACKUP_NOMATCH_L1),
+    ENTRY(UI_STR_BAGL_BACKUP_NOMATCH_L2),
     ENTRY(UI_STR_BAGL_SSKR_INVALID_TITLE_L1),
     ENTRY(UI_STR_BAGL_SSKR_INVALID_TITLE_L2),
     ENTRY(UI_STR_BAGL_SSKR_REENTER_SHARES),
@@ -231,12 +238,16 @@ static const unsigned char k_nanos_char_width_bold[96] = {
  * the tighter 87px in the bold font -- the more conservative of the two
  * combinations -- rather than guessed at a wider or lighter one.
  *
- * Two strings fail the bound below and are deliberately not asserted:
- * "recovery phrase" (UI_STR_BAGL_IDLE_BIP39_L2 / _SSKR_L2, 93px bold, PBB) and
- * "BIP39 Recovery" (UI_STR_BAGL_BIP39_INVALID_TITLE_L1, 90px bold, PBB), both
- * 3-6px over the 87px PBB budget on nanos. Both predate this header, and
- * neither is changed here. They are recorded rather than silently passed, so
- * the gap this test cannot close is visible beside the strings it does check.
+ * One string still fails the bound below and is deliberately not asserted:
+ * "BIP39 Recovery" (UI_STR_BAGL_BIP39_INVALID_TITLE_L1), 90px bold against
+ * the 87px PBB budget on nanos. It predates this header and no change since
+ * has touched that screen's wording.
+ *
+ * There were two. The other was "recovery phrase", 93px, which the two idle
+ * entries used to end on; the three entries that replaced them were written
+ * against this budget and are asserted below like everything else. Recording
+ * the gap here rather than only in a PR body is what made it visible enough
+ * to close when those lines were next rewritten.
  */
 #define BOUND_WIDE           116
 #define BOUND_TIGHT          87
@@ -255,10 +266,24 @@ static const struct {
     BOUNDED(UI_STR_WORDS_18, BOUND_WIDE, true),
     BOUNDED(UI_STR_WORDS_24, BOUND_WIDE, true),
     BOUNDED(UI_STR_BAGL_PROCESSING, BOUND_WIDE, true),
-    BOUNDED(UI_STR_BAGL_IDLE_BIP39_L1, BOUND_TIGHT, true),
-    /* IDLE_BIP39_L2 ("recovery phrase") -- see the file comment above. */
-    BOUNDED(UI_STR_BAGL_IDLE_SSKR_L1, BOUND_TIGHT, true),
-    /* IDLE_SSKR_L2 ("recovery phrase") -- see the file comment above. */
+    /*
+     * All six idle-menu fragments, both lines of each. The two entries these
+     * replaced ended on "recovery phrase", 93px against an 87px box, and were
+     * recorded above as unassertable rather than asserted; the three that
+     * took their place were written to the budget and are held to it.
+     */
+    BOUNDED(UI_STR_BAGL_IDLE_CHECK_L1, BOUND_TIGHT, true),
+    BOUNDED(UI_STR_BAGL_IDLE_CHECK_L2, BOUND_TIGHT, true),
+    BOUNDED(UI_STR_BAGL_IDLE_BACKUP_L1, BOUND_TIGHT, true),
+    BOUNDED(UI_STR_BAGL_IDLE_BACKUP_L2, BOUND_TIGHT, true),
+    BOUNDED(UI_STR_BAGL_IDLE_RECOVER_L1, BOUND_TIGHT, true),
+    BOUNDED(UI_STR_BAGL_IDLE_RECOVER_L2, BOUND_TIGHT, true),
+    /* nn steps, so the wide box and the regular font. */
+    BOUNDED(UI_STR_BAGL_BACKUP_EXPLAIN_L1, BOUND_WIDE, false),
+    BOUNDED(UI_STR_BAGL_BACKUP_EXPLAIN_L2, BOUND_WIDE, false),
+    BOUNDED(UI_STR_BAGL_BACKUP_EXPLAIN_L3, BOUND_WIDE, false),
+    BOUNDED(UI_STR_BAGL_BACKUP_NOMATCH_L1, BOUND_WIDE, false),
+    BOUNDED(UI_STR_BAGL_BACKUP_NOMATCH_L2, BOUND_WIDE, false),
     BOUNDED(UI_STR_BAGL_BIP39_LENGTH_TITLE_L1_NANOS, BOUND_WIDE, false),
     BOUNDED(UI_STR_BAGL_BIP39_LENGTH_TITLE_L2_NANOS, BOUND_WIDE, false),
     BOUNDED(UI_STR_BAGL_BIP39_LENGTH_TITLE_L1, BOUND_WIDE, false),


### PR DESCRIPTION
## What you could not find, and now can

Backing up your recovery phrase.

Today it is reachable from exactly one place: `check_result_callback()` in
`src/nbgl/ui.c` offers it, and only when the tool was BIP39, the phrase was
well formed, and it matched the device.

```c
if (tool_type == TOOL_TYPE_BIP39 && bip39_mnemonic_check(&seed_match) &&
    seed_match) {
    display_select_generate_sskr_page();
```

So to split a phrase into SSKR shares you have to open `BIP39 Check`, type it
in, succeed, and then accept an offer you did not ask for. Nothing in the menu
says any of that is there. Rebuilding a phrase from shares has the same shape,
behind a successful `SSKR Check`. On the Nano devices it is the same defect:
generating shares is the third step of the BIP-39 match flow.

The menu named formats, and the two operations worth the most in a backup tool
were the two with no entry.

| before | after |
|---|---|
| <img src="https://raw.githubusercontent.com/buzzromain/app-seed-tool/screenshots/four-intent-menu/menu-before-stax.png" width="260"> | <img src="https://raw.githubusercontent.com/buzzromain/app-seed-tool/screenshots/four-intent-menu/menu-after-stax.png" width="260"> |
| <img src="https://raw.githubusercontent.com/buzzromain/app-seed-tool/screenshots/four-intent-menu/menu-before-flex.png" width="280"> | <img src="https://raw.githubusercontent.com/buzzromain/app-seed-tool/screenshots/four-intent-menu/menu-after-flex.png" width="280"> |
| <img src="https://raw.githubusercontent.com/buzzromain/app-seed-tool/screenshots/four-intent-menu/menu-before-apex_p.png" width="220"> | <img src="https://raw.githubusercontent.com/buzzromain/app-seed-tool/screenshots/four-intent-menu/menu-after-apex_p.png" width="220"> |

The icon goes with the three-entry menu. Two reasons, both measured: on apex_p
the fourth button occupies the space the icon and title used, and the icons in
this repository name formats, so Generate and Recover would both have taken
`icon_sskr` — which is what the BIP85 entry already wore, identical to the SSKR
one beside it.

## The screen this adds

One, and it is on the path the user walks. Someone who picks `Generate backup
shares` is about to be asked to type twenty-four words into a device that
already holds them, and nothing said why. `compare_recovery_phrase()` gets a
seed back from the device and never the words, so the words have to come from
the person.

<p>
<img src="https://raw.githubusercontent.com/buzzromain/app-seed-tool/screenshots/four-intent-menu/why-the-phrase-stax.png" width="230">
<img src="https://raw.githubusercontent.com/buzzromain/app-seed-tool/screenshots/four-intent-menu/why-the-phrase-flex.png" width="250">
<img src="https://raw.githubusercontent.com/buzzromain/app-seed-tool/screenshots/four-intent-menu/why-the-phrase-apex_p.png" width="195">
</p>

It takes the place of `Generate SSKR Phrase?`, which sat *after* the verdict and
asked whether to do a thing the user had not asked for.

## What replaced the arithmetic on `tool_type`

A fourth menu entry does not become a fourth `tool_type`, and the reason is not
the display code.

`compare_recovery_phrase()` (`src/common/common_seed.c`) dispatches on
`tool_type` to decide which buffer to derive a seed from. A fourth value falls
through both of its branches, hands 64 zero bytes to the comparison, and
reports every phrase as not matching the device — with nothing on screen to say
the derivation never ran. That is worse than the failure the verdict screen's
own comment warns about, and it is not where that comment is looking.

So `tool_type` keeps its three values and means "what was typed". A separate
`user_intent` (`src/constants.h`) carries the four and means "what it is being
typed for". Checking a phrase and backing one up are the same tool and
different intentions, which is exactly what the old enumeration could not
express.

That also retires the indexing the verdict screen used:

```c
const uint8_t text_index =
    (tool_type == TOOL_TYPE_BIP39 || tool_type == TOOL_TYPE_SSKR)
        ? (uint8_t)(1 + (tool_type * 2) + seed_match)
        : 1;
```

into a `[2][5]` table, bounded by a test naming the two values that were safe.
It is a table with one row per intention now, indexed by named constants and
sized on the enumeration.

Adding a fifth intention and compiling produces two compile errors and three
`-Wswitch` diagnostics on the touch stack, and a third compile error on the
Nano stack — each on a line that has to decide something:

```
src/nbgl/ui.c:173  error: static assertion failed: the menu shows one entry per intention
src/nbgl/ui.c:353  warning: enumeration value 'USER_INTENT_FIFTH' not handled [-Wswitch]
src/nbgl/ui.c:384  warning: ...
src/nbgl/ui.c:700  warning: ...
src/nbgl/ui.c:750  error: static assertion failed: verdict_body[] has one row per intention
src/bagl/ux_nano.c:231  error: static assertion failed: the two functions below choose a flow
                               on the intention, and everything they do not name takes the
                               check flow
```

The row index is bounded at run time as well, and `user_intent` is `volatile`
so that the bound survives compilation. It did not, at first: with the variable
`static` and every write to it a constant, the compiler proves the comparison
and folds it away — `_etext` was byte-identical on all three touch targets with
the bound present and with it removed. What a bound is for is a byte that
changed without anyone writing it, which is the case that proof excludes. Same
reason `checkpoints` is `volatile` in `compare_recovery_phrase_finish()`.

## How the verdict behaves in each flow

The verdict is a destination when you came to check a phrase and a step on the
way when you came to back one up, so it does not say the same thing — and a
failure says least the same thing of all.

| | check | backup |
|---|---|---|
| matches | `…matches the one present on this Ledger device.` | `This is the recovery phrase on this Ledger device. It can be split into shares.` |
| doesn't match | `…doesn't match the one present on this Ledger device.` | `You would be backing up a phrase this Ledger cannot recover.` |
| not well formed | the same in both, advice line included | the same |
| footer | `Tap to dismiss` | `Tap to continue`, and only on the match |

<p>
<img src="https://raw.githubusercontent.com/buzzromain/app-seed-tool/screenshots/four-intent-menu/verdict-check-match-stax.png" width="215">
<img src="https://raw.githubusercontent.com/buzzromain/app-seed-tool/screenshots/four-intent-menu/verdict-backup-match-stax.png" width="215">
<img src="https://raw.githubusercontent.com/buzzromain/app-seed-tool/screenshots/four-intent-menu/verdict-backup-mismatch-stax.png" width="215">
</p>

`doesn't match the one present on this Ledger device` is a complete answer to
"is this my phrase?". It is half of one to "can I back this up?", where what
matters is that the shares about to be written down would restore something
this device cannot.

From there the flow is unchanged, reached without a single screen having
offered anything:

<p>
<img src="https://raw.githubusercontent.com/buzzromain/app-seed-tool/screenshots/four-intent-menu/share-count-stax.png" width="215">
<img src="https://raw.githubusercontent.com/buzzromain/app-seed-tool/screenshots/four-intent-menu/share-1-of-3-stax.png" width="215">
</p>

Checking no longer offers to split: the offer duplicated a menu entry, and the
screen it stood on is a destination. The share-count keypad's back arrow now
leaves for the home page, reaching `reset_globals()` in one gesture where the
offer took two.

## What the Nano menu becomes

Three entries, not four. BIP-85 has no BAGL screen on any Nano, so a fourth
would lead nowhere. This is the one place the two stacks genuinely differ.

```
Check phrase        Generate            Recover
on this Ledger      backup shares       from backup
```

The last two say word for word what the touch buttons say. The first cannot: a
`pbb` step draws its two lines in an icon-flanked box 87px wide on the 128x32
Nano S, and `Check recovery` alone is 88px. What it does with the room it has
is worth more than the consistency it loses — `on this Ledger` says what the
phrase is checked against, which the touch button has no room to say at all.

The two entries these replace ended on `recovery phrase`, 93px against that
87px box, and had always been over it: one of the two strings the unit test
recorded as failing rather than asserting. All six new fragments are asserted,
and so are the five on the two screens the Nano flow gains.

A mismatch in the backup flow gets a second step, `It would not restore this
Ledger`, because a `pbb` title has no room for the sentence the touch screen
carries in one. `nanos` also gains a `memzero` that `nanox_enter_phrase.c`
already had on the same branch: after a BIP-39 mismatch nothing reads the
phrase again, and this flow now puts one more screen between the verdict and
the erasure `ui_idle_init()` performs.

## Sizes

`_etext` and `_ebss` read with `arm-none-eabi-nm`. Not `text`/`data`/`bss` from
`size`: on the touch targets `_install_parameters` sits at a fixed address and
`.text` runs to the end of that block, so those numbers are constants rather
than measurements.

| target | `_etext` | Δ | `_ebss` | Δ |
|---|---|---|---|---|
| nanos | `c0d0a228` | +408 | `20000c80` | +4 |
| nanox | `c0debd08` | +416 | `da7a144d` | +4 |
| nanos+ | `c0debd08` | +416 | `da7a144d` | +4 |
| stax | `c0df2adc` | +284 | `da7a1b4e` | 0 |
| flex | `c0df2c28` | +280 | `da7a1b12` | 0 |
| apex_p | `c0df1e28` | +288 | `da7a1b12` | 0 |

The 4 bytes of RAM on the three Nanos are the context field recording which
menu entry was chosen. Six targets, zero warnings.

The two commits are split by interface stack, which buys a claim that can be
checked with `sha256` rather than by reading: **after the first commit `nanox`
and `nanos+` are byte-identical to the base** — `nanos` differs only in DWARF,
which it alone carries, and `--strip-debug` gives the same hash with `.text`,
`.rodata`, `.data` and `.bss` identical — and **after the second the three
touch binaries are byte-identical to the first**.

## Verification

- The six configurations of `unit-tests-matrix.yml`, reported separately:
  **80/80 on each**.
- Functional under Speculos: stax 19/10, flex 19/10, apex_p 19/10, nanox 13/16,
  nanos+ 13/16.
- `clang-format --dry-run -Werror` clean on every touched file in `src/`.
- The guard in front of the shares was proven by mutation on both stacks rather
  than by reading: removing the `seed_match` requirement fails exactly the test
  that claims to cover it on the touch stack, and two tests on the Nano stack.

**This repository's CI does not run the functional tests on pull requests from
a fork** — workflow permissions are read-only there. That is a property of
where the branch lives rather than a fault in the change; the results above
were produced locally on the same six binaries these commits contain.

## What is not held by a test

- **Nano S is not emulated at all.** Its three menu entries, its two-line
  explanation step and its backup-mismatch step have never been rendered
  anywhere. They are held only by the unit test that measures each fragment
  against the layout's real pixel budget — which measures characters, not
  pixels drawn. That test's metrics are the Nano S ones applied to all three
  Nano devices: conservative, and therefore right, but by approximation.
- **There are no snapshot tests here, by decision.** Every screen is held by a
  text assertion, so wording is pinned and placement is not. The menu, the
  explanation screen and the verdicts were checked by reading back the
  coordinates Speculos reports; those checks are not automated.
- **The BIP-85 row of the verdict table is empty and unreachable.** Nothing
  tests it because nothing can reach it: that flow goes to
  `display_generic_review()` and never asks for a verdict. Left empty rather
  than filled with a plausible sentence, so a path that did arrive there would
  draw a title over an empty body instead of an answer about a comparison that
  never happened.
- **Two of the four touch entries do not stand entirely on their own.**
  `Check recovery phrase` does not say what it is checked against, and
  `Derive with BIP85` says nothing to someone who does not already know. Both
  would be the better for a line of their own, and there is no room: between
  the back button and the fourth entry Flex has 96px, of which one title line
  takes 44, and a subtitle wrapped to two lines was measured under Speculos
  drawing its second line underneath the first button — which does not clip it,
  it deletes it. The per-entry alternative does not fit either:
  `nbgl_layoutAddTouchableBar()` makes an entry 94px on apex_p with a one-line
  subtitle, and four come to 376px against 340px of usable height.
- **SSKR recovery still reveals the phrase without a device match**, on both
  stacks: `ux_sskr_nomatch_flow` ends on the step that displays it, and the
  touch side gates on reconstruction rather than on `seed_match`. That is
  unchanged here and is presumably intended — rebuilding a phrase from its own
  shares on a device holding a different seed is the point of the feature — but
  it is the one place a secret is displayed without a match, and this change
  promotes that path from an offer behind a verdict to a menu entry.
- **`wordCandidates[]` in `src/nbgl/ui.c` is still not erased** by
  `reset_globals()`, which clears the pointer array but not the buffer holding
  the suggested words. Pre-existing, untouched, named because this change walks
  past it.
